### PR TITLE
Added cache control and Java6 build to appveyor

### DIFF
--- a/appveyor.yml
+++ b/appveyor.yml
@@ -2,18 +2,27 @@ version: '{build}'
 skip_tags: true
 clone_depth: 10
 environment:
+  MAVEN_VERSION: 3.3.9
   matrix:
+    - JAVA_HOME: C:\Program Files\Java\jdk1.6.0
     - JAVA_HOME: C:\Program Files\Java\jdk1.7.0
     - JAVA_HOME: C:\Program Files\Java\jdk1.8.0
 install:
   - ps: |
+      # If we run Java6 we install last Java6 compatible Maven
+      if ($env:JAVA_HOME.EndsWith('jdk1.6.0')) {
+        $env:MAVEN_VERSION = '3.2.5'
+        $env:TESTS_OPTS = '-Dtest=AsciidoctorMojoTest,AsciidoctorMojoExtensionsTest,AsciidoctorHttpMojoTest,AsciidoctorZipMojoTest'
+      }
       Add-Type -AssemblyName System.IO.Compression.FileSystem
       if (!(Test-Path -Path "C:\maven" )) {
-        (new-object System.Net.WebClient).DownloadFile('https://repo1.maven.org/maven2/org/apache/maven/apache-maven/3.3.9/apache-maven-3.3.9-bin.zip', 'C:\maven-bin.zip')
+        Write-Host "Downloading Maven $env:MAVEN_VERSION"
+        (new-object System.Net.WebClient).DownloadFile("https://repo1.maven.org/maven2/org/apache/maven/apache-maven/$env:MAVEN_VERSION/apache-maven-$env:MAVEN_VERSION-bin.zip", 'C:\maven-bin.zip')
         [System.IO.Compression.ZipFile]::ExtractToDirectory("C:\maven-bin.zip", "C:\maven")
       }
+  - cmd: SET M2_HOME=C:\maven\apache-maven-%MAVEN_VERSION%
   # Prepend Java entry, remove Ruby entry (C:\Ruby193\bin;) from PATH
-  - cmd: SET PATH=C:\maven\apache-maven-3.3.9\bin;%JAVA_HOME%\bin;%PATH:C:\Ruby193\bin;=%
+  - cmd: SET PATH=%M2_HOME%\bin;%JAVA_HOME%\bin;%PATH:C:\Ruby193\bin;=%;
   - cmd: SET MAVEN_OPTS=-XX:MaxPermSize=1g -Xmx2g
   - cmd: SET JAVA_OPTS=-XX:MaxPermSize=1g -Xmx2g
   - cmd: mvn --version
@@ -21,6 +30,7 @@ install:
 build_script:
   - mvn clean package -B -Dmaven.test.skip=true
 test_script:
-  - mvn -Prun-its verify -B
+  - mvn -Prun-its verify -B %TESTS_OPTS%
 cache:
-  - C:\maven
+  - C:\maven\ -> appveyor.yml
+  - C:\Users\appveyor\.m2\ -> pom.xml


### PR DESCRIPTION
This PR includes:
- Cache for maven installation folder and repository. Each cache adds a depedency file (https://www.appveyor.com/docs/build-cache/#addchange-dependency), so that if that file changes the cache gets invalidated.
- Support for Java6 builds. Since officialy until asciidoctor 1.6.0 Java6 is supported and now Appveyor offers it, I added it. To make the build work for Java6, it uses maven 3.2.5 instead. Higher versions fail because they are compiled for Java7. `RefreshTest` hangs, could not reproduce, so I disabled it for Java6.

Finally, Maven wrapper has not been included to support the Java6.