### PR TITLE
Adds support to define resources directories with include/exclude filters

### DIFF
--- a/README.adoc
+++ b/README.adoc
@@ -73,6 +73,21 @@ There are several configuration options that the asciidoctor-maven-plugin uses, 
 sourceDirectory:: defaults to `${basedir}/src/main/asciidoc`
 sourceDocumentName:: an override to process a single source file; defaults to all files in `${sourceDirectory}`
 sourceDocumentExtensions:: (named `extensions` in v1.5.3 and below) a `List<String>` of non-standard file extensions to render. Currently ad, adoc, and asciidoc will be rendered by default
+resources:: list of resource files to copy to the output directory (e.g., images, css). By default everything is copied
++
+[source, xml]
+----
+    <resources>
+        <resource>
+            <directory>DIRECTORY</directory>
+            <include>**/*.jpg</include>
+            <include>**/*.gif</include>
+            <exclude>**/.svn</exclude>
+        </resource>
+        <resource>
+            ...
+    <resources>
+----
 outputDirectory:: defaults to `${project.build.directory}/generated-docs`
 baseDir:: (not Maven's basedir) enables to set the root path for resouces (e.g. included files), defaults to `${sourceDirectory}`
 skip:: set this to `true` to bypass generation, defaults to `false`

--- a/pom.xml
+++ b/pom.xml
@@ -1,4 +1,5 @@
-<project xmlns="http://maven.apache.org/POM/4.0.0" xmlns:xsi="http://www.w3.org/2001/XMLSchema-instance" xsi:schemaLocation="http://maven.apache.org/POM/4.0.0 http://maven.apache.org/xsd/maven-4.0.0.xsd">
+<project xmlns="http://maven.apache.org/POM/4.0.0" xmlns:xsi="http://www.w3.org/2001/XMLSchema-instance"
+         xsi:schemaLocation="http://maven.apache.org/POM/4.0.0 http://maven.apache.org/xsd/maven-4.0.0.xsd">
     <modelVersion>4.0.0</modelVersion>
 
     <parent>
@@ -76,6 +77,7 @@
         <maven.project.version>2.2.1</maven.project.version>
         <maven.compiler.plugin.version>3.1</maven.compiler.plugin.version>
         <maven.plugin.plugin.version>3.2</maven.plugin.plugin.version>
+        <maven.filtering.version>3.1.0</maven.filtering.version>
         <plexus.utils.version>3.0.10</plexus.utils.version>
         <plexus.component.metadata.version>1.5.5</plexus.component.metadata.version>
         <netty.version>4.0.0.CR1</netty.version>
@@ -113,11 +115,16 @@
             <version>${maven.project.version}</version>
             <scope>compile</scope>
         </dependency>
-      <dependency>
+        <dependency>
             <groupId>org.apache.maven.plugin-tools</groupId>
             <artifactId>maven-plugin-annotations</artifactId>
             <version>${maven.plugin.annotations.version}</version>
             <scope>compile</scope>
+        </dependency>
+        <dependency>
+            <groupId>org.apache.maven.shared</groupId>
+            <artifactId>maven-filtering</artifactId>
+            <version>${maven.filtering.version}</version>
         </dependency>
         <dependency>
             <groupId>org.codehaus.plexus</groupId>
@@ -386,8 +393,8 @@
                     <url>http://dl.bintray.com/lordofthejars/maven</url>
                 </repository>
             </repositories>
-          </profile>
-          <profile>
+        </profile>
+        <profile>
             <id>run-its</id>
             <build>
                 <plugins>

--- a/src/main/java/org/asciidoctor/maven/AsciidoctorMojo.java
+++ b/src/main/java/org/asciidoctor/maven/AsciidoctorMojo.java
@@ -12,38 +12,31 @@
 
 package org.asciidoctor.maven;
 
-import java.io.File;
-import java.io.FileFilter;
-import java.io.IOException;
-import java.lang.reflect.InvocationTargetException;
-import java.lang.reflect.Method;
-import java.util.ArrayList;
-import java.util.HashMap;
-import java.util.Iterator;
-import java.util.List;
-import java.util.Map;
-
 import org.apache.commons.io.FileUtils;
+import org.apache.maven.execution.MavenSession;
+import org.apache.maven.model.Resource;
 import org.apache.maven.plugin.AbstractMojo;
 import org.apache.maven.plugin.MojoExecutionException;
 import org.apache.maven.plugin.MojoFailureException;
+import org.apache.maven.plugins.annotations.Component;
 import org.apache.maven.plugins.annotations.Mojo;
 import org.apache.maven.plugins.annotations.Parameter;
-import org.asciidoctor.AbstractDirectoryWalker;
-import org.asciidoctor.AsciiDocDirectoryWalker;
-import org.asciidoctor.Asciidoctor;
-import org.asciidoctor.Attributes;
-import org.asciidoctor.AttributesBuilder;
-import org.asciidoctor.DirectoryWalker;
-import org.asciidoctor.Options;
-import org.asciidoctor.OptionsBuilder;
-import org.asciidoctor.SafeMode;
+import org.apache.maven.project.MavenProject;
+import org.apache.maven.shared.filtering.MavenFilteringException;
+import org.apache.maven.shared.filtering.MavenResourcesExecution;
+import org.apache.maven.shared.filtering.MavenResourcesFiltering;
+import org.asciidoctor.*;
 import org.asciidoctor.internal.JRubyRuntimeContext;
-import org.asciidoctor.internal.RubyUtils;
 import org.asciidoctor.maven.extensions.AsciidoctorJExtensionRegistry;
 import org.asciidoctor.maven.extensions.ExtensionConfiguration;
 import org.asciidoctor.maven.extensions.ExtensionRegistry;
+import org.asciidoctor.maven.io.AsciidoctorFileScanner;
 import org.jruby.Ruby;
+import org.sonatype.plexus.build.incremental.BuildContext;
+
+import java.io.File;
+import java.io.IOException;
+import java.util.*;
 
 
 /**
@@ -54,6 +47,8 @@ public class AsciidoctorMojo extends AbstractMojo {
     // copied from org.asciidoctor.AsciiDocDirectoryWalker.ASCIIDOC_REG_EXP_EXTENSION
     // should probably be configured in AsciidoctorMojo through @Parameter 'extension'
     protected static final String ASCIIDOC_REG_EXP_EXTENSION = ".*\\.a((sc(iidoc)?)|d(oc)?)$";
+
+    protected static final String FILE_ENCODING = System.getProperty("file.encoding");
 
     @Parameter(property = AsciidoctorMaven.PREFIX + "sourceDirectory", defaultValue = "${basedir}/src/main/asciidoc", required = true)
     protected File sourceDirectory;
@@ -139,6 +134,22 @@ public class AsciidoctorMojo extends AbstractMojo {
     @Parameter(property = AsciidoctorMaven.PREFIX + "attributeUndefined")
     protected String attributeUndefined = "drop-line";
 
+    // List of resources to copy to the output directory (e.g., images, css). By default everything is copied
+    @Parameter(property = AsciidoctorMaven.PREFIX + "sources")
+    protected List<Resource> resources;
+
+    @Parameter(defaultValue = "${project}", readonly = true, required = true)
+    protected MavenProject project;
+
+    @Parameter(defaultValue = "${session}", readonly = true, required = true)
+    protected MavenSession session;
+
+    @Component
+    protected MavenResourcesFiltering outputResourcesFiltering;
+
+    @Component
+    protected BuildContext buildContext;
+
     @Override
     public void execute() throws MojoExecutionException, MojoFailureException {
         if (skip) {
@@ -156,6 +167,15 @@ public class AsciidoctorMojo extends AbstractMojo {
         }
 
         ensureOutputExists();
+
+        // Validate resources to avoid errors later on
+        if (resources != null) {
+            for (Resource resource : resources) {
+                if (resource.getDirectory() == null || resource.getDirectory().isEmpty()) {
+                    throw new MojoExecutionException("Found empty resource directory");
+                }
+            }
+        }
 
         final Asciidoctor asciidoctor = getAsciidoctorInstance(gemPath);
 
@@ -184,7 +204,11 @@ public class AsciidoctorMojo extends AbstractMojo {
                 throw new MojoExecutionException(e.getMessage(), e);
             }
         }
-        
+
+        // Copy output resources
+        repareResources();
+        copyResources();
+
         if (sourceDocumentName == null) {
             for (final File f : scanSourceFiles()) {
                 setDestinationPaths(optionsBuilder, f);
@@ -196,15 +220,68 @@ public class AsciidoctorMojo extends AbstractMojo {
             renderFile(asciidoctor, optionsBuilder.asMap(), sourceFile);
         }
 
-        // #67 -- get all files that aren't adoc/ad/asciidoc and create synchronizations for them
-        try {
-            FileUtils.copyDirectory(sourceDirectory, outputDirectory, new NonAsciiDocExtensionFileFilter(), false);
-        } catch (IOException e) {
-            throw new MojoExecutionException("Error copying resources", e);
-        }
-
         if (synchronizations != null && !synchronizations.isEmpty()) {
             synchronize();
+        }
+    }
+
+    /**
+     * Initializes resources attribute excluding AsciiDoc documents and hidden directories/files (those prefixed with
+     * underscore).
+     * By default everything in the sources directories is copied.
+     */
+    private void repareResources() {
+        if (resources == null || resources.isEmpty()) {
+            resources = new ArrayList<Resource>();
+            // we don't want to copy files considered sources
+            Resource resource = new Resource();
+            resource.setDirectory(sourceDirectory.getAbsolutePath());
+            resource.setExcludes(new ArrayList<String>());
+            // exclude sourceDocumentName if defined
+            if (sourceDocumentName != null && sourceDocumentName.isEmpty()) {
+                resource.getExcludes().add(sourceDocumentName);
+            }
+            // exclude filename extensions if defined
+            if (sourceDocumentExtensions == null || sourceDocumentExtensions.isEmpty()) {
+                for (String docExtension : sourceDocumentExtensions) {
+                    resource.getExcludes().add(docExtension);
+                }
+            }
+            resources.add(resource);
+        }
+
+        // All resources must exclude AsciiDoc documents and folders beginning with underscore
+        for (Resource resource : resources) {
+            if (resource.getExcludes() == null || resource.getExcludes().isEmpty()) {
+                resource.setExcludes(new ArrayList<String>());
+            }
+            List<String> excludes = new ArrayList<String>();
+            for (String value : AsciidoctorFileScanner.IGNORED_FOLDERS_AND_FILES) {
+                excludes.add(value);
+            }
+            for (String value : AsciidoctorFileScanner.DEFAULT_FILE_EXTENSIONS) {
+                excludes.add(value);
+            }
+            // in case someone wants to include some of the default excluded files (.e.g., AsciiDoc docs)
+            excludes.removeAll(resource.getIncludes());
+            resource.getExcludes().addAll(excludes);
+        }
+    }
+
+    /**
+     * Copies the resources defined in the 'resources' attribute
+     */
+    private void copyResources() throws MojoExecutionException {
+        try {
+            // Right now it's not used at all, but could be used to apply resource filters/replacements
+            MavenResourcesExecution resourcesExecution =
+                    new MavenResourcesExecution(resources, outputDirectory, project, FILE_ENCODING,
+                            Collections.<String>emptyList(), Collections.<String>emptyList(), session);
+            resourcesExecution.setIncludeEmptyDirs(true);
+            outputResourcesFiltering.filterResources(resourcesExecution);
+        } catch (MavenFilteringException e) {
+            throw new MojoExecutionException("Could not copy resources", e);
+
         }
     }
 
@@ -242,10 +319,9 @@ public class AsciidoctorMojo extends AbstractMojo {
 
     protected Asciidoctor getAsciidoctorInstance(String gemPath) throws MojoExecutionException {
         Asciidoctor asciidoctor = null;
-        if (gemPath == null) {
-             asciidoctor = Asciidoctor.Factory.create();
-        }
-        else {
+        if (gemPath == null || gemPath.isEmpty()) {
+            asciidoctor = Asciidoctor.Factory.create();
+        } else {
             // Replace Windows path separator to avoid paths with mixed \ and /.
             // This happens for instance when setting: <gemPath>${project.build.directory}/gems-provided</gemPath>
             // because the project's path is converted to string.
@@ -619,6 +695,14 @@ public class AsciidoctorMojo extends AbstractMojo {
         this.extensions = extensions;
     }
 
+    public List<Resource> getResources() {
+        return resources;
+    }
+
+    public void setResources(List<Resource> resources) {
+        this.resources = resources;
+    }
+
     private static class CustomExtensionDirectoryWalker extends AbstractDirectoryWalker {
         private final List<String> fileExtensions;
 
@@ -639,22 +723,4 @@ public class AsciidoctorMojo extends AbstractMojo {
         }
     }
 
-    private static class NonAsciiDocExtensionFileFilter implements FileFilter {
-        private final List<String> fileExtensions;
-
-        public NonAsciiDocExtensionFileFilter() {
-            this.fileExtensions = java.util.Arrays.asList("ad", "adoc", "asciidoc");
-        }
-
-        @Override
-        public boolean accept(File pathname) {
-            final String name = pathname.getName();
-            for (final String extension : fileExtensions) {
-                if (name.endsWith(extension)) {
-                    return false;
-                }
-            }
-            return true;
-        }
-    }
 }

--- a/src/main/java/org/asciidoctor/maven/AsciidoctorMojo.java
+++ b/src/main/java/org/asciidoctor/maven/AsciidoctorMojo.java
@@ -206,7 +206,7 @@ public class AsciidoctorMojo extends AbstractMojo {
         }
 
         // Copy output resources
-        repareResources();
+        prepareResources();
         copyResources();
 
         if (sourceDocumentName == null) {
@@ -230,7 +230,7 @@ public class AsciidoctorMojo extends AbstractMojo {
      * underscore).
      * By default everything in the sources directories is copied.
      */
-    private void repareResources() {
+    private void prepareResources() {
         if (resources == null || resources.isEmpty()) {
             resources = new ArrayList<Resource>();
             // we don't want to copy files considered sources
@@ -319,7 +319,7 @@ public class AsciidoctorMojo extends AbstractMojo {
 
     protected Asciidoctor getAsciidoctorInstance(String gemPath) throws MojoExecutionException {
         Asciidoctor asciidoctor = null;
-        if (gemPath == null || gemPath.isEmpty()) {
+        if (gemPath == null) {
             asciidoctor = Asciidoctor.Factory.create();
         } else {
             // Replace Windows path separator to avoid paths with mixed \ and /.

--- a/src/main/java/org/asciidoctor/maven/AsciidoctorZipMojo.java
+++ b/src/main/java/org/asciidoctor/maven/AsciidoctorZipMojo.java
@@ -12,17 +12,16 @@
 
 package org.asciidoctor.maven;
 
-import java.io.File;
-import java.io.IOException;
-
 import org.apache.maven.plugin.MojoExecutionException;
 import org.apache.maven.plugin.MojoFailureException;
 import org.apache.maven.plugins.annotations.Component;
 import org.apache.maven.plugins.annotations.Mojo;
 import org.apache.maven.plugins.annotations.Parameter;
-import org.apache.maven.project.MavenProject;
 import org.apache.maven.project.MavenProjectHelper;
 import org.asciidoctor.maven.io.Zips;
+
+import java.io.File;
+import java.io.IOException;
 
 @Mojo(name = "zip")
 public class AsciidoctorZipMojo extends AsciidoctorMojo {
@@ -30,9 +29,6 @@ public class AsciidoctorZipMojo extends AsciidoctorMojo {
 
     @Component
     private MavenProjectHelper projectHelper;
-
-    @Parameter(property = PREFIX, defaultValue = "${project}", readonly = true)
-    private MavenProject project;
 
     @Parameter(property = PREFIX + "attach", defaultValue = "true")
     protected boolean attach;

--- a/src/main/java/org/asciidoctor/maven/io/AsciidoctorFileScanner.java
+++ b/src/main/java/org/asciidoctor/maven/io/AsciidoctorFileScanner.java
@@ -1,0 +1,99 @@
+package org.asciidoctor.maven.io;
+
+import org.apache.maven.model.Resource;
+import org.codehaus.plexus.util.Scanner;
+import org.sonatype.plexus.build.incremental.BuildContext;
+
+import java.io.File;
+import java.util.*;
+
+/**
+ * Recursively traverses directories returning the list of AsciiDoc files that match the applied filters.
+ * If no filters are set, AsciiDoc documents with extensions .adoc, .ad, .asc and .asciidoc are returned.
+ */
+public class AsciidoctorFileScanner {
+
+    public static String[] DEFAULT_FILE_EXTENSIONS = {"**/*.adoc", "**/*.ad", "**/*.asc","**/*.asciidoc"};
+    // Files and directories beginning with underscore are ignored
+    public static String[] IGNORED_FOLDERS_AND_FILES = {"**/_*.*", "**/_*", "**/_*/**/*.*"};
+
+    private BuildContext buildContext;
+
+    public AsciidoctorFileScanner(BuildContext buildContext) {
+        this.buildContext = buildContext;
+    }
+
+    /**
+     * Scans a resource directory (and sub-subdirectories) returning all AsciiDoc documents found.
+     *
+     * @param resource {@link Resource} to scan (the directory property is mandatory)
+     * @return List of found documents matching the resource properties
+     */
+    public List<File> scan(Resource resource) {
+        Scanner scanner = buildContext.newScanner(new File(resource.getDirectory()), true);
+        setupScanner(scanner, resource);
+        scanner.scan();
+        List<File> files = new ArrayList<File>();
+        for (String file : scanner.getIncludedFiles()) {
+            files.add(new File(resource.getDirectory(), file));
+        }
+        return files;
+    }
+
+    /**
+     * Scans a list of resources returning all AsciiDoc documents found.
+     *
+     * @param resources List of {@link Resource} to scan (the directory property is mandatory)
+     * @return List of found documents matching the resources properties
+     */
+    public List<File> scan(List<Resource> resources) {
+        List<File> files = new ArrayList<File>();
+        for (Resource resource: resources) {
+            files.addAll(scan(resource));
+        }
+        return files;
+    }
+
+    /**
+     * Initializes the Scanner with the default values.
+     * <br>
+     * By default:
+     * <ul>
+     *     <li>includes adds extension .adoc, .ad, .asc and .asciidoc
+     *     <li>excludes adds filters to avoid hidden files and directoris beginning with undersore
+     * </ul>
+     *
+     * NOTE: Patterns both in inclusions and exclusions are automatically excluded.
+     */
+    private void setupScanner(Scanner scanner, Resource resource) {
+
+        if (resource.getIncludes() == null || resource.getIncludes().isEmpty()) {
+            scanner.setIncludes(DEFAULT_FILE_EXTENSIONS);
+        } else {
+            scanner.setIncludes(resource.getIncludes().toArray(new String[] {}));
+        }
+
+        if (resource.getExcludes() == null || resource.getExcludes().isEmpty()) {
+            scanner.setExcludes(IGNORED_FOLDERS_AND_FILES);
+        } else {
+            scanner.setExcludes(mergeAndConvert(resource.getExcludes(), IGNORED_FOLDERS_AND_FILES));
+        }
+        // adds exclusions like SVN or GIT files
+        scanner.addDefaultExcludes();
+    }
+
+    /**
+     * Returns a String[] with the values of both input parameters.
+     * Duplicated values are inserted only once.
+     *
+     * @param list List of string
+     * @param array Array of String
+     * @return Array of String with all values
+     */
+    private String[] mergeAndConvert(List<String> list, String[] array) {
+        Set<String> set = new HashSet<String>(Arrays.asList(array));
+        set.addAll(list);
+        return set.toArray(new String[set.size()]);
+    }
+
+}

--- a/src/test/groovy/org/asciidoctor/maven/test/AsciidoctorHttpMojoTest.groovy
+++ b/src/test/groovy/org/asciidoctor/maven/test/AsciidoctorHttpMojoTest.groovy
@@ -1,13 +1,31 @@
 package org.asciidoctor.maven.test
 
 import org.asciidoctor.maven.AsciidoctorHttpMojo
+import org.asciidoctor.maven.AsciidoctorMojo
 import org.asciidoctor.maven.test.io.DoubleOuputStream
 import org.asciidoctor.maven.test.io.PrefilledInputStream
+import org.asciidoctor.maven.test.plexus.MockPlexusContainer
 import spock.lang.Specification
 
 import java.util.concurrent.CountDownLatch
 
 class AsciidoctorHttpMojoTest extends Specification {
+
+    /**
+     * Intercept Asciidoctor mojo constructor to mock and inject required
+     * plexus objects
+     */
+    def setupSpec() {
+        MockPlexusContainer mockPlexusContainer = new MockPlexusContainer()
+        def oldConstructor = AsciidoctorHttpMojo.constructors[0]
+
+        AsciidoctorHttpMojo.metaClass.constructor = {
+            def mojo = oldConstructor.newInstance()
+            mockPlexusContainer.initializeContext(mojo)
+            return mojo
+        }
+    }
+
     def "http front should let access rendered files"() {
         setup:
             def srcDir = new File('target/test-classes/src/asciidoctor-http')

--- a/src/test/groovy/org/asciidoctor/maven/test/AsciidoctorMojoTest.groovy
+++ b/src/test/groovy/org/asciidoctor/maven/test/AsciidoctorMojoTest.groovy
@@ -1,19 +1,39 @@
 package org.asciidoctor.maven.test
 
 import groovy.io.FileType
-
 import org.apache.commons.io.FileUtils
+import org.apache.maven.model.Resource
 import org.asciidoctor.maven.AsciidoctorMojo
-import spock.lang.Ignore
+import org.asciidoctor.maven.io.AsciidoctorFileScanner
+import org.asciidoctor.maven.test.plexus.MockPlexusContainer
 import spock.lang.Specification
 
 /**
  *
  */
 class AsciidoctorMojoTest extends Specification {
+
+    static final String DEFAULT_SOURCE_DIRECTORY = 'target/test-classes/src/asciidoctor'
+    static final String MULTIPLE_RESOURCES_OUTPUT = 'target/asciidoctor-output/multiple-resources'
+
+    /**
+     * Intercept Asciidoctor mojo constructor to mock and inject required
+     * plexus objects
+     */
+    def setupSpec() {
+        MockPlexusContainer mockPlexusContainer = new MockPlexusContainer()
+        def oldConstructor = AsciidoctorMojo.constructors[0]
+
+        AsciidoctorMojo.metaClass.constructor = {
+            def mojo = oldConstructor.newInstance()
+            mockPlexusContainer.initializeContext(mojo)
+            return mojo
+        }
+    }
+
     def "renders docbook"() {
         setup:
-            File srcDir = new File('target/test-classes/src/asciidoctor')
+            File srcDir = new File(DEFAULT_SOURCE_DIRECTORY)
             File outputDir = new File('target/asciidoctor-output')
 
             if (!outputDir.exists())
@@ -35,7 +55,7 @@ class AsciidoctorMojoTest extends Specification {
 
     def "renders html"() {
         setup:
-            File srcDir = new File('target/test-classes/src/asciidoctor')
+            File srcDir = new File(DEFAULT_SOURCE_DIRECTORY)
             File outputDir = new File('target/asciidoctor-output')
 
             if (!outputDir.exists())
@@ -69,7 +89,7 @@ class AsciidoctorMojoTest extends Specification {
 
     def "should honor doctype set in document"() {
         setup:
-            File srcDir = new File('target/test-classes/src/asciidoctor')
+            File srcDir = new File(DEFAULT_SOURCE_DIRECTORY)
             File outputDir = new File('target/asciidoctor-output')
             if (!outputDir.exists())
                 outputDir.mkdir()
@@ -98,7 +118,7 @@ class AsciidoctorMojoTest extends Specification {
             outputDir.delete()
 
         when: 'asciidoctor mojo is called with extension foo and bar and it exists a sample1.foo and a sample2.bar'
-            def srcDir = new File('target/test-classes/src/asciidoctor')
+            def srcDir = new File(DEFAULT_SOURCE_DIRECTORY)
 
             outputDir.mkdirs()
 
@@ -145,7 +165,7 @@ class AsciidoctorMojoTest extends Specification {
 
     def "should require library"() {
         setup:
-            File srcDir = new File('target/test-classes/src/asciidoctor')
+            File srcDir = new File(DEFAULT_SOURCE_DIRECTORY)
             File outputDir = new File('target/asciidoctor-output')
 
             if (!outputDir.exists())
@@ -166,7 +186,7 @@ class AsciidoctorMojoTest extends Specification {
 
     def "embedding resources"() {
         setup:
-            File srcDir = new File('target/test-classes/src/asciidoctor')
+            File srcDir = new File(DEFAULT_SOURCE_DIRECTORY)
             File outputDir = new File('target/asciidoctor-output')
 
             if (!outputDir.exists())
@@ -196,7 +216,7 @@ class AsciidoctorMojoTest extends Specification {
 
     def "missing-attribute skip"() {
         given:
-            File srcDir = new File('target/test-classes/src/asciidoctor')
+            File srcDir = new File(DEFAULT_SOURCE_DIRECTORY)
             File outputDir = new File('target/asciidoctor-output')
 
             if (!outputDir.exists())
@@ -217,7 +237,7 @@ class AsciidoctorMojoTest extends Specification {
 
     def "missing-attribute drop"() {
         given:
-            File srcDir = new File('target/test-classes/src/asciidoctor')
+            File srcDir = new File(DEFAULT_SOURCE_DIRECTORY)
             File outputDir = new File('target/asciidoctor-output')
 
             if (!outputDir.exists())
@@ -239,7 +259,7 @@ class AsciidoctorMojoTest extends Specification {
 
     def "missing-attribute drop-line"() {
         given:
-            File srcDir = new File('target/test-classes/src/asciidoctor')
+            File srcDir = new File(DEFAULT_SOURCE_DIRECTORY)
             File outputDir = new File('target/asciidoctor-output')
 
             if (!outputDir.exists())
@@ -261,7 +281,7 @@ class AsciidoctorMojoTest extends Specification {
 
     def "undefined-attribute drop"() {
         given:
-            File srcDir = new File('target/test-classes/src/asciidoctor')
+            File srcDir = new File(DEFAULT_SOURCE_DIRECTORY)
             File outputDir = new File('target/asciidoctor-output')
 
             if (!outputDir.exists())
@@ -283,7 +303,7 @@ class AsciidoctorMojoTest extends Specification {
 
     def "undefined-attribute drop-line"() {
         given:
-            File srcDir = new File('target/test-classes/src/asciidoctor')
+            File srcDir = new File(DEFAULT_SOURCE_DIRECTORY)
             File outputDir = new File('target/asciidoctor-output')
 
             if (!outputDir.exists())
@@ -306,7 +326,7 @@ class AsciidoctorMojoTest extends Specification {
     // Test for Issue 62
     def 'setting_boolean_values'() {
         given:
-            File srcDir = new File('target/test-classes/src/asciidoctor')
+            File srcDir = new File(DEFAULT_SOURCE_DIRECTORY)
             File outputDir = new File('target/asciidoctor-output-issue-62')
 
             if (!outputDir.exists())
@@ -331,7 +351,7 @@ class AsciidoctorMojoTest extends Specification {
     // Test for Issue 62 (unset)
     def 'unsetting_boolean_values'() {
         given:
-        File srcDir = new File('target/test-classes/src/asciidoctor')
+        File srcDir = new File(DEFAULT_SOURCE_DIRECTORY)
         File outputDir = new File('target/asciidoctor-output-issue-62-unset')
 
         if (!outputDir.exists())
@@ -354,7 +374,7 @@ class AsciidoctorMojoTest extends Specification {
 
     def 'test_imageDir_properly_passed'() {
         given:
-            File srcDir = new File('target/test-classes/src/asciidoctor')
+            File srcDir = new File(DEFAULT_SOURCE_DIRECTORY)
             File outputDir = new File('target/asciidoctor-output-imageDir')
 
             if (!outputDir.exists())
@@ -375,7 +395,7 @@ class AsciidoctorMojoTest extends Specification {
 
     def 'includes_test'() {
         given:
-            File srcDir = new File('target/test-classes/src/asciidoctor')
+            File srcDir = new File(DEFAULT_SOURCE_DIRECTORY)
             File outputDir = new File('target/asciidoctor-output-include-test')
 
             if (!outputDir.exists())
@@ -396,7 +416,7 @@ class AsciidoctorMojoTest extends Specification {
 
     def 'skip'() {
         given:
-            File srcDir = new File('target/test-classes/src/asciidoctor')
+            File srcDir = new File(DEFAULT_SOURCE_DIRECTORY)
             File outputDir = new File('target/asciidoctor-output-skip-test')
             if (outputDir.exists())
                 outputDir.delete()
@@ -461,7 +481,7 @@ class AsciidoctorMojoTest extends Specification {
             File mainDocumentOutput = new File(outputDir, 'main-document.html')
             String text = mainDocumentOutput.getText()
             text.contains('CodeRay')
-    }   
+    }
 
     /**
      * Tests Highlight.js source code highlighting options.
@@ -499,7 +519,7 @@ class AsciidoctorMojoTest extends Specification {
             mojo.sourceDirectory = srcDir
             mojo.outputDirectory = outputDir
             mojo.sourceHighlighter = 'prettify'
-            mojo.sourceDocumentName = new File('main-document.adoc')   
+            mojo.sourceDocumentName = new File('main-document.adoc')
             mojo.backend = 'html'
             mojo.execute()
 
@@ -560,13 +580,13 @@ class AsciidoctorMojoTest extends Specification {
             // No extra CSS is added other than Asciidoctor's default
             text.count('<style>') == 1
     }
-    
+
     /**
      * Tests for relative folder structures treatment
      */
     static final FileFilter DIRECTORY_FILTER = {File f -> f.isDirectory()} as FileFilter
     static final String ASCIIDOC_REG_EXP_EXTENSION = '.*\\.a((sc(iidoc)?)|d(oc)?)$'
-    
+
     /**
      * Validates that the folder structures under certain files are the same
      *
@@ -574,17 +594,25 @@ class AsciidoctorMojoTest extends Specification {
      *         list of expected folders
      * @param actual
      *         list of actual folders (the ones to validate)
+     * @param ignoreUnderscore
+     *         tells where to ignore hidden Asciidoctor files (prefixed with underscore) in the expected parameter
      */
-    private void assertEqualsStructure (File[] expected, File[] actual) {
+    private void assertEqualsStructure (File[] expected, File[] actual, Boolean ignoreUnderscore = true) {
+        if (ignoreUnderscore)
+            expected = expected.findAll { !it.name.startsWith('_')}
+
         assert expected.length == actual.length
         expected*.name.containsAll(actual*.name)
-        actual*.name.containsAll(expected*.name) 
+        actual*.name.containsAll(expected*.name)
         for (File actualFile in actual) {
-            File expectedFile = expected.find {it.getName() == actualFile.getName()}
+            File expectedFile = expected.find { it.getName() == actualFile.getName() }
             assert expectedFile != null
-            
+
             // check that at least the number of html files and asciidoc are the same in each folder
-            File[] expectedChildren =  expectedFile.listFiles(DIRECTORY_FILTER)
+            File[] expectedChildren = expectedFile.listFiles(DIRECTORY_FILTER)
+            if (ignoreUnderscore)
+                expectedChildren = expectedChildren.findAll { !it.name.startsWith('_')}
+
             File[] htmls =  actualFile.listFiles({File f -> f.getName() ==~ /.+html/} as FileFilter)
             if (htmls) {
                 File[] asciidocs =  expectedFile.listFiles({File f -> f.getName() ==~ ASCIIDOC_REG_EXP_EXTENSION} as FileFilter)
@@ -595,13 +623,13 @@ class AsciidoctorMojoTest extends Specification {
         }
     }
 
-    
+
     /**
-     * Tests the behaviour when: 
+     * Tests the behaviour when:
      *  - simple paths are used
      *  - preserveDirectories = true
      *  - relativeBaseDir = true
-     *  
+     *
      *  Expected:
      *   - all documents are rendered in the same folder structure found in the sourceDirectory
      *   - all documents are correctly rendered with the import
@@ -641,11 +669,11 @@ class AsciidoctorMojoTest extends Specification {
     }
 
     /**
-     * Tests the behaviour when: 
+     * Tests the behaviour when:
      *  - complex paths are used
      *  - preserveDirectories = true
      *  - relativeBaseDir = true
-     *  
+     *
      *  Expected:
      *   - all documents are rendered in the same folder structure found in the sourceDirectory
      *   - all documents are correctly rendered with the import
@@ -665,7 +693,7 @@ class AsciidoctorMojoTest extends Specification {
             mojo.sourceHighlighter = 'coderay'
             mojo.attributes = ['icons':'font']
             mojo.execute()
-        
+
         then:
             outputDir.list().toList().isEmpty() == false
             outputDir.listFiles({File f -> f.getName().endsWith('html')} as FileFilter).length == 1
@@ -685,11 +713,11 @@ class AsciidoctorMojoTest extends Specification {
     }
 
     /**
-     * Tests the behaviour when: 
+     * Tests the behaviour when:
      *  - complex paths are used
      *  - preserveDirectories = false
      *  - relativeBaseDir = false
-     *  
+     *
      *  Expected:
      *   - all documents are rendered in the same outputDirectory. 1 document is overwritten
      *   - all documents but 1 (in the root) are incorrectly rendered because they cannot find the imported file
@@ -725,11 +753,11 @@ class AsciidoctorMojoTest extends Specification {
     }
 
     /**
-     * Tests the behaviour when: 
+     * Tests the behaviour when:
      *  - simple paths are used
      *  - preserveDirectories = true
      *  - relativeBaseDir = false
-     *  
+     *
      *  Expected:
      *   - all documents are rendered in the same folder structure found in the sourceDirectory
      *   - all documents but 1 (in the root) are incorrectly rendered because they cannot find the imported file
@@ -766,19 +794,19 @@ class AsciidoctorMojoTest extends Specification {
                     assert renderedFile.text.contains('Unresolved directive')
                 }
             }
-        
+
         cleanup:
             // Avoids false positives in other tests
             FileUtils.deleteDirectory(outputDir)
     }
 
     /**
-     * Tests the behaviour when: 
-     *  - simple paths are used 
+     * Tests the behaviour when:
+     *  - simple paths are used
      *  - preserveDirectories = false
      *  - relativeBaseDir = true
-     *  
-     *  Expected: all documents are correctly rendered in the same folder 
+     *
+     *  Expected: all documents are correctly rendered in the same folder
      */
     def 'should not replicate source structure-baseDir rewrite'() {
         setup:
@@ -807,7 +835,7 @@ class AsciidoctorMojoTest extends Specification {
             for (File renderedFile in asciidocs) {
                 assert renderedFile.text.contains('Unresolved directive') == false
             }
-        
+
         cleanup:
             // Avoids false positives in other tests
             FileUtils.deleteDirectory(outputDir)
@@ -816,7 +844,7 @@ class AsciidoctorMojoTest extends Specification {
     def 'project-version test'()
     {
         given:
-            File srcDir = new File( 'target/test-classes/src/asciidoctor' )
+            File srcDir = new File(DEFAULT_SOURCE_DIRECTORY)
             File outputDir = new File( 'target/asciidoctor-output-project-version-test' )
 
             if (!outputDir.exists()) {
@@ -839,7 +867,7 @@ class AsciidoctorMojoTest extends Specification {
 
     def 'github files can be included'() {
         setup:
-            File srcDir = new File( 'target/test-classes/src/asciidoctor' )
+            File srcDir = new File(DEFAULT_SOURCE_DIRECTORY)
             File outputDir = new File('target/test-resources/github-include')
             String documentName = 'github-include.adoc'
 
@@ -860,7 +888,7 @@ class AsciidoctorMojoTest extends Specification {
 
     def "command line attributes replace configurations"() {
         setup:
-            File srcDir = new File('target/test-classes/src/asciidoctor')
+            File srcDir = new File(DEFAULT_SOURCE_DIRECTORY)
             File outputDir = new File('target/asciidoctor-output/command-line-options')
 
             if (!outputDir.exists())
@@ -884,6 +912,163 @@ class AsciidoctorMojoTest extends Specification {
             String text = sampleOutput.getText()
             text.contains('<body class="article toc2 toc-right">')
             text.contains('<pre class="highlightjs highlight">')
+    }
+
+    def "should skip processing when source directory does no exist"() {
+        setup:
+            def originalOut = System.out
+            def newOut = new ByteArrayOutputStream()
+            System.setOut(new PrintStream(newOut))
+
+            File outputDir = new File("$MULTIPLE_RESOURCES_OUTPUT/skipped-process/${System.currentTimeMillis()}")
+            if (!outputDir.exists())
+                outputDir.mkdir()
+        when:
+            AsciidoctorMojo mojo = new AsciidoctorMojo()
+            mojo.sourceDirectory = new File(UUID.randomUUID().toString())
+            mojo.backend = 'html5'
+            mojo.outputDirectory = outputDir
+            mojo.execute()
+        then:
+            newOut.toString().contains('sourceDirectory does not exist. Skip processing')
+            !outputDir.exists()
+        cleanup:
+            System.setOut(originalOut)
+    }
+
+    def "should only convert documents and not copy any resources when resources directory does no exist"() {
+        setup:
+            File outputDir = new File("$MULTIPLE_RESOURCES_OUTPUT/multi-sources/error-source-not-found/${System.currentTimeMillis()}")
+
+            if (!outputDir.exists())
+                outputDir.mkdir()
+        when: 'resource directory does not exist but source AsciiDoc documents do'
+            AsciidoctorMojo mojo = new AsciidoctorMojo()
+            mojo.sourceDirectory = new File(DEFAULT_SOURCE_DIRECTORY)
+            mojo.resources = [
+                    [
+                            directory: UUID.randomUUID().toString()
+                    ] as Resource
+            ]
+            mojo.backend = 'html5'
+            mojo.outputDirectory = outputDir
+            mojo.execute()
+        then: 'only rendered (html) files are found in the target directory'
+            def allFiles = outputDir.listFiles({File f -> f.isFile()} as FileFilter)
+            def htmlFiles = FileUtils.listFiles(outputDir, ['html'] as String[], true)
+            allFiles.size() == htmlFiles.size()
+            outputDir.listFiles({File f -> f.isDirectory()} as FileFilter).size() == 0
+
+    }
+
+    def "should only render a single file and not copy any resource"() {
+        setup:
+            File outputDir = new File("$MULTIPLE_RESOURCES_OUTPUT/file-pattern/${System.currentTimeMillis()}")
+
+            if (!outputDir.exists())
+                outputDir.mkdir()
+            else
+                FileUtils.deleteDirectory(outputDir)
+        when:
+            AsciidoctorMojo mojo = new AsciidoctorMojo()
+            mojo.sourceDirectory = new File(DEFAULT_SOURCE_DIRECTORY)
+            mojo.sourceDocumentName = 'attribute-missing.adoc'
+            // excludes all, nothing at all is copied
+            mojo.resources = [[
+                                      directory: DEFAULT_SOURCE_DIRECTORY,
+                                      excludes : ['**/**']
+                              ] as Resource]
+            mojo.backend = 'html5'
+            mojo.outputDirectory = outputDir
+            mojo.execute()
+        then:
+            def files = outputDir.listFiles({File f -> f.isFile()} as FileFilter)
+            files.size() == 1
+            files*.name.containsAll(['attribute-missing.html'])
+    }
+
+    def "should copy all resources (2 directories with filters) into output folder"() {
+        setup:
+            File outputDir = new File("$MULTIPLE_RESOURCES_OUTPUT/multi-sources/${System.currentTimeMillis()}")
+            String relativeTestsPath = "$DEFAULT_SOURCE_DIRECTORY/relative-path-treatment"
+
+            if (!outputDir.exists())
+                outputDir.mkdir()
+        when:
+            AsciidoctorMojo mojo = new AsciidoctorMojo()
+            mojo.sourceDirectory = new File("$DEFAULT_SOURCE_DIRECTORY/issue-78")
+            mojo.resources = [[
+                                      directory: "$DEFAULT_SOURCE_DIRECTORY/issue-78",
+                                      includes : ['**/*.adoc']
+                              ] as Resource, [
+                                      directory: relativeTestsPath,
+                                      excludes : ['**/*.jpg']
+                              ] as Resource]
+            mojo.preserveDirertories = true
+            mojo.backend = 'html5'
+            mojo.outputDirectory = outputDir
+            mojo.execute()
+        then:
+            def files = outputDir.listFiles({File f -> f.isFile()} as FileFilter)
+            // includes 2 rendered AsciiDoc documents and 3 resources
+            files.size() == 5
+            // from 'issue-78' directory
+            // resource files obtained using the include
+            files*.name.findAll({it.endsWith('html')}).containsAll(['main.html', 'image-test.html'])
+            // 'images' folder is not copied because it's not included
+            files*.name.findAll({it == 'images'}) ==  []
+            // from 'relative-path-treatment' directory
+            // all folders and files are created because only image files are excluded
+            assertEqualsStructure(new File(relativeTestsPath).listFiles(DIRECTORY_FILTER), outputDir.listFiles(DIRECTORY_FILTER))
+            // images are excluded but not the rest of files
+            FileUtils.listFiles(outputDir, ['groovy'] as String[], true).size == 5
+            FileUtils.listFiles(outputDir, ["jpg"] as String[], true).size() == 0
+    }
+
+    def "should render GitHub README alone"() {
+        setup:
+            File outputDir = new File("$MULTIPLE_RESOURCES_OUTPUT/readme/${System.currentTimeMillis()}")
+
+            if (!outputDir.exists())
+                outputDir.mkdir()
+        when:
+            AsciidoctorMojo mojo = new AsciidoctorMojo()
+            mojo.sourceDirectory = new File('.')
+            mojo.sourceDocumentName = 'README.adoc'
+            mojo.resources = [[
+                                      directory: ".",
+                                      excludes : ['**/**']
+                              ] as Resource]
+            mojo.backend = 'html5'
+            mojo.outputDirectory = outputDir
+            mojo.execute()
+        then:
+            def files = outputDir.listFiles({File f -> f.isFile()} as FileFilter)
+            // includes only 1 rendered AsciiDoc document
+            files.size() == 1
+            files.first().text.contains('Asciidoctor Maven Plugin')
+    }
+
+    def "should not include files in hidden directories (prefixes with underscore)"() {
+        setup:
+            File outputDir = new File("target/asciidoctor-output/hidden/${System.currentTimeMillis()}")
+            String relativeTestsPath = "$DEFAULT_SOURCE_DIRECTORY/relative-path-treatment"
+
+            if (!outputDir.exists())
+                outputDir.mkdir()
+        when:
+            AsciidoctorMojo mojo = new AsciidoctorMojo()
+            mojo.sourceDirectory = new File(relativeTestsPath)
+            mojo.preserveDirertories = true
+            mojo.backend = 'html5'
+            mojo.outputDirectory = outputDir
+            mojo.execute()
+        then:
+            def hiddenDirectories = ['_this_is_ignored', 'level-1-1/level-2-2/_this_is_ignored']
+            hiddenDirectories. each { directoryPath ->
+                assert new File(relativeTestsPath, directoryPath).exists()
+                assert !(new File(outputDir, directoryPath).exists())
+            }
     }
 
 }

--- a/src/test/groovy/org/asciidoctor/maven/test/AsciidoctorRefreshMojoTest.groovy
+++ b/src/test/groovy/org/asciidoctor/maven/test/AsciidoctorRefreshMojoTest.groovy
@@ -3,11 +3,28 @@ package org.asciidoctor.maven.test
 import org.asciidoctor.maven.AsciidoctorRefreshMojo
 import org.asciidoctor.maven.test.io.DoubleOuputStream
 import org.asciidoctor.maven.test.io.PrefilledInputStream
+import org.asciidoctor.maven.test.plexus.MockPlexusContainer
 import spock.lang.Specification
 
 import java.util.concurrent.CountDownLatch
 
 class AsciidoctorRefreshMojoTest extends Specification {
+
+    /**
+     * Intercept Asciidoctor mojo constructor to mock and inject required
+     * plexus objects
+     */
+    def setupSpec() {
+        MockPlexusContainer mockPlexusContainer = new MockPlexusContainer()
+        def oldConstructor = AsciidoctorRefreshMojo.constructors[0]
+
+        AsciidoctorRefreshMojo.metaClass.constructor = {
+            def mojo = oldConstructor.newInstance()
+            mockPlexusContainer.initializeContext(mojo)
+            return mojo
+        }
+    }
+
     def "auto render when source updated"() {
         setup:
             def srcDir = new File('target/test-classes/src/asciidoctor-refresh')

--- a/src/test/groovy/org/asciidoctor/maven/test/AsciidoctorZipMojoTest.groovy
+++ b/src/test/groovy/org/asciidoctor/maven/test/AsciidoctorZipMojoTest.groovy
@@ -1,15 +1,31 @@
 package org.asciidoctor.maven.test
 
-import java.util.zip.ZipFile
-
 import org.apache.commons.io.FileUtils
 import org.asciidoctor.maven.AsciidoctorZipMojo
-
+import org.asciidoctor.maven.test.plexus.MockPlexusContainer
 import spock.lang.Specification
+
+import java.util.zip.ZipFile
+
 /**
  *
  */
 class AsciidoctorZipMojoTest extends Specification {
+
+    /**
+     * Intercept Asciidoctor mojo constructor to mock and inject required
+     * plexus objects
+     */
+    def setupSpec() {
+        MockPlexusContainer mockPlexusContainer = new MockPlexusContainer()
+        def oldConstructor = AsciidoctorZipMojo.constructors[0]
+
+        AsciidoctorZipMojo.metaClass.constructor = {
+            def mojo = oldConstructor.newInstance()
+            mockPlexusContainer.initializeContext(mojo)
+            return mojo
+        }
+    }
 
     def "zip it"() {
         given: 'an empty output directory'

--- a/src/test/groovy/org/asciidoctor/maven/test/plexus/MockPlexusContainer.groovy
+++ b/src/test/groovy/org/asciidoctor/maven/test/plexus/MockPlexusContainer.groovy
@@ -1,0 +1,50 @@
+package org.asciidoctor.maven.test.plexus
+
+import org.apache.maven.plugin.logging.Log
+import org.apache.maven.plugin.logging.SystemStreamLog
+import org.apache.maven.project.MavenProject
+import org.apache.maven.shared.filtering.DefaultMavenFileFilter
+import org.apache.maven.shared.filtering.DefaultMavenResourcesFiltering
+import org.asciidoctor.maven.AsciidoctorMojo
+import org.sonatype.plexus.build.incremental.DefaultBuildContext
+
+/**
+ * Initializes a mocks components required to simulate a Plexus container for the tests.
+ *
+ * Note: This is a temporal solution. At some point 'proper' testing should be introduced, see:
+ *  - https://vzurczak.wordpress.com/2014/07/23/write-unit-tests-for-a-maven-plug-in/
+ *
+ * @author abelsromero
+ */
+class MockPlexusContainer {
+
+    class FakeMavenLogger {
+        @Delegate
+        Log logger = new SystemStreamLog()
+    }
+
+    void initializeContext(AsciidoctorMojo mojo) {
+
+        mojo.@project = [
+                getBasedir: {
+                    return new File('.')
+                }] as MavenProject
+
+        mojo.@buildContext = new DefaultBuildContext()
+
+        def logger = new FakeMavenLogger() as org.codehaus.plexus.logging.Logger
+
+        DefaultMavenFileFilter mavenFileFilter = new DefaultMavenFileFilter()
+        mavenFileFilter.@buildContext = mojo.@buildContext
+        mavenFileFilter.enableLogging(logger)
+
+        DefaultMavenResourcesFiltering resourceFilter = new DefaultMavenResourcesFiltering()
+        resourceFilter.@mavenFileFilter = mavenFileFilter
+        resourceFilter.@buildContext = mojo.@buildContext
+        resourceFilter.initialize()
+        resourceFilter.enableLogging(logger)
+        mojo.@outputResourcesFiltering = resourceFilter
+
+    }
+
+}

--- a/src/test/resources/src/asciidoctor/relative-path-treatment/_this_is_ignored/ignored.adoc
+++ b/src/test/resources/src/asciidoctor/relative-path-treatment/_this_is_ignored/ignored.adoc
@@ -1,0 +1,8 @@
+:toc: left
+:icons:
+
+== Summary
+This document won't get rendered by default because it is inside a hidden folder. +
+Hidden folders begin with udnersore `_`.
+
+TIP: How cool is this?

--- a/src/test/resources/src/asciidoctor/relative-path-treatment/level-1-1/level-2-2/_this_is_ignored/ignored.adoc
+++ b/src/test/resources/src/asciidoctor/relative-path-treatment/level-1-1/level-2-2/_this_is_ignored/ignored.adoc
@@ -1,0 +1,8 @@
+:toc: left
+:icons:
+
+== Summary
+This document won't get rendered by default because it is inside a hidden folder. +
+Hidden folders begin with udnersore `_`.
+
+TIP: How cool is this?


### PR DESCRIPTION
This PR fixes issues:
- #187 and #217: being able to exclude/filter the resources that are copied into the output directory.
- #196: using asciidoctor-diagram with asciidoctor-pdf requires copying the resources before the AsciiDoc documents are rendered. ->_I added this change because it was just moving 2 lines of code_

Following the approach in [PR 192](https://github.com/asciidoctor/asciidoctor-maven-plugin/pull/193) I have added the `maven-filtering` library to allow defining sets of resources like in this example:
````
<resources>
    <resource>
        <!-- add some images and exclude SVN files -->
        <directory>DIRECTORY</directory>
        <include>**/*.jpg</include>
        <include>**/*.gif</include>
        <exclude>**/.svn</exclude>
    </resource>
    <resource>
        <!-- add some sources that are linked in the docs -->
        <directory>DIRECTORY_2</directory>
        <include>**/*.java</include>
        <exclude>**/.class</exclude>
    </resource>
    <resource>
        <!-- exclude all -->
        <directory>DIRECTORY_3</directory>
        <exclude>**/**</exclude>
    </resource>
</resources
```

This breaks no compatibility with current versions, but has some drawbacks:
- Additional log messages from the 'maven-filtering' component appear showing the list of resources being copied.
- Since resources are copied before rendering, if something fails during rendering resources are kept in the target folder.


Note:
If this is accepted, there are some TODOs for the near future:
- README: section about `Using Asciidoctor Diagram` can be simplified to only require setting `imagesdir` to the output folder.
- maven examples: after release, I'd like to update the maven diagram example to include flat images also and show how both (generated by diagram and flat) can co-exists.
- lots of refactoring...I tried to keep changes to minimum for now, but at some point I'd like to improve the tests structure and `AsciidoctorMojo` class. The later has grown a lot and is a bit messy.