### PR TITLE
Upgrade project version and AsciidoctorJ dependency to 1.5.5

### DIFF
--- a/pom.xml
+++ b/pom.xml
@@ -71,7 +71,7 @@
         <asciidoctorj.version>1.5.5</asciidoctorj.version>
         <maven.coveralls.plugin.version>4.3.0</maven.coveralls.plugin.version>
         <maven.jacoco.plugin.version>0.7.2.201409121644</maven.jacoco.plugin.version>
-        <jruby.version>1.7.21</jruby.version>
+        <jruby.version>1.7.26</jruby.version>
         <maven.plugin.plugin.version>3.4</maven.plugin.plugin.version>
         <maven.plugin.api.version>2.0</maven.plugin.api.version>
         <maven.project.version>2.2.1</maven.project.version>

--- a/pom.xml
+++ b/pom.xml
@@ -10,7 +10,7 @@
 
     <groupId>org.asciidoctor</groupId>
     <artifactId>asciidoctor-maven-plugin</artifactId>
-    <version>1.5.4-SNAPSHOT</version>
+    <version>1.5.5-SNAPSHOT</version>
     <packaging>maven-plugin</packaging>
 
     <name>Asciidoctor Maven Plugin</name>
@@ -68,7 +68,7 @@
         <project.execution.environment>JavaSE-1.6</project.execution.environment>
         <spock.version>0.7-groovy-2.0</spock.version>
         <groovy.version>2.1.3</groovy.version>
-        <asciidoctorj.version>1.5.3.2</asciidoctorj.version>
+        <asciidoctorj.version>1.5.5</asciidoctorj.version>
         <maven.coveralls.plugin.version>4.3.0</maven.coveralls.plugin.version>
         <maven.jacoco.plugin.version>0.7.2.201409121644</maven.jacoco.plugin.version>
         <jruby.version>1.7.21</jruby.version>

--- a/src/test/groovy/org/asciidoctor/maven/test/AsciidoctorMojoTest.groovy
+++ b/src/test/groovy/org/asciidoctor/maven/test/AsciidoctorMojoTest.groovy
@@ -920,7 +920,7 @@ class AsciidoctorMojoTest extends Specification {
     def 'github files can be included'() {
         setup:
             File srcDir = new File(DEFAULT_SOURCE_DIRECTORY)
-            File outputDir = new File('target/test-resources/github-include')
+            File outputDir = new File("target/test-resources/github-include/${System.currentTimeMillis()}")
             String documentName = 'github-include.adoc'
 
         when:
@@ -931,11 +931,15 @@ class AsciidoctorMojoTest extends Specification {
             mojo.outputDirectory = outputDir
             mojo.sourceHighlighter = 'coderay'
             mojo.attributes = ['allow-uri-read':'true']
+            mojo.resources = [[
+                                  directory: '.',
+                                  excludes : ['**/**']
+                          ] as Resource]
             mojo.execute()
 
         then:
             outputDir.list().toList().isEmpty() == false
-            !(new File(outputDir, 'github-include.html').text.contains('modelVersion'))
+            (new File(outputDir, 'github-include.html').text.contains('modelVersion'))
     }
 
     def "command line attributes replace configurations"() {

--- a/src/test/java/org/asciidoctor/maven/test/processors/ChangeAttributeValuePreprocessor.java
+++ b/src/test/java/org/asciidoctor/maven/test/processors/ChangeAttributeValuePreprocessor.java
@@ -19,7 +19,7 @@ public class ChangeAttributeValuePreprocessor extends Preprocessor {
     @Override
     public PreprocessorReader process(Document document, PreprocessorReader reader) {
         System.out.println("Processing "+ this.getClass().getSimpleName());
-        System.out.println("Processing: blocks found: " + document.blocks().size());
+        System.out.println("Processing: blocks found: " + document.getBlocks().size());
         document.getAttributes().put("author", AUTHOR_NAME);
         return reader;
     }

--- a/src/test/java/org/asciidoctor/maven/test/processors/DummyPostprocessor.java
+++ b/src/test/java/org/asciidoctor/maven/test/processors/DummyPostprocessor.java
@@ -16,7 +16,7 @@ public class DummyPostprocessor extends Postprocessor {
     @Override
     public String process(Document document, String output) {
         System.out.println("Processing "+ this.getClass().getSimpleName());
-        System.out.println("Processing: blocks found: " + document.blocks().size());
+        System.out.println("Processing: blocks found: " + document.getBlocks().size());
         System.out.println("Processing: output size: " + output.length());
         return output;
     }

--- a/src/test/java/org/asciidoctor/maven/test/processors/DummyTreeprocessor.java
+++ b/src/test/java/org/asciidoctor/maven/test/processors/DummyTreeprocessor.java
@@ -21,7 +21,7 @@ public class DummyTreeprocessor extends Treeprocessor {
     @Override
     public Document process(Document document) {
         System.out.println("Processing "+ this.getClass().getSimpleName());
-        System.out.println("Processing: blocks found: " + document.blocks().size());
+        System.out.println("Processing: blocks found: " + document.getBlocks().size());
         return document;
     }
 

--- a/src/test/java/org/asciidoctor/maven/test/processors/FailingPreprocessor.java
+++ b/src/test/java/org/asciidoctor/maven/test/processors/FailingPreprocessor.java
@@ -1,23 +1,23 @@
 package org.asciidoctor.maven.test.processors;
 
-import java.util.Map;
-
 import org.asciidoctor.ast.Document;
 import org.asciidoctor.extension.Preprocessor;
 import org.asciidoctor.extension.PreprocessorReader;
 
+import java.util.Map;
+
 public class FailingPreprocessor extends Preprocessor {
-    
+
     public FailingPreprocessor(Map<String, Object> config) {
         super(config);
-        System.out.println(this.getClass().getSimpleName() + "(" 
+        System.out.println(this.getClass().getSimpleName() + "("
                 + this.getClass().getSuperclass().getSimpleName() + ") initialized");
     }
 
     @Override
     public PreprocessorReader process(Document document, PreprocessorReader reader) {
         System.out.println("Processing "+ this.getClass().getSimpleName());
-        System.out.println("Processing: blocks found: " + document.blocks().size());
+        System.out.println("Processing: blocks found: " + document.getBlocks().size());
         throw new RuntimeException("That's all folks");
     }
 

--- a/src/test/java/org/asciidoctor/maven/test/processors/GistBlockMacroProcessor.java
+++ b/src/test/java/org/asciidoctor/maven/test/processors/GistBlockMacroProcessor.java
@@ -1,11 +1,11 @@
 package org.asciidoctor.maven.test.processors;
 
-import java.util.Arrays;
-import java.util.Map;
-
 import org.asciidoctor.ast.AbstractBlock;
 import org.asciidoctor.ast.Block;
 import org.asciidoctor.extension.BlockMacroProcessor;
+
+import java.util.Arrays;
+import java.util.Map;
 
 public class GistBlockMacroProcessor extends BlockMacroProcessor {
 

--- a/src/test/java/org/asciidoctor/maven/test/processors/MetaDocinfoProcessor.java
+++ b/src/test/java/org/asciidoctor/maven/test/processors/MetaDocinfoProcessor.java
@@ -16,7 +16,7 @@ public class MetaDocinfoProcessor extends DocinfoProcessor {
     @Override
     public String process(Document document) {
         System.out.println("Processing "+ this.getClass().getSimpleName());
-        System.out.println("Processing: blocks found: " + document.blocks().size());
+        System.out.println("Processing: blocks found: " + document.getBlocks().size());
         return "<meta name=\"author\" content=\"asciidoctor\">";
     }
 

--- a/src/test/resources/src/asciidoctor/github-include.adoc
+++ b/src/test/resources/src/asciidoctor/github-include.adoc
@@ -7,7 +7,7 @@ NOTE: This is test, only a test.
 
 == Includes a file from GitHub
 
-Note that this will only works with jruby 9k
+This works using jRuby 9k or >= 1.7.22.
 
 [source,xml]
 ----


### PR DESCRIPTION
Also AsciidoctorJ extensions tests don't use deprecated methods.