### PR TITLE
Fixes issue #194

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -1,5 +1,6 @@
 target
 .settings
 .idea
+*.iml
 .classpath
 .project

--- a/appveyor.yml
+++ b/appveyor.yml
@@ -6,19 +6,16 @@ environment:
     - JAVA_HOME: C:\Program Files\Java\jdk1.7.0
     - JAVA_HOME: C:\Program Files\Java\jdk1.8.0
 install:
-  - ps: >-
-      $MVNDIR = 'C:\bin\apache-maven-3.2.5\'
-
-      if(!(Test-Path -Path $MVNDIR )){
-        Write-Host (Test-Path -Path $MVNDIR)
-        Write-Host 'Installing Maven'
-        cinst maven -Version 3.2.5
-      } else {
-        Write-Host 'Found Maven cached installation'
+  - ps: |
+      Add-Type -AssemblyName System.IO.Compression.FileSystem
+      if (!(Test-Path -Path "C:\maven" )) {
+        (new-object System.Net.WebClient).DownloadFile('http://www.us.apache.org/dist/maven/maven-3/3.3.9/binaries/apache-maven-3.3.9-bin.zip', 'C:\maven-bin.zip')
+        [System.IO.Compression.ZipFile]::ExtractToDirectory("C:\maven-bin.zip", "C:\maven")
       }
-# Note: env variables are not correctly updated by choco (setting it manually)
-# Prepend Java entry, remove Ruby entry (C:\Ruby193\bin;) from PATH
-  - cmd: SET PATH=C:\bin\apache-maven-3.2.5\bin;%JAVA_HOME%\bin;%PATH:C:\Ruby193\bin;=%
+  # Prepend Java entry, remove Ruby entry (C:\Ruby193\bin;) from PATH
+  - cmd: SET PATH=C:\maven\apache-maven-3.3.9\bin;%JAVA_HOME%\bin;%PATH:C:\Ruby193\bin;=%
+  - cmd: SET MAVEN_OPTS=-XX:MaxPermSize=1g -Xmx2g
+  - cmd: SET JAVA_OPTS=-XX:MaxPermSize=1g -Xmx2g
   - cmd: mvn --version
   - cmd: java -version
 build_script:
@@ -26,4 +23,4 @@ build_script:
 test_script:
   - mvn -Prun-its verify -B
 cache:
-  - C:\bin\apache-maven-3.2.5\
+  - C:\maven

--- a/pom.xml
+++ b/pom.xml
@@ -394,7 +394,7 @@
                     <plugin>
                         <groupId>org.apache.maven.plugins</groupId>
                         <artifactId>maven-invoker-plugin</artifactId>
-                        <version>1.8</version>
+                        <version>2.0.0</version>
                         <configuration>
                             <debug>true</debug>
                             <projectsDirectory>src/it</projectsDirectory>


### PR DESCRIPTION
A part from upgrading the version of the `maven-invoker-plugin` (2.0.0) and maven (3.3.9), I replaced the way Maven is installed.
Now it is download/installed directly without using chocolately. That way we don't need to wait for a package to be published in choco.
Thanks to @yegor256 and this article http://www.yegor256.com/2015/01/10/windows-appveyor-maven.html.