### PR TITLE
fixing maven installation in AppVeyor

### DIFF
--- a/appveyor.yml
+++ b/appveyor.yml
@@ -7,18 +7,18 @@ environment:
     - JAVA_HOME: C:\Program Files\Java\jdk1.8.0
 install:
   - ps: >-
-      $MVNDIR = 'C:\bin\apache-maven-3.2.3\'
+      $MVNDIR = 'C:\bin\apache-maven-3.2.5\'
 
       if(!(Test-Path -Path $MVNDIR )){
         Write-Host (Test-Path -Path $MVNDIR)
         Write-Host 'Installing Maven'
-        cinst maven
+        cinst maven -Version 3.2.5
       } else {
         Write-Host 'Found Maven cached installation'
       }
 # Note: env variables are not correctly updated by choco (setting it manually)
 # Prepend Java entry, remove Ruby entry (C:\Ruby193\bin;) from PATH
-  - cmd: SET PATH=C:\bin\apache-maven-3.2.3\bin;%JAVA_HOME%\bin;%PATH:C:\Ruby193\bin;=%
+  - cmd: SET PATH=C:\bin\apache-maven-3.2.5\bin;%JAVA_HOME%\bin;%PATH:C:\Ruby193\bin;=%
   - cmd: mvn --version
   - cmd: java -version
 build_script:
@@ -26,4 +26,4 @@ build_script:
 test_script:
   - mvn test -B
 cache:
-  - C:\bin\apache-maven-3.2.3\
+  - C:\bin\apache-maven-3.2.5\


### PR DESCRIPTION
The url used to download has been removed and this causes the build to fail.
It is only required to configure it using the new -Version parameter.