### PR TITLE
fixes #206 - adds the option to set attributes through command line an…

### DIFF
--- a/README.adoc
+++ b/README.adoc
@@ -92,7 +92,7 @@ eruby:: defaults to erb, the version used in JRuby
 headerFooter:: defaults to `true`
 templateDir:: disabled by default, defaults to `null`
 templateEngine:: disabled by default
-sourceHighlighter:: enables and sets the source highlighter (currently `coderay` or `highlightjs` are supported)
+sourceHighlighter:: enables and sets the source highlighter (currently `coderay` or `highlight.js` are supported)
 attributes:: a `Map<String,Object>` of attributes to pass to Asciidoctor, defaults to `null`
 embedAssets:: Embedd the CSS file, etc into the output, defaults to `false`
 gemPaths:: enables to specify the location to one or more gem installation directories (same as GEM_PATH environment var), `empty` by default
@@ -204,6 +204,36 @@ In the `<attributes>` part of the Asciidoctor Maven Plugin configuration:
 ----
 
 You can find more information and many examples ready to copy-paste in the {uri-examples}[Asciidoctor Maven examples] project.
+
+==== Command line configuration
+
+Configuration options can be set (but not replaced) using system properties directly in the command line as follows:
+
+ mvn generate-resources -Dasciidoctor.sourceDirectory=src/docs -Dasciidoctor.outputDirectory=target/docs
+
+All options follow the naming convention _`asciidoctor.` + option_name_.
+
+In order to provide a higher degree of flexibility `attributes` configuration follows a different behavior.
+Attributes defined through the command line are added to the ones already found in the XML configuration.
+The result of it is that attributes and other configuration options can be updated if they are added to the command line as attributes.
+For example, the following configuration could be modified with the command options as seen below.
+
+[source,xml]
+----
+<configuration>
+    <backend>html5</backend>
+    <sourceHighlighter>coderay</sourceHighlighter>
+    <attributes>
+        <toc>left</toc>
+    </attributes>
+</configuration>
+----
+
+ mvn generate-resources -Dasciidoctor.attributes=toc=right
+
+ mvn generate-resources -Dasciidoctor.attributes="toc=right source-highlighter=highlight.js imagesdir=my_images"
+
+Note that in the second case we need to use quotes due to the spaces, and that `source-highlighter` is the asciidoctor attribute name used to update the configuration.
 
 === Multiple outputs for the same file
 

--- a/src/main/java/org/asciidoctor/maven/AsciidoctorMojo.java
+++ b/src/main/java/org/asciidoctor/maven/AsciidoctorMojo.java
@@ -82,8 +82,11 @@ public class AsciidoctorMojo extends AbstractMojo {
     @Parameter(property = AsciidoctorMaven.PREFIX + "requires")
     protected List<String> requires = new ArrayList<String>();
 
-    @Parameter(property = AsciidoctorMaven.PREFIX + Options.ATTRIBUTES, required = false)
+    @Parameter(required = false)
     protected Map<String, Object> attributes = new HashMap<String, Object>();
+
+    @Parameter(property = AsciidoctorMaven.PREFIX + Options.ATTRIBUTES, required = false)
+    protected String attributesChain = "";
 
     @Parameter(property = AsciidoctorMaven.PREFIX + Options.BACKEND, defaultValue = "docbook", required = true)
     protected String backend = "";
@@ -384,6 +387,12 @@ public class AsciidoctorMojo extends AbstractMojo {
                 attributesBuilder.attribute(attributeEntry.getKey(), val);
             }
         }
+
+        if (!attributesChain.isEmpty()) {
+            getLog().info("Attributes: " + attributesChain);
+            attributesBuilder.arguments(attributesChain);
+        }
+
     }
 
     public File getSourceDirectory() {

--- a/src/test/groovy/org/asciidoctor/maven/test/AsciidoctorMojoTest.groovy
+++ b/src/test/groovy/org/asciidoctor/maven/test/AsciidoctorMojoTest.groovy
@@ -466,7 +466,7 @@ class AsciidoctorMojoTest extends Specification {
     /**
      * Tests Highlight.js source code highlighting options.
      */
-    def 'code highlighting - highlightjs'() {
+    def 'code highlighting - highlight.js'() {
         setup:
             File srcDir = new File('src/test/resources/src/asciidoctor')
             File outputDir = new File('target/asciidoctor-output-sourceHighlighting/highlightjs')
@@ -475,7 +475,7 @@ class AsciidoctorMojoTest extends Specification {
             AsciidoctorMojo mojo = new AsciidoctorMojo()
             mojo.sourceDirectory = srcDir
             mojo.outputDirectory = outputDir
-            mojo.sourceHighlighter = 'highlightjs'
+            mojo.sourceHighlighter = 'highlight.js'
             mojo.sourceDocumentName = new File('main-document.adoc')
             mojo.backend = 'html'
             mojo.execute()
@@ -856,6 +856,34 @@ class AsciidoctorMojoTest extends Specification {
         then:
             outputDir.list().toList().isEmpty() == false
             !(new File(outputDir, 'github-include.html').text.contains('modelVersion'))
+    }
+
+    def "command line attributes replace configurations"() {
+        setup:
+            File srcDir = new File('target/test-classes/src/asciidoctor')
+            File outputDir = new File('target/asciidoctor-output/command-line-options')
+
+            if (!outputDir.exists())
+                outputDir.mkdirs()
+        when: 'set toc and sourceHighlighter as XML configuration and command line attributes'
+            AsciidoctorMojo mojo = new AsciidoctorMojo()
+            mojo.backend = 'html'
+            mojo.sourceDirectory = srcDir
+            mojo.sourceDocumentName = 'sample.asciidoc'
+            mojo.outputDirectory = outputDir
+            mojo.sourceHighlighter = 'coderay'
+            mojo.attributes['toc'] = 'left'
+            // replace some options
+            mojo.attributesChain = 'toc=right source-highlighter=highlight.js'
+            mojo.execute()
+        then: 'command line options are applied instead of xml configuration'
+            outputDir.list().toList().isEmpty() == false
+            outputDir.list().toList().contains('sample.html')
+            File sampleOutput = new File('sample.html', outputDir)
+            sampleOutput.length() > 0
+            String text = sampleOutput.getText()
+            text.contains('<body class="article toc2 toc-right">')
+            text.contains('<pre class="highlightjs highlight">')
     }
 
 }


### PR DESCRIPTION
This PR reconfigures the attributes configuration in AsciidoctorMojo to allow setting them using command line options in the same as in asciidoctor.
This PR does not replace or change in any way how attributes are set using the standard XML.