### PR TITLE
This fixes #200 - same name for sourceDirectory and outputDirectory X…

### DIFF
--- a/.travis.yml
+++ b/.travis.yml
@@ -1,5 +1,7 @@
 language: java
 sudo: false
+before_script:
+  - export MAVEN_SKIP_RC=true
 jdk:
   - oraclejdk8
   - oraclejdk7

--- a/pom.xml
+++ b/pom.xml
@@ -404,6 +404,8 @@
                             </pomIncludes>
                             <preBuildHookScript>setup</preBuildHookScript>
                             <postBuildHookScript>validate</postBuildHookScript>
+                            <showErrors>true</showErrors>
+                            <debug>true</debug>
                             <!-- <localRepositoryPath>${project.build.directory}/local-repo</localRepositoryPath>-->
                             <!-- <settingsFile>src/it/settings.xml</settingsFile>-->
                             <goals>

--- a/src/it/article-html-command/invoker.properties
+++ b/src/it/article-html-command/invoker.properties
@@ -1,0 +1,2 @@
+invoker.goals=clean asciidoctor:process-asciidoc
+invoker.mavenOpts=-Dasciidoctor.sourceDirectory=src/main/doc -Dasciidoctor.outputDirectory=target/docs

--- a/src/it/article-html-command/pom.xml
+++ b/src/it/article-html-command/pom.xml
@@ -1,0 +1,29 @@
+<project xmlns="http://maven.apache.org/POM/4.0.0" xmlns:xsi="http://www.w3.org/2001/XMLSchema-instance"
+	xsi:schemaLocation="http://maven.apache.org/POM/4.0.0 http://maven.apache.org/maven-v4_0_0.xsd">
+	<modelVersion>4.0.0</modelVersion>
+
+	<groupId>org.asciidoctor</groupId>
+	<artifactId>test</artifactId>
+	<version>1.0-SNAPSHOT</version>
+
+	<name>Run Asciidoctor Article to Html with command line arguments</name>
+	<description>Runs asciidoctor-maven-plugin:process-asciidoc</description>
+
+	<properties>
+		<project.build.sourceEncoding>UTF-8</project.build.sourceEncoding>
+	</properties>
+
+	<build>
+		<plugins>
+			<plugin>
+				<groupId>org.asciidoctor</groupId>
+				<artifactId>asciidoctor-maven-plugin</artifactId>
+				<version>@project.version@</version>
+				<configuration>
+					<backend>html</backend>
+					<doctype>article</doctype>
+				</configuration>
+			</plugin>
+		</plugins>
+	</build>
+</project>

--- a/src/it/article-html-command/src/main/doc/sample.asciidoc
+++ b/src/it/article-html-command/src/main/doc/sample.asciidoc
@@ -1,0 +1,25 @@
+Document Title
+==============
+Doc Writer <thedoc@asciidoctor.org>
+:idprefix: id_
+
+Preamble paragraph.
+
+NOTE: This is test, only a test.
+
+== Section A
+
+*Section A* paragraph.
+
+=== Section A Subsection
+
+*Section A* 'subsection' paragraph.
+
+== Section B
+
+*Section B* paragraph.
+
+.Section B list
+* Item 1
+* Item 2
+* Item 3

--- a/src/it/article-html-command/validate.groovy
+++ b/src/it/article-html-command/validate.groovy
@@ -1,0 +1,16 @@
+import java.io.*;
+
+
+File outputDir = new File( basedir, "target/docs" )
+
+String[] expectedFiles = ["sample.html"]
+
+for ( String expectedFile : expectedFiles ) {
+    File file = new File( outputDir, expectedFile )
+    println ( "Checking for existence of " + file )
+    if ( !file.isFile() ) {
+        throw new Exception( "Missing file " + file )
+    }
+}
+
+return true;

--- a/src/main/java/org/asciidoctor/maven/AsciidoctorMojo.java
+++ b/src/main/java/org/asciidoctor/maven/AsciidoctorMojo.java
@@ -52,10 +52,10 @@ public class AsciidoctorMojo extends AbstractMojo {
     // should probably be configured in AsciidoctorMojo through @Parameter 'extension'
     protected static final String ASCIIDOC_REG_EXP_EXTENSION = ".*\\.a((sc(iidoc)?)|d(oc)?)$";
 
-    @Parameter(property = AsciidoctorMaven.PREFIX + "sourceDir", defaultValue = "${basedir}/src/main/asciidoc", required = true)
+    @Parameter(property = AsciidoctorMaven.PREFIX + "sourceDirectory", defaultValue = "${basedir}/src/main/asciidoc", required = true)
     protected File sourceDirectory;
 
-    @Parameter(property = AsciidoctorMaven.PREFIX + "outputDir", defaultValue = "${project.build.directory}/generated-docs", required = true)
+    @Parameter(property = AsciidoctorMaven.PREFIX + "outputDirectory", defaultValue = "${project.build.directory}/generated-docs", required = true)
     protected File outputDirectory;
 
     @Parameter(property = AsciidoctorMaven.PREFIX + "preserveDirectories", defaultValue = "false", required = false)
@@ -141,7 +141,7 @@ public class AsciidoctorMojo extends AbstractMojo {
         }
 
         if (sourceDirectory == null) {
-            throw new MojoExecutionException("Required parameter 'asciidoctor.sourceDir' not set.");
+            throw new MojoExecutionException("Required parameter 'asciidoctor.sourceDirectory' not set.");
         }
 
         if (!sourceDirectory.exists()) {


### PR DESCRIPTION
This PR includes the correction to the command options configuration and and a new integration test to validate it.

Note: TravisCI adds some Maven configuration that messes with tests that use command line arguments like the one added. To make it work I had to add the `export MAVEN_SKIP_RC=true` option to the Travis configuration.