### PR TITLE
Improved Tips & Tricks section with an example of header attributes

### DIFF
--- a/README.adoc
+++ b/README.adoc
@@ -211,15 +211,6 @@ The custom AsciiDoc property can then be used in the document like this:
 
  The latest version of the project is {project-version}.
 
-[NOTE]
-====
-If you want to have the project version as the revision number of the document, use this construct:
-
- :revnumber: {project-version}
-
-This will make the version number appear in the header and footer of the output.
-====
-
 ==== Setting boolean values
 
 Boolean attributes in asciidoctor, such as `sectnums`, `linkcss` or `copycss` can be set with a value of `true` and unset with a value of `false`.

--- a/README.adoc
+++ b/README.adoc
@@ -211,7 +211,7 @@ The custom AsciiDoc property can then be used in the document like this:
 
  The latest version of the project is {project-version}.
 
-[TIP]
+[NOTE]
 ====
 If you want to have the project version as the revision number of the document, use this construct:
 
@@ -461,6 +461,8 @@ NOTE: If I can figure out a good way to setup a Ruby testing environment I'll do
 
 === Generate your documentation in separate folders per version
 
+Use Maven `project.version` property to create dedicated custom output directories.
+
 [source, xml]
 -----
 <configuration>
@@ -472,6 +474,8 @@ NOTE: If I can figure out a good way to setup a Ruby testing environment I'll do
 
 === Enable section numbering
 
+Enable section numbering in the build using the `attributes` section.
+
 [source, xml]
 -----
 <configuration>
@@ -480,6 +484,24 @@ NOTE: If I can figure out a good way to setup a Ruby testing environment I'll do
         ...
         <sectnums>true</sectnums>
         ...
+    </attributes>
+    ...
+</configuration>
+-----
+
+=== Add version and build date to the header
+
+Automatically add version details to header and footer to all documents.
+
+[source, xml]
+-----
+<configuration>
+    ...
+    <attributes>
+        ...
+        <revnumber>${project.version}</revnumber>
+        <revdate>${maven.build.date}</revdate>
+        <organization>${project.organization.name}</organization>
     </attributes>
     ...
 </configuration>

--- a/README.adoc
+++ b/README.adoc
@@ -486,14 +486,20 @@ Automatically add version details to header and footer to all documents.
 
 [source, xml]
 -----
+
+<properties>
+   <maven.build.timestamp.format>yyyy-MM-dd HH</maven.build.timestamp.format>  <1>
+</properties>
+
 <configuration>
     ...
     <attributes>
         ...
         <revnumber>${project.version}</revnumber>
-        <revdate>${maven.build.date}</revdate>
+        <revdate>${maven.build.timestamp}</revdate>
         <organization>${project.organization.name}</organization>
     </attributes>
     ...
 </configuration>
 -----
+<1> Add `maven.build.timestamp.format` to the pom's properties section to set a custom date format.


### PR DESCRIPTION
This PR contains:
· As a closure for https://github.com/asciidoctor/asciidoctor-maven-plugin/issues/278 I added the resolution into the tips & trick section of the README document.
· Added brief text descriptions of the different Tips&Tricks.
· Removed Tip note about use of `revnumber` in `Passing POM properties`. I consider that the new tip is more elegant and having both can create some confusion.