### PR TITLE
Added clarification about released documentation

### DIFF
--- a/README.adoc
+++ b/README.adoc
@@ -9,11 +9,22 @@
 ifdef::env-github[:badges:]
 // URIs
 :project-repo: asciidoctor/asciidoctor-maven-plugin
+:uri-repo: https://github.com/{project-repo}
 :uri-asciidoc: http://asciidoc.org
 :uri-asciidoctor: http://asciidoctor.org
 :uri-examples: https://github.com/asciidoctor/asciidoctor-maven-examples
 :uri-maven: http://maven.apache.org
-
+// GitHub customization
+ifdef::env-github[]
+:tag: master
+:!toc-title:
+:tip-caption: :bulb:
+:note-caption: :paperclip:
+:important-caption: :heavy_exclamation_mark:
+:caution-caption: :fire:
+:warning-caption: :warning:
+endif::[]
+// Badges
 ifdef::badges[]
 image:https://ci.appveyor.com/api/projects/status/chebmu91f08dlmsc/branch/master?svg=true["Build Status (AppVeyor)", link="https://ci.appveyor.com/project/asciidoctor/asciidoctor-maven-plugin"]
 image:http://img.shields.io/travis/asciidoctor/asciidoctor-maven-plugin/master.svg["Build Status (Travis CI)", link="https://travis-ci.org/asciidoctor/asciidoctor-maven-plugin"]
@@ -25,6 +36,19 @@ The Asciidoctor Maven Plugin is the official way to convert your {uri-asciidoc}[
 
 .Translations of the document are available in the following languages:
 * link:README_zh-CN.adoc[汉语]
+
+ifeval::['{tag}' == 'master']
+[NOTE]
+====
+You're viewing the documentation for the upcoming release.
+If you're looking for the documentation for an older release, please refer to one of the following tags: +
+{uri-repo}/tree/asciidoctor-maven-plugin-1.5.5#readme[1.5.5]
+&hybull;
+{uri-repo}/tree/asciidoctor-maven-plugin-1.5.3#readme[1.5.3]
+&hybull;
+{uri-repo}/tree/asciidoctor-maven-plugin-1.5.2.1#readme[1.5.2.1]
+====
+endif::[]
 
 == Installation
 

--- a/README_zh-CN.adoc
+++ b/README_zh-CN.adoc
@@ -15,7 +15,17 @@ ifdef::env-github[:badges:]
 :uri-asciidoctor: http://asciidoctor.org
 :uri-examples: https://github.com/asciidoctor/asciidoctor-maven-examples
 :uri-maven: http://maven.apache.org
-
+// GitHub customization
+ifdef::env-github[]
+:tag: master
+:!toc-title:
+:tip-caption: :bulb:
+:note-caption: :paperclip:
+:important-caption: :heavy_exclamation_mark:
+:caution-caption: :fire:
+:warning-caption: :warning:
+endif::[]
+// Badges
 ifdef::badges[]
 image:https://ci.appveyor.com/api/projects/status/chebmu91f08dlmsc/branch/master?svg=true["Build Status (AppVeyor)", link="https://ci.appveyor.com/project/asciidoctor/asciidoctor-maven-plugin"]
 image:http://img.shields.io/travis/asciidoctor/asciidoctor-maven-plugin/master.svg["Build Status (Travis CI)", link="https://travis-ci.org/asciidoctor/asciidoctor-maven-plugin"]


### PR DESCRIPTION
· Added note about where to find documentation for release versions  (based on https://github.com/asciidoctor/jekyll-asciidoc/)
· Added GitHub emojis for admonition icons.

Note that unlike jekyll-asciidoc, which uses branches, here I redirect to tags.