### PR TITLE
Additional fix for issue #147 - Use `docVersion` in readme everywhere to...

### DIFF
--- a/README.adoc
+++ b/README.adoc
@@ -148,7 +148,7 @@ The custom Asciidoc property can then be used in the document like this `Version
 ====
 If you want to have the project version as the revision number of the document, use this construct:
 
- :revnumber: {project-version}
+ :revnumber: {docVersion}
 
 This will make the version number appear in the header and footer of the output.
 ====


### PR DESCRIPTION
... make it consistent.