### PR TITLE
AsciidoctorMojo getAsciidoctorInstance updated to check the JRubyRunt…

### DIFF
--- a/src/main/java/org/asciidoctor/maven/AsciidoctorMojo.java
+++ b/src/main/java/org/asciidoctor/maven/AsciidoctorMojo.java
@@ -252,59 +252,27 @@ public class AsciidoctorMojo extends AbstractMojo {
             String normalizedGemPath = (File.separatorChar == '\\') ? gemPath.replaceAll("\\\\", "/") : gemPath;
             asciidoctor = Asciidoctor.Factory.create(normalizedGemPath);
         }
-
+        
         Ruby rubyInstance = null;
-        try
-		{
-        	rubyInstance = (Ruby) JRubyRuntimeContext.class.getMethod("get").invoke(null);
-		}
-		catch (NoSuchMethodException e)
-		{
-	        if(rubyInstance == null)
-	        {
-				try
-				{
-		        	rubyInstance = (Ruby) JRubyRuntimeContext.class.getMethod("get", Asciidoctor.class).invoke(null, asciidoctor);
-				}
-				catch (NoSuchMethodException e1)
-				{
-		            throw new MojoExecutionException("Failed to invoke get(AsciiDoctor) for JRubyRuntimeContext",e);
-				}
-				catch (SecurityException e1)
-				{
-		            throw new MojoExecutionException("Failed to invoke get(AsciiDoctor) for JRubyRuntimeContext",e);
-				}
-				catch (IllegalAccessException e1)
-				{
-		            throw new MojoExecutionException("Failed to invoke get(AsciiDoctor) for JRubyRuntimeContext",e);
-				}
-				catch (IllegalArgumentException e1)
-				{
-		            throw new MojoExecutionException("Failed to invoke get(AsciiDoctor) for JRubyRuntimeContext",e);
-				}
-				catch (InvocationTargetException e1)
-				{
-		            throw new MojoExecutionException("Failed to invoke get(AsciiDoctor) for JRubyRuntimeContext",e);
-				}
-	        	
-	        }
-		}
-		catch (SecurityException e)
-		{
-            throw new MojoExecutionException("Failed to retrieve get method information from JRubyRuntimeContext",e);
-		}
-		catch (IllegalAccessException e)
-		{
-            throw new MojoExecutionException("Failed to invoke get for JRubyRuntimeContext",e);
-		}
-		catch (IllegalArgumentException e)
-		{
-            throw new MojoExecutionException("Failed to invoke get for JRubyRuntimeContext",e);
-		}
-		catch (InvocationTargetException e)
-		{
-            throw new MojoExecutionException("Failed to invoke get for JRubyRuntimeContext",e);
-		}
+        try {
+            rubyInstance = (Ruby) JRubyRuntimeContext.class.getMethod("get")
+                    .invoke(null);
+        } catch (NoSuchMethodException e) {
+            if (rubyInstance == null) {
+                try {
+                    rubyInstance = (Ruby) JRubyRuntimeContext.class.getMethod(
+                            "get", Asciidoctor.class).invoke(null, asciidoctor);
+                } catch (ReflectiveOperationException e1) {
+                    throw new MojoExecutionException(
+                            "Failed to invoke get(AsciiDoctor) for JRubyRuntimeContext",
+                            e);
+                }
+
+            }
+        } catch (ReflectiveOperationException e) {
+            throw new MojoExecutionException(
+                    "Failed to invoke get for JRubyRuntimeContext", e);
+        }
         
         String gemHome = rubyInstance.evalScriptlet("ENV['GEM_HOME']").toString();
         String gemHomeExpected = (gemPath == null || "".equals(gemPath)) ? "" : gemPath.split(java.io.File.pathSeparator)[0];

--- a/src/main/java/org/asciidoctor/maven/AsciidoctorMojo.java
+++ b/src/main/java/org/asciidoctor/maven/AsciidoctorMojo.java
@@ -15,6 +15,8 @@ package org.asciidoctor.maven;
 import java.io.File;
 import java.io.FileFilter;
 import java.io.IOException;
+import java.lang.reflect.InvocationTargetException;
+import java.lang.reflect.Method;
 import java.util.ArrayList;
 import java.util.HashMap;
 import java.util.Iterator;
@@ -41,6 +43,7 @@ import org.asciidoctor.internal.RubyUtils;
 import org.asciidoctor.maven.extensions.AsciidoctorJExtensionRegistry;
 import org.asciidoctor.maven.extensions.ExtensionConfiguration;
 import org.asciidoctor.maven.extensions.ExtensionRegistry;
+import org.jruby.Ruby;
 
 
 /**
@@ -250,7 +253,60 @@ public class AsciidoctorMojo extends AbstractMojo {
             asciidoctor = Asciidoctor.Factory.create(normalizedGemPath);
         }
 
-        String gemHome = JRubyRuntimeContext.get().evalScriptlet("ENV['GEM_HOME']").toString();
+        Ruby rubyInstance = null;
+        try
+		{
+        	rubyInstance = (Ruby) JRubyRuntimeContext.class.getMethod("get").invoke(null);
+		}
+		catch (NoSuchMethodException e)
+		{
+	        if(rubyInstance == null)
+	        {
+				try
+				{
+		        	rubyInstance = (Ruby) JRubyRuntimeContext.class.getMethod("get", Asciidoctor.class).invoke(null, asciidoctor);
+				}
+				catch (NoSuchMethodException e1)
+				{
+		            throw new MojoExecutionException("Failed to invoke get(AsciiDoctor) for JRubyRuntimeContext",e);
+				}
+				catch (SecurityException e1)
+				{
+		            throw new MojoExecutionException("Failed to invoke get(AsciiDoctor) for JRubyRuntimeContext",e);
+				}
+				catch (IllegalAccessException e1)
+				{
+		            throw new MojoExecutionException("Failed to invoke get(AsciiDoctor) for JRubyRuntimeContext",e);
+				}
+				catch (IllegalArgumentException e1)
+				{
+		            throw new MojoExecutionException("Failed to invoke get(AsciiDoctor) for JRubyRuntimeContext",e);
+				}
+				catch (InvocationTargetException e1)
+				{
+		            throw new MojoExecutionException("Failed to invoke get(AsciiDoctor) for JRubyRuntimeContext",e);
+				}
+	        	
+	        }
+		}
+		catch (SecurityException e)
+		{
+            throw new MojoExecutionException("Failed to retrieve get method information from JRubyRuntimeContext",e);
+		}
+		catch (IllegalAccessException e)
+		{
+            throw new MojoExecutionException("Failed to invoke get for JRubyRuntimeContext",e);
+		}
+		catch (IllegalArgumentException e)
+		{
+            throw new MojoExecutionException("Failed to invoke get for JRubyRuntimeContext",e);
+		}
+		catch (InvocationTargetException e)
+		{
+            throw new MojoExecutionException("Failed to invoke get for JRubyRuntimeContext",e);
+		}
+        
+        String gemHome = rubyInstance.evalScriptlet("ENV['GEM_HOME']").toString();
         String gemHomeExpected = (gemPath == null || "".equals(gemPath)) ? "" : gemPath.split(java.io.File.pathSeparator)[0];
 
         if (!"".equals(gemHome) && !gemHomeExpected.equals(gemHome)) {

--- a/src/main/java/org/asciidoctor/maven/AsciidoctorMojo.java
+++ b/src/main/java/org/asciidoctor/maven/AsciidoctorMojo.java
@@ -262,14 +262,14 @@ public class AsciidoctorMojo extends AbstractMojo {
                 try {
                     rubyInstance = (Ruby) JRubyRuntimeContext.class.getMethod(
                             "get", Asciidoctor.class).invoke(null, asciidoctor);
-                } catch (ReflectiveOperationException e1) {
+                } catch (Exception e1) {
                     throw new MojoExecutionException(
                             "Failed to invoke get(AsciiDoctor) for JRubyRuntimeContext",
-                            e);
+                            e1);
                 }
 
             }
-        } catch (ReflectiveOperationException e) {
+        } catch (Exception e) {
             throw new MojoExecutionException(
                     "Failed to invoke get for JRubyRuntimeContext", e);
         }


### PR DESCRIPTION
…imeContext instance to determine whether either get or get(AsciiDoctor) overloads exist and invoke if the method exists. This ensures we can be compatible with both 1.5.x and 1.6.0 of asciidoctorj