### PR TITLE
upgrade Jruby dependency to 9K

### DIFF
--- a/pom.xml
+++ b/pom.xml
@@ -70,7 +70,7 @@
         <asciidoctorj.version>1.5.5</asciidoctorj.version>
         <maven.coveralls.plugin.version>4.3.0</maven.coveralls.plugin.version>
         <maven.jacoco.plugin.version>0.7.2.201409121644</maven.jacoco.plugin.version>
-        <jruby.version>1.7.26</jruby.version>
+        <jruby.version>9.1.8.0</jruby.version>
         <maven.plugin.plugin.version>3.4</maven.plugin.plugin.version>
         <maven.plugin.api.version>2.0</maven.plugin.api.version>
         <maven.project.version>2.2.1</maven.project.version>


### PR DESCRIPTION
We are facing the below issue when we are building Apache HBase on AArch64：　
[ERROR] Failed to execute goal org.asciidoctor:asciidoctor-maven-plugin:1.5.2.1:process-asciidoc (output-pdf) on project hbase: Execution output-pdf of goal org.asciidoctor:asciidoctor-maven-plugin:1.5.2.1:process-asciidoc failed: (NotImplementedError) fstat unimplemented unsupported or native support failed to load ->

This error took place because asciidoctor-maven-plugin used an old version of Jruby (1.7.26) which didn’t support AArch64  (due to the fact that Jffi 1.2.12 which Jruby 1.7.26 depends on has no native AArch64 libraries).

Is it ok for upgrade jruby version to 9K to support AArch64?

