### PR TITLE
fixes #248 - Run clean verify together in CI

### DIFF
--- a/.travis.yml
+++ b/.travis.yml
@@ -7,10 +7,10 @@ jdk:
   - oraclejdk7
   - openjdk7
   - openjdk6
-install:
-  - mvn package -DskipTests=true -Dmaven.javadoc.skip=true -B -V
+# skip installation step entirely
+install: true
 script:
-  - mvn -Prun-its verify jacoco:report
+  - mvn -B -V -Prun-its clean verify jacoco:report
 after_success:
   # 'coveralls:report' goal is responsible for updating coverall.io stats once travisCI build completes
   # Look for the article 'Coveralls.io configuration for maven projects' in the wiki (https://github.com/asciidoctor/asciidoctor/wiki) for more details

--- a/appveyor.yml
+++ b/appveyor.yml
@@ -28,7 +28,7 @@ install:
   - cmd: mvn --version
   - cmd: java -version
 build_script:
-  - mvn -B -V -Prun-its clean verify
+  - mvn -B -V -Prun-its clean verify %TESTS_OPTS%
 cache:
   - C:\maven\ -> appveyor.yml
   - C:\Users\appveyor\.m2\ -> pom.xml

--- a/appveyor.yml
+++ b/appveyor.yml
@@ -28,7 +28,7 @@ install:
   - cmd: mvn --version
   - cmd: java -version
 build_script:
-  - mvn -B -V -Prun-its clean verify jacoco:report
+  - mvn -B -V -Prun-its clean verify
 cache:
   - C:\maven\ -> appveyor.yml
   - C:\Users\appveyor\.m2\ -> pom.xml

--- a/appveyor.yml
+++ b/appveyor.yml
@@ -28,9 +28,7 @@ install:
   - cmd: mvn --version
   - cmd: java -version
 build_script:
-  - mvn clean package -B -Dmaven.test.skip=true
-test_script:
-  - mvn -Prun-its verify -B %TESTS_OPTS%
+  - mvn -B -V -Prun-its clean verify jacoco:report
 cache:
   - C:\maven\ -> appveyor.yml
   - C:\Users\appveyor\.m2\ -> pom.xml

--- a/pom.xml
+++ b/pom.xml
@@ -69,7 +69,7 @@
         <spock.version>0.7-groovy-2.0</spock.version>
         <groovy.version>2.1.3</groovy.version>
         <asciidoctorj.version>1.5.3.2</asciidoctorj.version>
-        <maven.coveralls.plugin.version>3.0.1</maven.coveralls.plugin.version>
+        <maven.coveralls.plugin.version>4.3.0</maven.coveralls.plugin.version>
         <maven.jacoco.plugin.version>0.7.2.201409121644</maven.jacoco.plugin.version>
         <jruby.version>1.7.21</jruby.version>
         <maven.plugin.plugin.version>3.4</maven.plugin.plugin.version>


### PR DESCRIPTION
As discussed https://github.com/asciidoctor/asciidoctor-maven-plugin/issues/248, the build process have been simplified for TravisCI and Appveyor. Now the whole build & test process is done in a single execution.
2 things to mention:
- jacoco reports are only executed in Travis since this is only done to publish on coveralls.io. Other than that both build processes are equivalent.
- coveralls-maven-plugin version has been updated.