### PR TITLE
Adding a new parser module seems to fix the multiple extensions.

### DIFF
--- a/src/main/java/org/asciidoctor/maven/site/AsciidocParserModule.java
+++ b/src/main/java/org/asciidoctor/maven/site/AsciidocParserModule.java
@@ -1,0 +1,31 @@
+package org.asciidoctor.maven.site;
+
+import org.apache.maven.doxia.parser.module.AbstractParserModule;
+import org.apache.maven.doxia.parser.module.ParserModule;
+import org.codehaus.plexus.component.annotations.Component;
+
+/**
+ * This class is the entry point for the site plugin integration for Doxia 1.6+ for files with extension 'asciidoc'.
+ *
+ * @author paranoiabla
+ */
+@Component(role = ParserModule.class, hint = AsciidoctorParser.ROLE_HINT)
+public class AsciidocParserModule extends AbstractParserModule {
+
+    /**
+     * The source directory for AsciiDoc files.
+     */
+    public static final String SOURCE_DIRECTORY = AsciidoctorParser.ROLE_HINT;
+
+    /**
+     * The extension for AsciiDoc files.
+     */
+    public static final String FILE_EXTENSION = "asciidoc";
+
+    /**
+     * Build a new instance of {@link AsciidocParserModule}.
+     */
+    public AsciidocParserModule() {
+        super(SOURCE_DIRECTORY, FILE_EXTENSION, AsciidoctorParser.ROLE_HINT);
+    }
+}


### PR DESCRIPTION
#125 I'm not sure if this is allowed, or if it's a hack, but it seems to work for me. I have added another parser module for the `asciidoc` extension and now `mvn site:site` works for me.