### PR TITLE
Resource filtering fix

### DIFF
--- a/README.adoc
+++ b/README.adoc
@@ -73,15 +73,15 @@ There are several configuration options that the asciidoctor-maven-plugin uses, 
 sourceDirectory:: defaults to `${basedir}/src/main/asciidoc`
 sourceDocumentName:: an override to process a single source file; defaults to all files in `${sourceDirectory}`
 sourceDocumentExtensions:: (named `extensions` in v1.5.3 and below) a `List<String>` of non-standard file extensions to render. Currently ad, adoc, and asciidoc will be rendered by default
-resources:: list of resource files to copy to the output directory (e.g., images, css). The configuration follows the same patterns as the `maven-resources-plugin`
+resources:: list of resource files to copy to the output directory (e.g., images, css). The configuration follows the same patterns as the `maven-resources-plugin`. If not set, all resources inside `sourceDirectory` are copied
 +
 [source, xml]
 ----
     <resources>
         <resource>
-            <!-- (Mandatory) Directory to copy from. By default uses maven's ${baseDir} -->
+            <!-- (Mandatory) Directory to copy from. Paths are relative to maven's ${baseDir} -->
             <directory>DIRECTORY</directory>
-            <!-- (Optional) Directory to copy to. By default uses the option `sourceDirectory` -->
+            <!-- (Optional) Directory to copy to. By default uses the option `outputDirectory` -->
             <targetPath>OUTPUT_DIR</targetPath>
             <!-- (Optional) NOTE: SVN, GIT and other version control files are excluded by default, there's no need to add them -->
             <excludes>

--- a/README.adoc
+++ b/README.adoc
@@ -73,19 +73,28 @@ There are several configuration options that the asciidoctor-maven-plugin uses, 
 sourceDirectory:: defaults to `${basedir}/src/main/asciidoc`
 sourceDocumentName:: an override to process a single source file; defaults to all files in `${sourceDirectory}`
 sourceDocumentExtensions:: (named `extensions` in v1.5.3 and below) a `List<String>` of non-standard file extensions to render. Currently ad, adoc, and asciidoc will be rendered by default
-resources:: list of resource files to copy to the output directory (e.g., images, css). By default everything is copied
+resources:: list of resource files to copy to the output directory (e.g., images, css). The configuration follows the same patterns as the `maven-resources-plugin`
 +
 [source, xml]
 ----
     <resources>
         <resource>
+            <!-- (Mandatory) Directory to copy from. By default uses maven's ${baseDir} -->
             <directory>DIRECTORY</directory>
-            <include>**/*.jpg</include>
-            <include>**/*.gif</include>
-            <exclude>**/.svn</exclude>
+            <!-- (Optional) Directory to copy to. By default uses the option `sourceDirectory` -->
+            <targetPath>OUTPUT_DIR</targetPath>
+            <!-- (Optional) SVN, GIT and other version control files are excluded by default, there's no need to add them -->
+            <excludes>
+                <exclude>**/.txt</exclude>
+            </excludes>
+            <!-- (Optional) If not set, includes all files but default exceptions mentioned -->
+            <includes>
+                <include>**/*.jpg</include>
+                <include>**/*.gif</include>
+            </includes>
         </resource>
         <resource>
-            ...
+                ...
     <resources>
 ----
 outputDirectory:: defaults to `${project.build.directory}/generated-docs`

--- a/README.adoc
+++ b/README.adoc
@@ -83,7 +83,7 @@ resources:: list of resource files to copy to the output directory (e.g., images
             <directory>DIRECTORY</directory>
             <!-- (Optional) Directory to copy to. By default uses the option `sourceDirectory` -->
             <targetPath>OUTPUT_DIR</targetPath>
-            <!-- (Optional) SVN, GIT and other version control files are excluded by default, there's no need to add them -->
+            <!-- (Optional) NOTE: SVN, GIT and other version control files are excluded by default, there's no need to add them -->
             <excludes>
                 <exclude>**/.txt</exclude>
             </excludes>

--- a/pom.xml
+++ b/pom.xml
@@ -128,6 +128,11 @@
         </dependency>
         <dependency>
             <groupId>org.codehaus.plexus</groupId>
+            <artifactId>plexus-interpolation</artifactId>
+            <version>1.22</version>
+        </dependency>
+        <dependency>
+            <groupId>org.codehaus.plexus</groupId>
             <artifactId>plexus-utils</artifactId>
             <version>${plexus.utils.version}</version>
             <scope>compile</scope>

--- a/src/it/article-html-command/pom.xml
+++ b/src/it/article-html-command/pom.xml
@@ -6,7 +6,7 @@
 	<artifactId>test</artifactId>
 	<version>1.0-SNAPSHOT</version>
 
-	<name>Run Asciidoctor Article to Html with command line arguments</name>
+	<name>Converts Asciidoctor Article to Html with command line arguments</name>
 	<description>Runs asciidoctor-maven-plugin:process-asciidoc</description>
 
 	<properties>

--- a/src/it/article-html/pom.xml
+++ b/src/it/article-html/pom.xml
@@ -6,7 +6,7 @@
 	<artifactId>test</artifactId>
 	<version>1.0-SNAPSHOT</version>
 
-	<name>Run Asciidoctor Article to Html</name>
+	<name>Converts Asciidoctor Article to Html</name>
 	<description>Runs asciidoctor-maven-plugin:process-asciidoc</description>
 
 	<properties>

--- a/src/it/book-html/pom.xml
+++ b/src/it/book-html/pom.xml
@@ -6,7 +6,7 @@
 	<artifactId>test</artifactId>
 	<version>1.0-SNAPSHOT</version>
 
-	<name>Run Asciidoctor Article to Html</name>
+	<name>Converts Asciidoctor Article to Html</name>
 	<description>Runs asciidoctor-maven-plugin:process-asciidoc</description>
 
 	<properties>

--- a/src/it/resource-filtering/invoker.properties
+++ b/src/it/resource-filtering/invoker.properties
@@ -1,0 +1,1 @@
+invoker.goals=clean asciidoctor:process-asciidoc -Dcommand.property=command_value

--- a/src/it/resource-filtering/pom.xml
+++ b/src/it/resource-filtering/pom.xml
@@ -6,7 +6,7 @@
 	<artifactId>test</artifactId>
 	<version>1.0-SNAPSHOT</version>
 
-	<name>Run Asciidoctor Article to Html</name>
+	<name>Converts Asciidoctor Article to Html adding selected resources</name>
 	<description>Runs asciidoctor-maven-plugin:process-asciidoc</description>
 
 	<properties>

--- a/src/it/resource-filtering/pom.xml
+++ b/src/it/resource-filtering/pom.xml
@@ -1,0 +1,49 @@
+<project xmlns="http://maven.apache.org/POM/4.0.0" xmlns:xsi="http://www.w3.org/2001/XMLSchema-instance"
+	xsi:schemaLocation="http://maven.apache.org/POM/4.0.0 http://maven.apache.org/maven-v4_0_0.xsd">
+	<modelVersion>4.0.0</modelVersion>
+
+	<groupId>org.asciidoctor</groupId>
+	<artifactId>test</artifactId>
+	<version>1.0-SNAPSHOT</version>
+
+	<name>Run Asciidoctor Article to Html</name>
+	<description>Runs asciidoctor-maven-plugin:process-asciidoc</description>
+
+	<properties>
+		<project.build.sourceEncoding>UTF-8</project.build.sourceEncoding>
+		<pom.property>pom_value</pom.property>
+	</properties>
+
+	<build>
+		<plugins>
+			<plugin>
+				<groupId>org.asciidoctor</groupId>
+				<artifactId>asciidoctor-maven-plugin</artifactId>
+				<version>@project.version@</version>
+				<configuration>
+					<sourceDirectory>src/main/doc</sourceDirectory>
+					<outputDirectory>target/docs</outputDirectory>
+					<resources>
+						<resource>
+							<filtering>true</filtering>
+							<directory>${project.build.sourceDirectory}</directory>
+							<includes>
+								<include>**/*.java</include>
+							</includes>
+						</resource>
+						<resource>
+							<directory>.</directory>
+							<includes>
+								<include>*.properties</include>
+							</includes>
+							<excludes>
+								<exclude>.*</exclude>
+							</excludes>
+						</resource>
+					</resources>
+					<backend>html</backend>
+				</configuration>
+			</plugin>
+		</plugins>
+	</build>
+</project>

--- a/src/it/resource-filtering/src/main/doc/sample.asciidoc
+++ b/src/it/resource-filtering/src/main/doc/sample.asciidoc
@@ -1,0 +1,25 @@
+Document Title
+==============
+Doc Writer <thedoc@asciidoctor.org>
+:idprefix: id_
+
+Preamble paragraph.
+
+NOTE: This is test, only a test.
+
+== Section A
+
+*Section A* paragraph.
+
+=== Section A Subsection
+
+*Section A* 'subsection' paragraph.
+
+== Section B
+
+*Section B* paragraph.
+
+.Section B list
+* Item 1
+* Item 2
+* Item 3

--- a/src/it/resource-filtering/src/main/java/StringUtils.java
+++ b/src/it/resource-filtering/src/main/java/StringUtils.java
@@ -1,0 +1,15 @@
+package example;
+
+/**
+ * Using ${java.vendor} ${java.version}
+ *
+ * Command property: ${command.property}
+ * POM property: ${pom.property}
+ */
+public class StringUtils {
+    // tag::contains[]
+    public boolean contains(String haystack, String needle) {
+        return haystack.contains(needle);
+    }
+    // end::contains[]
+}

--- a/src/it/resource-filtering/validate.groovy
+++ b/src/it/resource-filtering/validate.groovy
@@ -1,0 +1,25 @@
+import java.io.*;
+
+
+File outputDir = new File(basedir, "target/docs")
+
+String[] expectedFiles = ['sample.html', 'invoker.properties', 'StringUtils.java']
+
+// output files should be copied
+for (String expectedFile : expectedFiles) {
+    File file = new File(outputDir, expectedFile)
+    println("Checking for existence of " + file)
+    if (!file.isFile()) {
+        throw new Exception("Missing file " + file)
+    }
+}
+
+String fileText = new File(outputDir, 'StringUtils.java').text
+// properties in 'StringUtils.java' should be filtered (replaced)
+['java.version', 'command.property', 'pom.property'].each {
+    if (fileText.contains(it)) {
+        throw new Exception("Propert " + file)
+    }
+}
+
+return true;

--- a/src/main/java/org/asciidoctor/maven/AsciidoctorMojo.java
+++ b/src/main/java/org/asciidoctor/maven/AsciidoctorMojo.java
@@ -242,11 +242,6 @@ public class AsciidoctorMojo extends AbstractMojo {
                 resource.getExcludes().add(sourceDocumentName);
             }
             // exclude filename extensions if defined
-            if (sourceDocumentExtensions == null || sourceDocumentExtensions.isEmpty()) {
-                for (String docExtension : sourceDocumentExtensions) {
-                    resource.getExcludes().add(docExtension);
-                }
-            }
             resources.add(resource);
         }
 
@@ -261,6 +256,9 @@ public class AsciidoctorMojo extends AbstractMojo {
             }
             for (String value : AsciidoctorFileScanner.DEFAULT_FILE_EXTENSIONS) {
                 excludes.add(value);
+            }
+            for (String docExtension : sourceDocumentExtensions) {
+                resource.getExcludes().add("**/*." + docExtension);
             }
             // in case someone wants to include some of the default excluded files (.e.g., AsciiDoc docs)
             excludes.removeAll(resource.getIncludes());
@@ -278,6 +276,7 @@ public class AsciidoctorMojo extends AbstractMojo {
                     new MavenResourcesExecution(resources, outputDirectory, project, FILE_ENCODING,
                             Collections.<String>emptyList(), Collections.<String>emptyList(), session);
             resourcesExecution.setIncludeEmptyDirs(true);
+            resourcesExecution.setAddDefaultExcludes(true);
             outputResourcesFiltering.filterResources(resourcesExecution);
         } catch (MavenFilteringException e) {
             throw new MojoExecutionException("Could not copy resources", e);

--- a/src/test/resources/src/asciidoctor/sample.ext
+++ b/src/test/resources/src/asciidoctor/sample.ext
@@ -1,0 +1,28 @@
+Document Title
+==============
+Doc Writer <thedoc@asciidoctor.org>
+:idprefix: id_
+
+Preamble paragraph.
+
+NOTE: This is test, only a test.
+
+== Section A
+
+*Section A* paragraph.
+
+=== Section A Subsection
+
+*Section A* 'subsection' paragraph.
+
+== Section B
+
+*Section B* paragraph.
+
+.Section B list
+* Item 1
+* Item 2
+* Item 3
+
+[source,ruby]
+require 'asciidoctor'


### PR DESCRIPTION
This PR includes the fixes discussed in issue #187.
The required libraries to enable filtering have been added and now it's possible to use it. Hovewer, this is not exposed in the documentation.

Here is the list of changes in this PR:

* Updated README to align with `maven-resource-plugin` configuration and explain the supported options. Note that using only <include> without <includes> works also, I guess it's my gradle side that preffers it.
*  Added integration test for property filtering (a.k.a. replacing). Even if it's not officially supported, that way we have an example if someone wants to use it and asks about it.
* Fixed an issue: when defining custom _file extensions_ in `sourceDocumentExtension`, these were also copied. Now they are excluded.
