### PR TITLE
fixes #264 - adds support for sourcemap, catalog_assets and template_cache options

### DIFF
--- a/README.adoc
+++ b/README.adoc
@@ -118,9 +118,12 @@ backend:: defaults to `docbook`
 doctype:: defaults to `null` (which trigger's Asciidoctor's default of `article`)
 eruby:: defaults to erb, the version used in JRuby
 headerFooter:: defaults to `true`
-templateDir:: disabled by default, defaults to `null`
-templateEngine:: disabled by default
+templateDir:: directory of Tilt-compatible templates to be used instead of the default built-in templates, disabled by default (`null`)
+templateEngine:: template engine to use for the custom converter templates, disabled by default (`null`)
+templateCache:: enables the built-in cache used by the template converter when reading the source of template files. Only relevant if the :template_dir option is specified, defaults to `true`
 sourceHighlighter:: enables and sets the source highlighter (currently `coderay` or `highlight.js` are supported)
+sourcemap:: adds file and line number information to each parsed block (`lineno` and `source_location` attributes), defaults to `false`
+catalogAssets:: tells the parser to capture images and links in the reference table available via the `references property on the document AST object (experimental), defaults to `false`
 attributes:: a `Map<String,Object>` of attributes to pass to Asciidoctor, defaults to `null`
 embedAssets:: Embedd the CSS file, etc into the output, defaults to `false`
 gemPaths:: enables to specify the location to one or more gem installation directories (same as GEM_PATH environment var), `empty` by default

--- a/src/it/article-html-command-with-spaces/command-with-spaces-plain-maven/pom.xml
+++ b/src/it/article-html-command-with-spaces/command-with-spaces-plain-maven/pom.xml
@@ -1,0 +1,51 @@
+<project xmlns="http://maven.apache.org/POM/4.0.0" xmlns:xsi="http://www.w3.org/2001/XMLSchema-instance"
+	xsi:schemaLocation="http://maven.apache.org/POM/4.0.0 http://maven.apache.org/maven-v4_0_0.xsd">
+	<modelVersion>4.0.0</modelVersion>
+
+	<groupId>org.asciidoctor</groupId>
+	<artifactId>command-with-spaces-plain-maven</artifactId>
+	<version>1.0-SNAPSHOT</version>
+
+	<name>Run Asciidoctor Article to Html with command line arguments</name>
+	<description>Runs asciidoctor-maven-plugin:process-asciidoc</description>
+
+	<properties>
+		<project.build.sourceEncoding>UTF-8</project.build.sourceEncoding>
+	</properties>
+
+	<repositories>
+		<repository>
+			<snapshots>
+				<enabled>false</enabled>
+			</snapshots>
+			<id>bintray-abelsromero-maven</id>
+			<name>bintray</name>
+			<url>http://dl.bintray.com/abelsromero/maven</url>
+		</repository>
+	</repositories>
+
+	<pluginRepositories>
+		<pluginRepository>
+			<snapshots>
+				<enabled>false</enabled>
+			</snapshots>
+			<id>bintray-abelsromero-maven</id>
+			<name>bintray-plugins</name>
+			<url>http://dl.bintray.com/abelsromero/maven</url>
+		</pluginRepository>
+	</pluginRepositories>
+
+	<build>
+		<plugins>
+			<plugin>
+				<groupId>org.asciidoctor</groupId>
+				<artifactId>asciidoctor-maven-plugin</artifactId>
+				<version>1.5.4-preview.2</version>
+				<configuration>
+					<backend>html</backend>
+					<doctype>article</doctype>
+				</configuration>
+			</plugin>
+		</plugins>
+	</build>
+</project>

--- a/src/it/article-html-command-with-spaces/command-with-spaces-plain-maven/run.sh
+++ b/src/it/article-html-command-with-spaces/command-with-spaces-plain-maven/run.sh
@@ -1,0 +1,2 @@
+#!/bin/bash
+mvn clean asciidoctor:process-asciidoc -Dasciidoctor.sourceDirectory=src/main/doc -Dasciidoctor.outputDirectory=target/docs -Dasciidoctor.attributes="toc=left source-highlighter=coderay"

--- a/src/it/article-html-command-with-spaces/command-with-spaces-plain-maven/src/main/doc/sample.asciidoc
+++ b/src/it/article-html-command-with-spaces/command-with-spaces-plain-maven/src/main/doc/sample.asciidoc
@@ -1,0 +1,45 @@
+Document Title
+==============
+Doc Writer <thedoc@asciidoctor.org>
+:idprefix: id_
+
+Preamble paragraph.
+
+NOTE: This is test, only a test.
+
+== Section A
+
+*Section A* paragraph.
+
+=== Section A Subsection
+
+*Section A* 'subsection' paragraph.
+
+== Section B
+
+*Section B* paragraph.
+
+.Section B list
+* Item 1
+* Item 2
+* Item 3
+
+== Section C, let's show some code
+
+[source,java]
+.HelloWorld.java
+----
+public class HelloWorld {
+
+    public static void main(String[] args) {
+        // Prints "Hello, World" to the terminal window
+        if (args != null && args.length > 0) {
+            System.out.println("Hello " + args[0] + "!!");
+
+        } else {
+            System.out.println("Hello World!!");
+        }
+    }
+
+}
+----

--- a/src/it/article-html-command-with-spaces/invoker.properties
+++ b/src/it/article-html-command-with-spaces/invoker.properties
@@ -1,0 +1,2 @@
+invoker.goals=clean asciidoctor:process-asciidoc
+invoker.mavenOpts=-Dasciidoctor.sourceDirectory=src/main/doc -Dasciidoctor.outputDirectory=target/docs -Dasciidoctor.attributes="toc=left source-highlighter=coderay"

--- a/src/it/article-html-command-with-spaces/invoker.properties
+++ b/src/it/article-html-command-with-spaces/invoker.properties
@@ -1,2 +1,4 @@
-invoker.goals=clean asciidoctor:process-asciidoc
-invoker.mavenOpts=-Dasciidoctor.sourceDirectory=src/main/doc -Dasciidoctor.outputDirectory=target/docs -Dasciidoctor.attributes="toc=left source-highlighter=coderay"
+invoker.goals=clean asciidoctor:process-asciidoc \
+  -Dasciidoctor.sourceDirectory=src/main/doc \
+  -Dasciidoctor.outputDirectory=target/docs \
+  -Dasciidoctor.attributes="toc=left source-highlighter=coderay"

--- a/src/it/article-html-command-with-spaces/pom.xml
+++ b/src/it/article-html-command-with-spaces/pom.xml
@@ -1,0 +1,29 @@
+<project xmlns="http://maven.apache.org/POM/4.0.0" xmlns:xsi="http://www.w3.org/2001/XMLSchema-instance"
+	xsi:schemaLocation="http://maven.apache.org/POM/4.0.0 http://maven.apache.org/maven-v4_0_0.xsd">
+	<modelVersion>4.0.0</modelVersion>
+
+	<groupId>org.asciidoctor</groupId>
+	<artifactId>test</artifactId>
+	<version>1.0-SNAPSHOT</version>
+
+	<name>Run Asciidoctor Article to Html with command line arguments</name>
+	<description>Runs asciidoctor-maven-plugin:process-asciidoc</description>
+
+	<properties>
+		<project.build.sourceEncoding>UTF-8</project.build.sourceEncoding>
+	</properties>
+
+	<build>
+		<plugins>
+			<plugin>
+				<groupId>org.asciidoctor</groupId>
+				<artifactId>asciidoctor-maven-plugin</artifactId>
+				<version>@project.version@</version>
+				<configuration>
+					<backend>html</backend>
+					<doctype>article</doctype>
+				</configuration>
+			</plugin>
+		</plugins>
+	</build>
+</project>

--- a/src/it/article-html-command-with-spaces/src/main/doc/sample.asciidoc
+++ b/src/it/article-html-command-with-spaces/src/main/doc/sample.asciidoc
@@ -1,0 +1,45 @@
+Document Title
+==============
+Doc Writer <thedoc@asciidoctor.org>
+:idprefix: id_
+
+Preamble paragraph.
+
+NOTE: This is test, only a test.
+
+== Section A
+
+*Section A* paragraph.
+
+=== Section A Subsection
+
+*Section A* 'subsection' paragraph.
+
+== Section B
+
+*Section B* paragraph.
+
+.Section B list
+* Item 1
+* Item 2
+* Item 3
+
+== Section C, let's show some code
+
+[souce,java]
+.HelloWorld.java
+----
+public class HelloWorld {
+
+    public static void main(String[] args) {
+        // Prints "Hello, World" to the terminal window
+        if (args != null && args.length > 0) {
+            System.out.println("Hello " + args[0] + "!!");
+
+        } else {
+            System.out.println("Hello World!!");
+        }
+    }
+
+}
+----

--- a/src/it/article-html-command-with-spaces/validate.groovy
+++ b/src/it/article-html-command-with-spaces/validate.groovy
@@ -1,0 +1,16 @@
+import java.io.*;
+
+
+File outputDir = new File( basedir, "target/docs" )
+
+String[] expectedFiles = ["sample.html"]
+
+for ( String expectedFile : expectedFiles ) {
+    File file = new File( outputDir, expectedFile )
+    println ( "Checking for existence of " + file )
+    if ( !file.isFile() ) {
+        throw new Exception( "Missing file " + file )
+    }
+}
+
+return true;

--- a/src/main/java/org/asciidoctor/maven/AsciidoctorMojo.java
+++ b/src/main/java/org/asciidoctor/maven/AsciidoctorMojo.java
@@ -104,6 +104,9 @@ public class AsciidoctorMojo extends AbstractMojo {
     @Parameter(property = AsciidoctorMaven.PREFIX + "templateEngine", required = false)
     protected String templateEngine;
 
+    @Parameter(property = AsciidoctorMaven.PREFIX + "templateCache")
+    protected boolean templateCache = true;
+
     @Parameter(property = AsciidoctorMaven.PREFIX + "imagesDir", required = false)
     protected String imagesDir = "images"; // use a string because otherwise html doc uses absolute path
 
@@ -118,6 +121,12 @@ public class AsciidoctorMojo extends AbstractMojo {
 
     @Parameter(property = AsciidoctorMaven.PREFIX + "sourceDocumentExtensions")
     protected List<String> sourceDocumentExtensions = new ArrayList<String>();
+
+    @Parameter(property = AsciidoctorMaven.PREFIX + "sourcemap")
+    protected boolean sourcemap = false;
+
+    @Parameter(property = AsciidoctorMaven.PREFIX + "catalogAssets")
+    protected boolean catalogAssets = false;
 
     @Parameter(property = AsciidoctorMaven.PREFIX + "synchronizations", required = false)
     protected List<Synchronization> synchronizations = new ArrayList<Synchronization>();
@@ -181,17 +190,10 @@ public class AsciidoctorMojo extends AbstractMojo {
 
         asciidoctor.requireLibraries(requires);
 
-        final OptionsBuilder optionsBuilder = OptionsBuilder.options()
-                .backend(backend)
-                .safe(SafeMode.UNSAFE)
-                .headerFooter(headerFooter)
-                .eruby(eruby)
-                .mkDirs(true);
-
-        setOptions(optionsBuilder);
+        final OptionsBuilder optionsBuilder = OptionsBuilder.options();
+        setOptionsOnBuilder(optionsBuilder);
 
         final AttributesBuilder attributesBuilder = AttributesBuilder.attributes();
-
         setAttributesOnBuilder(attributesBuilder);
 
         optionsBuilder.attributes(attributesBuilder);
@@ -425,18 +427,38 @@ public class AsciidoctorMojo extends AbstractMojo {
         }
     }
 
-    protected void setOptions(OptionsBuilder optionsBuilder) {
-        if (doctype != null) {
+    /**
+     * Updates and OptionsBuilder instance with the options defined in the configuration.
+     *
+     * @param optionsBuilder
+     *            AsciidoctorJ options to be updated.
+     */
+    protected void setOptionsOnBuilder(OptionsBuilder optionsBuilder) {
+        optionsBuilder
+                .backend(backend)
+                .safe(SafeMode.UNSAFE)
+                .headerFooter(headerFooter)
+                .eruby(eruby)
+                .mkDirs(true);
+
+        // Following options are only set when the value is different than the default
+        if (sourcemap)
+            optionsBuilder.option("sourcemap", true);
+
+        if (catalogAssets)
+            optionsBuilder.option("catalog_assets", true);
+
+        if (!templateCache)
+            optionsBuilder.option("template_cache", false);
+
+        if (doctype != null)
             optionsBuilder.docType(doctype);
-        }
 
-        if (templateEngine != null) {
+        if (templateEngine != null)
             optionsBuilder.templateEngine(templateEngine);
-        }
 
-        if (templateDir != null) {
+        if (templateDir != null)
             optionsBuilder.templateDir(templateDir);
-        }
     }
 
     protected void setAttributesOnBuilder(AttributesBuilder attributesBuilder) throws MojoExecutionException {
@@ -480,8 +502,7 @@ public class AsciidoctorMojo extends AbstractMojo {
             // NOTE Maven can't assign a Boolean value from the XML-based configuration, but a client may
             else if (val instanceof Boolean) {
                 attributesBuilder.attribute(attributeEntry.getKey(), Attributes.toAsciidoctorFlag((Boolean) val));
-            }
-            else {
+            } else {
                 // Can't do anything about dates and times because all that logic is private in Attributes
                 attributesBuilder.attribute(attributeEntry.getKey(), val);
             }
@@ -684,8 +705,8 @@ public class AsciidoctorMojo extends AbstractMojo {
 
     public void setRelativeBaseDir(boolean relativeBaseDir) {
         this.relativeBaseDir = relativeBaseDir;
-    }    
-    
+    }
+
     public List<ExtensionConfiguration> getExtensions() {
         return extensions;
     }


### PR DESCRIPTION
The PR also adds better explanations for other options.
No tests are included since validation of those options require Asciidoctorj 1.6.0. When this is released, tests using Java extensions can be added.
Options are set using property names due to them not being available in OptionsBuilder.

I have validated the code using an external project that uses AsciidoctorJ 1.6.0-alpha.3.