### PR TITLE
Maven site integration uses .adoc, not .ad

### DIFF
--- a/README.adoc
+++ b/README.adoc
@@ -220,9 +220,9 @@ To author your Maven-generated site in AsciiDoc, you must first add a dependency
 </build>
 -----
 
-All of your AsciiDoc-based files should be placed in `src/site/asciidoc` with an extension of `.ad`.
+All of your AsciiDoc-based files should be placed in `src/site/asciidoc` with an extension of `.adoc`.
 
-For example, the file `src/site/asciidoc/usage.ad` will be rendered into `target/site/usage.html`.
+For example, the file `src/site/asciidoc/usage.adoc` will be rendered into `target/site/usage.html`.
 
 As always, make sure you add a `menu` item for each page:
 


### PR DESCRIPTION
In site module in asciidoctor-maven-plugin, the only extension that
works is ".adoc". It's hardcoded here: http://git.io/ghiLbA

We could change that so that any of .ad|.adoc|.asciidoc could be used,
but for now, the documentation should reflect the reality of the current
release.
