### PR TITLE
Allow imagesdir attribute override from documents.

### DIFF
--- a/src/main/java/org/asciidoctor/maven/AsciidoctorMojo.java
+++ b/src/main/java/org/asciidoctor/maven/AsciidoctorMojo.java
@@ -108,7 +108,7 @@ public class AsciidoctorMojo extends AbstractMojo {
     protected boolean templateCache = true;
 
     @Parameter(property = AsciidoctorMaven.PREFIX + "imagesDir", required = false)
-    protected String imagesDir = "images"; // use a string because otherwise html doc uses absolute path
+    protected String imagesDir = "images@"; // '@' Allows override by :imagesdir: document properties
 
     @Parameter(property = AsciidoctorMaven.PREFIX + "sourceHighlighter", required = false)
     protected String sourceHighlighter;

--- a/src/main/java/org/asciidoctor/maven/AsciidoctorMojo.java
+++ b/src/main/java/org/asciidoctor/maven/AsciidoctorMojo.java
@@ -108,7 +108,7 @@ public class AsciidoctorMojo extends AbstractMojo {
     protected boolean templateCache = true;
 
     @Parameter(property = AsciidoctorMaven.PREFIX + "imagesDir", required = false)
-    protected String imagesDir = "images@"; // '@' Allows override by :imagesdir: document properties
+    protected String imagesDir = "images@"; // '@' Allows override by :imagesdir: document attribute
 
     @Parameter(property = AsciidoctorMaven.PREFIX + "sourceHighlighter", required = false)
     protected String sourceHighlighter;


### PR DESCRIPTION
This fixes #294 by adding an `@` symbol to the default `imagesDir`
setting. Although this default shouldn't have been there in the first
place according to @mojavelinux, at least now it is overridable from
the documents.