### PR TITLE
Improved message on non-existing source directory

### DIFF
--- a/src/main/java/org/asciidoctor/maven/AsciidoctorMojo.java
+++ b/src/main/java/org/asciidoctor/maven/AsciidoctorMojo.java
@@ -171,7 +171,7 @@ public class AsciidoctorMojo extends AbstractMojo {
         }
 
         if (!sourceDirectory.exists()) {
-            getLog().info("sourceDirectory does not exist. Skip processing");
+            getLog().info("sourceDirectory " + sourceDirectory.getPath() + " does not exist. Skip processing");
             return;
         }
 

--- a/src/test/groovy/org/asciidoctor/maven/test/AsciidoctorMojoTest.groovy
+++ b/src/test/groovy/org/asciidoctor/maven/test/AsciidoctorMojoTest.groovy
@@ -986,7 +986,7 @@ class AsciidoctorMojoTest extends Specification {
             mojo.outputDirectory = outputDir
             mojo.execute()
         then:
-            newOut.toString().contains('sourceDirectory does not exist. Skip processing')
+            newOut.toString().contains("sourceDirectory ${mojo.sourceDirectory} does not exist. Skip processing")
             !outputDir.exists()
         cleanup:
             System.setOut(originalOut)


### PR DESCRIPTION
Added information about the expected source directory to the message logged if the expected directory does not exist. This could be helpful for the user.