### PR TITLE
Add parameter "failOnMissingSourceDirectory"

### DIFF
--- a/src/main/java/org/asciidoctor/maven/AsciidoctorMojo.java
+++ b/src/main/java/org/asciidoctor/maven/AsciidoctorMojo.java
@@ -133,6 +133,9 @@ public class AsciidoctorMojo extends AbstractMojo {
     @Parameter(property = AsciidoctorMaven.PREFIX + "attributeUndefined")
     protected String attributeUndefined = "drop-line";
 
+    @Parameter(property = AsciidoctorMaven.PREFIX + "failOnMissingSourceDirectory")
+    protected boolean failOnMissingSourceDirectory = true;
+
     @Override
     public void execute() throws MojoExecutionException, MojoFailureException {
         if (skip) {
@@ -142,6 +145,15 @@ public class AsciidoctorMojo extends AbstractMojo {
 
         if (sourceDirectory == null) {
             throw new MojoExecutionException("Required parameter 'asciidoctor.sourceDir' not set.");
+        }
+
+        if (!sourceDirectory.exists()) {
+            if (failOnMissingSourceDirectory) {
+                throw new MojoExecutionException("sourceDirectory " + sourceDirectory + " does not exist");
+            } else {
+                getLog().info("sourceDirectory does not exist. Skip processing");
+                return;
+            }
         }
 
         ensureOutputExists();


### PR DESCRIPTION
I want to use this plugin in a widely used parent pom, without breaking existing child projects which do not have the asciidoc source directory, so I decided to add a new option to change if the build fails in this case. I kept the current behavior as default. Please review and consider merging the PR