### PR TITLE
Use latest released version in pom snippet example

### DIFF
--- a/README.adoc
+++ b/README.adoc
@@ -140,7 +140,7 @@ An example of this setup is below:
 <plugin>
     <groupId>org.asciidoctor</groupId>
     <artifactId>asciidoctor-maven-plugin</artifactId>
-    <version>0.1.2</version>
+    <version>0.1.4</version>
     <executions>
         <execution>
             <id>output-html</id>


### PR DESCRIPTION
This should prevent people from grabbing an old version who don't know any better.
