### PR TITLE
Added configuration for coveralls.io

### DIFF
--- a/.travis.yml
+++ b/.travis.yml
@@ -4,3 +4,11 @@ jdk:
   - oraclejdk7
   - openjdk7
   - openjdk6
+install:
+  - mvn package -DskipTests=true -Dmaven.javadoc.skip=true -B -V
+script:
+  - mvn test jacoco:report
+after_success:
+  # 'coveralls:report' goal is responsible for updating coverall.io stats once travisCI build completes
+  # Look for the article 'Coveralls.io configuration for maven projects' in the wiki (https://github.com/asciidoctor/asciidoctor/wiki) for more details
+  - mvn coveralls:report

--- a/pom.xml
+++ b/pom.xml
@@ -68,6 +68,8 @@
         <spock.version>0.7-groovy-2.0</spock.version>
         <groovy.version>2.1.3</groovy.version>
         <asciidoctorj.version>1.5.2</asciidoctorj.version>
+        <maven.coveralls.plugin.version>3.0.1</maven.coveralls.plugin.version>
+        <maven.jacoco.plugin.version>0.7.2.201409121644</maven.jacoco.plugin.version>
         <jruby.version>1.7.17</jruby.version>
         <maven.plugin.annotations.version>3.2</maven.plugin.annotations.version>
         <maven.plugin.api.version>2.0</maven.plugin.api.version>
@@ -234,7 +236,26 @@
                     </dependency>
                 </dependencies>
             </plugin>
+            <plugin>
+                <groupId>org.eluder.coveralls</groupId>
+                <artifactId>coveralls-maven-plugin</artifactId>
+                <version>${maven.coveralls.plugin.version}</version>
+            </plugin>
+            <plugin>
+                <groupId>org.jacoco</groupId>
+                <artifactId>jacoco-maven-plugin</artifactId>
+                <version>${maven.jacoco.plugin.version}</version>
+                <executions>
+                    <execution>
+                        <id>prepare-agent</id>
+                        <goals>
+                            <goal>prepare-agent</goal>
+                        </goals>
+                    </execution>
+                </executions>
+            </plugin>
         </plugins>
+
         <pluginManagement>
           <plugins>
             <!--This plugin's configuration is used to store Eclipse m2e settings only. It has no influence on the Maven build itself.-->


### PR DESCRIPTION
This PR is meant to close the issue #107 adding coverage data with coveralls.io.
For @mojavelinux advise I added a coment on the _.travis.yml_ file and created a wiki page descriving the process.
https://github.com/abelsromero/asciidoctor-maven-plugin/wiki/Coveralls.io-configuration
If everythingt is fine with the document I'll migrate it to the main ascidoctor's wiki.

PS: once is merged I'll edit the badge on the readme.
