### PR TITLE
Preview for #174 and #187 - Selecting and filtering sources and resources

### DIFF
--- a/pom.xml
+++ b/pom.xml
@@ -70,12 +70,13 @@
         <asciidoctorj.version>1.5.3.2</asciidoctorj.version>
         <maven.coveralls.plugin.version>3.0.1</maven.coveralls.plugin.version>
         <maven.jacoco.plugin.version>0.7.2.201409121644</maven.jacoco.plugin.version>
-        <jruby.version>1.7.23</jruby.version>
+        <jruby.version>1.7.21</jruby.version>
         <maven.plugin.annotations.version>3.2</maven.plugin.annotations.version>
         <maven.plugin.api.version>2.0</maven.plugin.api.version>
         <maven.project.version>2.2.1</maven.project.version>
         <maven.compiler.plugin.version>3.1</maven.compiler.plugin.version>
         <maven.plugin.plugin.version>3.2</maven.plugin.plugin.version>
+        <maven.filtering.version>1.3</maven.filtering.version>
         <plexus.utils.version>3.0.10</plexus.utils.version>
         <plexus.component.metadata.version>1.5.5</plexus.component.metadata.version>
         <netty.version>4.0.0.CR1</netty.version>
@@ -113,7 +114,12 @@
             <version>${maven.project.version}</version>
             <scope>compile</scope>
         </dependency>
-      <dependency>
+        <dependency>
+            <groupId>org.apache.maven.shared</groupId>
+            <artifactId>maven-filtering</artifactId>
+            <version>${maven.filtering.version}</version>
+        </dependency>
+        <dependency>
             <groupId>org.apache.maven.plugin-tools</groupId>
             <artifactId>maven-plugin-annotations</artifactId>
             <version>${maven.plugin.annotations.version}</version>

--- a/pom.xml
+++ b/pom.xml
@@ -436,7 +436,7 @@
         <repository>
             <id>bintray-asciidoctor-maven-asciidoctor-maven-plugin</id>
             <name>asciidoctor-maven-asciidoctor-maven-plugin</name>
-            <url>https://api.bintray.com/maven/asciidoctor/maven/asciidoctor-maven-plugin</url>
+            <url>https://api.bintray.com/maven/abelsromero/maven/asciidoctor-maven-plugin</url>
         </repository>
     </distributionManagement>
 </project>

--- a/src/it/article-html/pom.xml
+++ b/src/it/article-html/pom.xml
@@ -20,7 +20,11 @@
 				<artifactId>asciidoctor-maven-plugin</artifactId>
 				<version>@project.version@</version>
 				<configuration>
-					<sourceDirectory>src/main/doc</sourceDirectory>
+					<sources>
+						<source>
+							<directory>src/main/doc</directory>
+						</source>
+					</sources>
 					<outputDirectory>target/docs</outputDirectory>
 					<backend>html</backend>
 					<doctype>article</doctype>

--- a/src/it/book-html/pom.xml
+++ b/src/it/book-html/pom.xml
@@ -20,7 +20,11 @@
 				<artifactId>asciidoctor-maven-plugin</artifactId>
 				<version>@project.version@</version>
 				<configuration>
-					<sourceDirectory>src/main/doc</sourceDirectory>
+					<sources>
+						<source>
+							<directory>src/main/doc</directory>
+						</source>
+					</sources>
 					<outputDirectory>target/docs</outputDirectory>
 					<backend>html</backend>
 					<doctype>book</doctype>

--- a/src/main/java/org/asciidoctor/maven/AsciidoctorZipMojo.java
+++ b/src/main/java/org/asciidoctor/maven/AsciidoctorZipMojo.java
@@ -20,7 +20,6 @@ import org.apache.maven.plugin.MojoFailureException;
 import org.apache.maven.plugins.annotations.Component;
 import org.apache.maven.plugins.annotations.Mojo;
 import org.apache.maven.plugins.annotations.Parameter;
-import org.apache.maven.project.MavenProject;
 import org.apache.maven.project.MavenProjectHelper;
 import org.asciidoctor.maven.io.Zips;
 
@@ -30,9 +29,6 @@ public class AsciidoctorZipMojo extends AsciidoctorMojo {
 
     @Component
     private MavenProjectHelper projectHelper;
-
-    @Parameter(property = PREFIX, defaultValue = "${project}", readonly = true)
-    private MavenProject project;
 
     @Parameter(property = PREFIX + "attach", defaultValue = "true")
     protected boolean attach;

--- a/src/main/java/org/asciidoctor/maven/io/AsciidoctorFileScanner.java
+++ b/src/main/java/org/asciidoctor/maven/io/AsciidoctorFileScanner.java
@@ -1,0 +1,100 @@
+package org.asciidoctor.maven.io;
+
+import org.apache.maven.model.Resource;
+import org.codehaus.plexus.util.Scanner;
+import org.sonatype.plexus.build.incremental.BuildContext;
+
+import java.io.File;
+import java.util.*;
+
+/**
+ * Recursively traverses directories returning the list of AsciiDoc files that match the applied filters.
+ * If no filters are set, AsciiDoc documents with extensions .adoc, .ad, .asc and .asciidoc are returned.
+ *
+ */
+public class AsciidoctorFileScanner {
+
+    public static String[] DEFAULT_FILE_EXTENSIONS = {"**/*.adoc", "**/*.ad", "**/*.asc","**/*.asciidoc"};
+    // Files and directories beginning with underscore are ignored
+    public static String[] IGNORED_FOLDERS_AND_FILES = {"**/_*.*", "**/_*", "**/_*/**/*.*"};
+
+    private BuildContext buildContext;
+
+    public AsciidoctorFileScanner(BuildContext buildContext) {
+        this.buildContext = buildContext;
+    }
+
+    /**
+     * Scans a resource directory (and sub-subdirectories) returning all AsciiDoc documents found.
+     *
+     * @param resource {@link Resource} to scan (the directory property is mandatory)
+     * @return List of found documents matching the resource properties
+     */
+    public List<File> scan(Resource resource) {
+        Scanner scanner = buildContext.newScanner(new File(resource.getDirectory()), true);
+        setupScanner(scanner, resource);
+        scanner.scan();
+        List<File> files = new ArrayList<File>();
+        for (String file : scanner.getIncludedFiles()) {
+            files.add(new File(resource.getDirectory(), file));
+        }
+        return files;
+    }
+
+    /**
+     * Scans a list of resources returning all AsciiDoc documents found.
+     *
+     * @param resources List of {@link Resource} to scan (the directory property is mandatory)
+     * @return List of found documents matching the resources properties
+     */
+    public List<File> scan(List<Resource> resources) {
+        List<File> files = new ArrayList<File>();
+        for (Resource resource: resources) {
+            files.addAll(scan(resource));
+        }
+        return files;
+    }
+
+    /**
+     * Initializes the Scanner with the default values.
+     * <br>
+     * By default:
+     * <ul>
+     *     <li>includes adds extension .adoc, .ad, .asc and .asciidoc
+     *     <li>excludes adds filters to avoid hidden files and directoris beginning with undersore
+     * </ul>
+     *
+     * NOTE: Patterns both in inclusions and exclusions are automatically excluded.
+     */
+    private void setupScanner(Scanner scanner, Resource resource) {
+
+        if (resource.getIncludes() == null || resource.getIncludes().isEmpty()) {
+            scanner.setIncludes(DEFAULT_FILE_EXTENSIONS);
+        } else {
+            scanner.setIncludes(resource.getIncludes().toArray(new String[] {}));
+        }
+
+        if (resource.getExcludes() == null || resource.getExcludes().isEmpty()) {
+            scanner.setExcludes(IGNORED_FOLDERS_AND_FILES);
+        } else {
+            scanner.setExcludes(mergeAndConvert(resource.getExcludes(), IGNORED_FOLDERS_AND_FILES));
+        }
+        // adds exclusions like SVN or GIT files
+        scanner.addDefaultExcludes();
+    }
+
+    /**
+     * Returns a String[] with the values of both input parameters.
+     * Duplicated values are inserted only once.
+     *
+     * @param list List of string
+     * @param array Array of String
+     * @return Array of String with all values
+     */
+    private String[] mergeAndConvert(List<String> list, String[] array) {
+        Set<String> set = new HashSet<String>(Arrays.asList(array));
+        set.addAll(list);
+        return set.toArray(new String[set.size()]);
+    }
+
+}

--- a/src/main/java/org/asciidoctor/maven/monitor/LoggingFileAlterationListenerAdaptor.java
+++ b/src/main/java/org/asciidoctor/maven/monitor/LoggingFileAlterationListenerAdaptor.java
@@ -1,0 +1,44 @@
+package org.asciidoctor.maven.monitor;
+
+import org.apache.commons.io.monitor.FileAlterationListenerAdaptor;
+import org.apache.maven.plugin.logging.Log;
+
+import java.io.File;
+import java.util.concurrent.atomic.AtomicBoolean;
+
+/**
+ * Used to monitor sources (AsciiDoc documents) in the "refresh" and "http" mojos
+ *
+ */
+public class LoggingFileAlterationListenerAdaptor extends FileAlterationListenerAdaptor {
+
+    private Log log;
+    private AtomicBoolean needsUpdate = new AtomicBoolean(false);
+
+    public LoggingFileAlterationListenerAdaptor(Log log, AtomicBoolean needsUpdate) {
+        this.log = log;
+        this.needsUpdate = needsUpdate;
+    }
+
+    @Override
+    public void onFileCreate(final File file) {
+        getLog().info("File " + file.getAbsolutePath() + " created.");
+        needsUpdate.set(true);
+    }
+
+    @Override
+    public void onFileChange(final File file) {
+        getLog().info("File " + file.getAbsolutePath() + " updated.");
+        needsUpdate.set(true);
+    }
+
+    @Override
+    public void onFileDelete(final File file) {
+        getLog().info("File " + file.getAbsolutePath() + " deleted.");
+        needsUpdate.set(true);
+    }
+
+    public Log getLog() {
+        return log;
+    }
+}

--- a/src/main/java/org/asciidoctor/maven/monitor/SynchronizingFileAlterationListenerAdaptor.java
+++ b/src/main/java/org/asciidoctor/maven/monitor/SynchronizingFileAlterationListenerAdaptor.java
@@ -1,0 +1,69 @@
+package org.asciidoctor.maven.monitor;
+
+import org.apache.commons.io.FileUtils;
+import org.apache.commons.io.monitor.FileAlterationListenerAdaptor;
+import org.apache.maven.plugin.logging.Log;
+import org.asciidoctor.maven.Synchronization;
+
+import java.io.File;
+import java.io.IOException;
+import java.util.concurrent.atomic.AtomicBoolean;
+
+/**
+ * Used to monitor resources and trigger updates in the "refresh" and "http" mojos
+ *
+ */
+public class SynchronizingFileAlterationListenerAdaptor extends FileAlterationListenerAdaptor {
+
+    private Log log;
+    private AtomicBoolean needsUpdate = new AtomicBoolean(false);
+    private final Synchronization s;
+
+    public SynchronizingFileAlterationListenerAdaptor(Log log, AtomicBoolean needsUpdate, Synchronization s){
+        this.log = log;
+        this.needsUpdate = needsUpdate;
+        this.s = s;
+    }
+
+    @Override
+    public void onFileCreate(final File file) {
+        getLog().info("File " + file.getAbsolutePath() + " created.");
+        synchronize(s, log);
+        needsUpdate.set(true);
+    }
+
+    @Override
+    public void onFileChange(final File file) {
+        getLog().info("File " + file.getAbsolutePath() + " updated.");
+        synchronize(s, log);
+        needsUpdate.set(true);
+    }
+
+    @Override
+    public void onFileDelete(final File file) {
+        getLog().info("File " + file.getAbsolutePath() + " deleted.");
+        FileUtils.deleteQuietly(file);
+        needsUpdate.set(true);
+    }
+
+    public static void synchronize(final Synchronization synchronization, final Log log) {
+        if (synchronization.getSource().isDirectory()) {
+            try {
+                FileUtils.copyDirectory(synchronization.getSource(), synchronization.getTarget());
+            } catch (IOException e) {
+                log.error(String.format("Can't synchronize %s -> %s", synchronization.getSource(), synchronization.getTarget()));
+            }
+        } else {
+            try {
+                FileUtils.copyFile(synchronization.getSource(), synchronization.getTarget());
+            } catch (IOException e) {
+                log.error(String.format("Can't synchronize %s -> %s", synchronization.getSource(), synchronization.getTarget()));
+            }
+        }
+    }
+
+    public Log getLog() {
+        return log;
+    }
+
+}

--- a/src/test/groovy/org/asciidoctor/maven/test/AsciidoctorHttpMojoTest.groovy
+++ b/src/test/groovy/org/asciidoctor/maven/test/AsciidoctorHttpMojoTest.groovy
@@ -1,13 +1,21 @@
 package org.asciidoctor.maven.test
 
+import org.apache.maven.model.Resource
 import org.asciidoctor.maven.AsciidoctorHttpMojo
 import org.asciidoctor.maven.test.io.DoubleOuputStream
 import org.asciidoctor.maven.test.io.PrefilledInputStream
+import org.asciidoctor.maven.test.plexus.mock.MockPlexusContainer
 import spock.lang.Specification
 
 import java.util.concurrent.CountDownLatch
 
 class AsciidoctorHttpMojoTest extends Specification {
+
+    static final String DEFAULT_SOURCE_DIRECTORY = 'target/test-classes/src/asciidoctor-http'
+    static final String DEFAULT_SOURCE_NAME = 'content.asciidoc'
+
+    MockPlexusContainer mockPlexusContainer = new MockPlexusContainer()
+
     def "http front should let access rendered files"() {
         setup:
             def srcDir = new File('target/test-classes/src/asciidoctor-http')
@@ -28,7 +36,7 @@ class AsciidoctorHttpMojoTest extends Specification {
 
             def httpPort = new AsciidoctorMojoTestHelper().availablePort
 
-            def content = new File(srcDir, "content.asciidoc")
+            def content = new File(srcDir, DEFAULT_SOURCE_NAME)
             content.withWriter{ it <<
                 '''Document Title
                 ==============
@@ -36,9 +44,14 @@ class AsciidoctorHttpMojoTest extends Specification {
                 This is test, only a test.'''.stripIndent() }
 
             def mojo = new AsciidoctorHttpMojo()
+            mockPlexusContainer.initializeContext(mojo)
+
             mojo.backend = 'html5'
             mojo.port = httpPort
-            mojo.sourceDirectory = srcDir
+            mojo.sources =  [[
+                    directory: DEFAULT_SOURCE_DIRECTORY,
+                    includes : [DEFAULT_SOURCE_NAME]
+                ] as Resource]
             mojo.outputDirectory = outputDir
             mojo.headerFooter = true
             mojo.home = 'index'
@@ -87,7 +100,7 @@ class AsciidoctorHttpMojoTest extends Specification {
             System.setOut(new PrintStream(newOut))
             System.setIn(newIn)
 
-            def content = new File(srcDir, "content.asciidoc")
+            def content = new File(srcDir, DEFAULT_SOURCE_NAME)
             content.withWriter{ it <<
                     '''Document Title
                     ==============
@@ -95,9 +108,14 @@ class AsciidoctorHttpMojoTest extends Specification {
                     DEFAULT.'''.stripIndent() }
 
             def mojo = new AsciidoctorHttpMojo()
+            mockPlexusContainer.initializeContext(mojo)
+
             mojo.backend = 'html5'
             mojo.port = httpPort
-            mojo.sourceDirectory = srcDir
+            mojo.sources = [[
+                    directory: "$DEFAULT_SOURCE_DIRECTORY-default",
+                    includes: [DEFAULT_SOURCE_NAME]
+                ] as Resource]
             mojo.outputDirectory = outputDir
             mojo.headerFooter = true
             mojo.home = 'content'

--- a/src/test/groovy/org/asciidoctor/maven/test/AsciidoctorZipMojoTest.groovy
+++ b/src/test/groovy/org/asciidoctor/maven/test/AsciidoctorZipMojoTest.groovy
@@ -1,5 +1,8 @@
 package org.asciidoctor.maven.test
 
+import org.apache.maven.model.Resource
+import org.asciidoctor.maven.test.plexus.mock.MockPlexusContainer
+
 import java.util.zip.ZipFile
 
 import org.apache.commons.io.FileUtils
@@ -10,6 +13,8 @@ import spock.lang.Specification
  *
  */
 class AsciidoctorZipMojoTest extends Specification {
+
+    MockPlexusContainer mockPlexusContainer = new MockPlexusContainer()
 
     def "zip it"() {
         given: 'an empty output directory'
@@ -32,9 +37,13 @@ class AsciidoctorZipMojoTest extends Specification {
                 '''.stripIndent()
             }
 
-            def mojo = new AsciidoctorZipMojo()
+            AsciidoctorZipMojo mojo = new AsciidoctorZipMojo()
+            mockPlexusContainer.initializeContext(mojo)
+
             mojo.backend = 'html'
-            mojo.sourceDirectory = srcDir
+            mojo.sources = [[
+                    directory: srcDir.getPath()
+                ] as Resource]
             mojo.outputDirectory = outputDir
             mojo.zipDestination = zip
             mojo.zip = true
@@ -60,8 +69,12 @@ class AsciidoctorZipMojoTest extends Specification {
 
         when:
             AsciidoctorZipMojo mojo = new AsciidoctorZipMojo()
+            mockPlexusContainer.initializeContext(mojo)
+
             mojo.backend = 'html5'
-            mojo.sourceDirectory = srcDir
+            mojo.sources = [[
+                    directory: srcDir.getPath()
+                ] as Resource]
             mojo.outputDirectory = outputDir
             mojo.preserveDirectories = true
             mojo.relativeBaseDir = true
@@ -109,8 +122,12 @@ class AsciidoctorZipMojoTest extends Specification {
 
         when:
             AsciidoctorZipMojo mojo = new AsciidoctorZipMojo()
+            mockPlexusContainer.initializeContext(mojo)
+
             mojo.backend = 'html5'
-            mojo.sourceDirectory = srcDir
+            mojo.sources = [[
+                    directory: srcDir.getPath()
+                ] as Resource]
             mojo.outputDirectory = outputDir
             mojo.sourceHighlighter = 'coderay'
             mojo.zipDestination = zip

--- a/src/test/groovy/org/asciidoctor/maven/test/plexus/mock/MockPlexusContainer.groovy
+++ b/src/test/groovy/org/asciidoctor/maven/test/plexus/mock/MockPlexusContainer.groovy
@@ -1,0 +1,50 @@
+package org.asciidoctor.maven.test.plexus.mock
+
+import org.apache.maven.plugin.logging.Log
+import org.apache.maven.plugin.logging.SystemStreamLog
+import org.apache.maven.project.MavenProject
+import org.apache.maven.shared.filtering.DefaultMavenFileFilter
+import org.apache.maven.shared.filtering.DefaultMavenResourcesFiltering
+import org.asciidoctor.maven.AsciidoctorMojo
+import org.sonatype.plexus.build.incremental.DefaultBuildContext
+
+/**
+ * Initializes a mocks components required to simulate a Plexus container for the tests.
+ *
+ * Note: This is a temporal solution. At some point 'proper' testing should be introduced, see:
+ *  - https://vzurczak.wordpress.com/2014/07/23/write-unit-tests-for-a-maven-plug-in/
+ *
+ * @author abelsromero
+ */
+class MockPlexusContainer {
+
+    class FakeMavenLogger {
+        @Delegate
+        Log logger = new SystemStreamLog()
+    }
+
+    void initializeContext(AsciidoctorMojo mojo) {
+
+        mojo.@project = [
+                getBasedir: {
+                    return new File('.')
+                }] as MavenProject
+
+        mojo.@buildContext = new DefaultBuildContext()
+
+        def logger = new FakeMavenLogger() as org.codehaus.plexus.logging.Logger
+
+        DefaultMavenFileFilter mavenFileFilter = new DefaultMavenFileFilter()
+        mavenFileFilter.@buildContext = mojo.@buildContext
+        mavenFileFilter.enableLogging(logger)
+
+        DefaultMavenResourcesFiltering resourceFilter = new DefaultMavenResourcesFiltering()
+        resourceFilter.@mavenFileFilter = mavenFileFilter
+        resourceFilter.@buildContext = mojo.@buildContext
+        resourceFilter.initialize()
+        resourceFilter.enableLogging(logger)
+        mojo.@outputResourcesFiltering = resourceFilter
+
+    }
+
+}

--- a/src/test/resources/src/asciidoctor/multiple-sources/sources-1/sample-1.adoc
+++ b/src/test/resources/src/asciidoctor/multiple-sources/sources-1/sample-1.adoc
@@ -1,0 +1,40 @@
+Document Title
+==============
+Doc Writer <thedoc@asciidoctor.org>
+:idprefix: id_
+
+Preamble paragraph.
+
+NOTE: This is test, only a test.
+
+== Section A
+
+*Section A* paragraph.
+
+=== Section A Subsection
+
+*Section A* 'subsection' paragraph.
+
+== Section B
+
+*Section B* paragraph.
+
+.Section B list
+* Item 1
+* Item 2
+* Item 3
+
+[source,ruby]
+require 'asciidoctor'
+
+[source,java]
+----
+public class HelloWorld {
+
+    public static void main(String[] args) {
+        // Prints "Hello, World" to the terminal window.
+        System.out.println("Hello, World");
+    }
+
+}
+----

--- a/src/test/resources/src/asciidoctor/multiple-sources/sources-2/sample-2.adoc
+++ b/src/test/resources/src/asciidoctor/multiple-sources/sources-2/sample-2.adoc
@@ -1,0 +1,40 @@
+Document Title
+==============
+Doc Writer <thedoc@asciidoctor.org>
+:idprefix: id_
+
+Preamble paragraph.
+
+NOTE: This is test, only a test.
+
+== Section A
+
+*Section A* paragraph.
+
+=== Section A Subsection
+
+*Section A* 'subsection' paragraph.
+
+== Section B
+
+*Section B* paragraph.
+
+.Section B list
+* Item 1
+* Item 2
+* Item 3
+
+[source,ruby]
+require 'asciidoctor'
+
+[source,java]
+----
+public class HelloWorld {
+
+    public static void main(String[] args) {
+        // Prints "Hello, World" to the terminal window.
+        System.out.println("Hello, World");
+    }
+
+}
+----

--- a/src/test/resources/src/asciidoctor/relative-path-treatment/level-1-1/_HelloWorld2.adoc
+++ b/src/test/resources/src/asciidoctor/relative-path-treatment/level-1-1/_HelloWorld2.adoc
@@ -1,0 +1,14 @@
+:toc: left
+:icons:
+
+== Summary
+TIP: Documentation for script 1 in depth 1
+
+image::asciidoctor-icon.jpg[Asciidoctor cool icon]
+
+== Code
+[source,groovy]
+.HelloWorld2.groovy
+----
+include::HelloWorld2.groovy[]
+----

--- a/src/test/resources/src/asciidoctor/relative-path-treatment/level-1-1/_this_is_ignored/ignored.adoc
+++ b/src/test/resources/src/asciidoctor/relative-path-treatment/level-1-1/_this_is_ignored/ignored.adoc
@@ -1,0 +1,8 @@
+:toc: left
+:icons:
+
+== Summary
+This document won't get rendered by default because it is inside a hidden folder. +
+Hidden folders begin with udnersore `_`.
+
+TIP: How cool is this?


### PR DESCRIPTION
**PR description**
This PR is a preview of a solution for issues #174 and #187.
Both issues highlighted the limitations in terms of sources and resources management of the maven plugin.
Following the recomendation of Dan on isue #174
```
Agreed. We should align with the Gradle plugin on this one.
See https://github.com/asciidoctor/asciidoctor-gradle-plugin#usage (sources)
```
this PR includes the following changes:
(1). `sourceDirectory`, `sourceDocumentName` & `sourceDocumentExtension` disappear in favour of two new options sources & resources.
(2). `sources`: follows a the same resource pattern as the [maven-resource-plugin](https://maven.apache.org/plugins/maven-resources-plugin/examples/include-exclude.html). Basically it uses the same underlying API (https://maven.apache.org/shared/maven-filtering/). The difference here is that filtering/replacement options are not available and by default only AsciiDoc files are included.
Rendered files can be modified using custom include and exclude filters. This includes, adding more sources files with custom file extensions, adding multiple files, directories, etc.
(3). `resources`: follows the same resources pattern [...]. If not set, all resources (images, css, etc.) in the different sources are copied. This is different to how the gradle plugin works, but is consistent with how the current maven plugn works. Also, all source files defined using `include` conditions are excluded by default. In this case, the filtering (a.k.a. replacement) options provided by the maven-resource-plugin can be used, I would not advertise them.
All of this can be modified using custom include and exclude filters. For instance, if someone wants to copy AsciiDoc documents to the target folder, just create a <resource> tag like this one:
```
<resource>
    <directory>DIRECTORY</directory>
    <include>**/*.adoc</>
    <include>**/*.asciidoc</>
</resource>
```

(4). Options related to the output (format and directory) are kept 'global', that is, at <configuration> level as now. To some degree it makes sense to define them in the source element, but in my opinion this is just re-implementing maven executions inside the plugin. This includes options like `outputDirectory`, `baseDir`, `backend`, `preserveDirectories`, etc.
The criteria I followed was:
 * You need to manage several inputs? Now you can :)
 * You need to manage multiple outputs? You should use different executions. In the same way in gradle you would define a different task.
But eventually, this could be implemented if the community asks for it. But this will mean that resources will a property inside each source.

**Next steps**
* Le'ts discuss this and please let me know of corner cases to test. There's quite a lot of include/exclude manipulation and I suspect I may have slipt some special case.
I have separated working code and test to ease the review. I'll merge them on the final PR.
* Documentation is missing, once we have the final approach I'll include it.
* Decide version: this is a major change with no backward compatibility. Should we save it for 1.6.0 and use 1.5.4/5 for urgent fixes?
* Improve and document the refresh mojo: right now I did a quick approach 'that works' but can consume lots of resources in some cases. I keep that for a separated PR.

* @marcaurele, to render the files in the root (README, CONTRIBUTING, etc.), you can do something like this:
```
<sources>
    <source>
        <directory>.</directory>
        <include>*.adoc</include> <!-- only includes files in 'directory' property, not sub-directories -->
    </source>
</sources>
<resources>
    <resource>
        <directory>.</directory>
        <exclude>**/**</exclude> <!-- does not copy anything -->
    </resource>
</resources>
```
or include each file one by one with differnt include tags. _Let me lnow what do you think_

* @AlexanderZobkov please, let me know if this approach helps you.


_I think that's all, thanks for you patience if you got here_