### PR TITLE
Use badges from shields.io in README

### DIFF
--- a/README.adoc
+++ b/README.adoc
@@ -5,7 +5,7 @@ asciidoctor-maven-plugin
 :issues: https://github.com/asciidoctor/asciidoctor-maven-plugin/issues
 :maven-url: http://maven.apache.org/
 
-image:https://travis-ci.org/asciidoctor/asciidoctor-maven-plugin.png?branch=master["Build Status", link="https://travis-ci.org/asciidoctor/asciidoctor-maven-plugin"]
+image:http://img.shields.io/travis/asciidoctor/asciidoctor-maven-plugin/master.svg["Build Status", link="https://travis-ci.org/asciidoctor/asciidoctor-maven-plugin"]
 
 The asciidoctor-maven-plugin is the official means of using {asciidoctor-url}[Asciidoctor] to render all your {asciidoc-url}[AsciiDoc] documentation using {maven-url}[Apache Maven].
 


### PR DESCRIPTION
I've found that the badges provided by shields.io look much better than the default ones provided by Travis.
