### PR TITLE
resolves #93 properly handle attribute values

### DIFF
--- a/src/main/java/org/asciidoctor/maven/AsciidoctorMojo.java
+++ b/src/main/java/org/asciidoctor/maven/AsciidoctorMojo.java
@@ -288,12 +288,24 @@ public class AsciidoctorMojo extends AbstractMojo {
 
         // TODO Figure out how to reliably set other values (like boolean values, dates, times, etc)
         for (Map.Entry<String, Object> attributeEntry : attributes.entrySet()) {
-            if (attributeEntry.getValue() instanceof Boolean) {
-                attributesBuilder.attribute(attributeEntry.getKey(), Attributes.toAsciidoctorFlag((Boolean) attributeEntry.getValue()));
-                continue;
+            Object val = attributeEntry.getValue();
+            // NOTE Maven interprets an empty value as null, so we need to explicitly convert it to empty string (see #36)
+            // NOTE In Asciidoctor, an empty string represents a true value
+            if (val == null || "true".equals(val)) {
+                attributesBuilder.attribute(attributeEntry.getKey(), "");
             }
-            // Can't do anything about dates and times because all that logic is private in Attributes
-            attributesBuilder.attribute(attributeEntry.getKey(), attributeEntry.getValue());
+            // NOTE a value of false is effectively the same as a null value, so recommend the use of the string "false"
+            else if ("false".equals(val)) {
+                attributesBuilder.attribute(attributeEntry.getKey(), null);
+            }
+            // NOTE Maven can't assign a Boolean value from the XML-based configuration, but a client may
+            else if (val instanceof Boolean) {
+                attributesBuilder.attribute(attributeEntry.getKey(), Attributes.toAsciidoctorFlag((Boolean) val));
+            }
+            else {
+                // Can't do anything about dates and times because all that logic is private in Attributes
+                attributesBuilder.attribute(attributeEntry.getKey(), val);
+            }
         }
     }
 

--- a/src/test/groovy/org/asciidoctor/maven/test/AsciidoctorMojoTest.groovy
+++ b/src/test/groovy/org/asciidoctor/maven/test/AsciidoctorMojoTest.groovy
@@ -43,7 +43,9 @@ class AsciidoctorMojoTest extends Specification {
             mojo.outputDirectory = outputDir
             mojo.headerFooter = true
             mojo.sourceHighlighter = 'coderay'
-            mojo.attributes['toc'] = true
+            // IMPORTANT Maven can only assign string values or null, so we have to emulate the value precisely in the test!
+            // Believe it or not, null is the equivalent of writing <toc/> in the XML configuration
+            mojo.attributes['toc'] = null
             mojo.attributes['linkcss!'] = ''
             mojo.execute()
         then:
@@ -263,7 +265,9 @@ class AsciidoctorMojoTest extends Specification {
             mojo.sourceDirectory = srcDir
             mojo.sourceDocumentName = 'sample.asciidoc'
             mojo.backend = 'html'
-            mojo.attributes.put('toc2', true)
+            // IMPORTANT Maven can only assign string values or null, so we have to emulate the value precisely in the test!
+            // Believe it or not, null is the equivalent of writing <toc/> in the XML configuration
+            mojo.attributes.put('toc2', 'true')
             mojo.execute()
         then:
             File sampleOutput = new File(outputDir, 'sample.html')
@@ -286,8 +290,9 @@ class AsciidoctorMojoTest extends Specification {
         mojo.sourceDirectory = srcDir
         mojo.sourceDocumentName = 'sample.asciidoc'
         mojo.backend = 'html'
-//        mojo.attributes.put('toc2', true)
-        mojo.attributes.put('toc2', false)
+        // IMPORTANT Maven can only assign string values or null, so we have to emulate the value precisely in the test!
+        // Believe it or not, null is the equivalent of writing <toc/> in the XML configuration
+        mojo.attributes.put('toc2', 'false')
         mojo.execute()
         then:
         File sampleOutput = new File(outputDir, 'sample.html')
@@ -351,7 +356,9 @@ class AsciidoctorMojoTest extends Specification {
         mojo.sourceDocumentName = new File('main.adoc')
         mojo.doctype = 'book'
         mojo.embedAssets = true
-        mojo.attributes['toc'] = true
+        // IMPORTANT Maven can only assign string values or null, so we have to emulate the value precisely in the test!
+        // Believe it or not, null is the equivalent of writing <toc/> in the XML configuration
+        mojo.attributes['toc'] = 'true'
         mojo.backend = 'html'
         mojo.execute()
         then:


### PR DESCRIPTION
- recognize null as an empty string (yes, Maven isn't that smart)
- recognize "true" and "false" as Boolean values
- update tests to cover these scenarios
