### PR TITLE
added outputFile option to override the generated filename

### DIFF
--- a/README.adoc
+++ b/README.adoc
@@ -130,6 +130,7 @@ When converting to HTML, images must be copied to the output location so that th
     <resources>
 ----
 outputDirectory:: defaults to `${project.build.directory}/generated-docs`
+outputFile:: defaults to `null`, can be used to override the name of the generated output file. This is useful for backends, that create a single file, e.g. the pdf backend. All output will be redirected to the same file, the same way as the `-o, --out-file=OUT_FILE` option from the `asciidoctor` CLI command.
 baseDir:: (not Maven's basedir) enables to set the root path for resources (e.g. included files), defaults to `${sourceDirectory}`
 skip:: set this to `true` to bypass generation, defaults to `false`
 preserveDirectories:: enables to specify whether the documents should be rendered in the same folder structure as in the source directory or not, defaults to `false`.

--- a/src/main/java/org/asciidoctor/maven/AsciidoctorMojo.java
+++ b/src/main/java/org/asciidoctor/maven/AsciidoctorMojo.java
@@ -538,6 +538,14 @@ public class AsciidoctorMojo extends AbstractMojo {
         this.outputDirectory = outputDirectory;
     }
 
+    public File getOutputFile() {
+        return outputFile;
+    }
+
+    public void setOutputFile(File outputFile) {
+        this.outputFile = outputFile;
+    }
+
     public String getBackend() {
         return backend;
     }

--- a/src/main/java/org/asciidoctor/maven/AsciidoctorMojo.java
+++ b/src/main/java/org/asciidoctor/maven/AsciidoctorMojo.java
@@ -56,6 +56,9 @@ public class AsciidoctorMojo extends AbstractMojo {
     @Parameter(property = AsciidoctorMaven.PREFIX + "outputDirectory", defaultValue = "${project.build.directory}/generated-docs", required = true)
     protected File outputDirectory;
 
+    @Parameter(property = AsciidoctorMaven.PREFIX + "outputFile", required = false)
+    protected File outputFile;
+
     @Parameter(property = AsciidoctorMaven.PREFIX + "preserveDirectories", defaultValue = "false", required = false)
     protected boolean preserveDirectories = false;
 
@@ -312,6 +315,10 @@ public class AsciidoctorMojo extends AbstractMojo {
                 optionsBuilder.toDir(relativePath).destinationDir(relativePath);
             } else {
                 optionsBuilder.toDir(outputDirectory).destinationDir(outputDirectory);
+            }
+            if (outputFile != null) {
+                //allow overriding the output file name
+                optionsBuilder.toFile(outputFile);
             }
         } catch (IOException e) {
             throw new MojoExecutionException("Unable to locate output directory", e);

--- a/src/test/groovy/org/asciidoctor/maven/test/AsciidoctorMojoTest.groovy
+++ b/src/test/groovy/org/asciidoctor/maven/test/AsciidoctorMojoTest.groovy
@@ -234,7 +234,7 @@ class AsciidoctorMojoTest extends Specification {
             mojo.execute()
         then:
             outputDir.list().toList().isEmpty() == false
-            outputDir.list().toList().contains('sample.html')
+            outputDir.list().toList().contains('sample-embedded.html')
 
             File sampleOutput = new File(outputDir, 'sample-embedded.html')
             sampleOutput.length() > 0
@@ -243,6 +243,38 @@ class AsciidoctorMojoTest extends Specification {
             text.contains('data:image/png;base64,iVBORw0KGgo')
             text.contains('font-awesome.min.css')
             text.contains('i class="fa icon-tip"')
+    }
+
+    def "override output file"() {
+        setup:
+        File srcDir = new File(DEFAULT_SOURCE_DIRECTORY)
+        File outputDir = new File('target/asciidoctor-output')
+        File outputFile = new File( 'custom_output_file.html')
+
+        if (!outputDir.exists())
+            outputDir.mkdir()
+        when:
+        AsciidoctorMojo mojo = new AsciidoctorMojo()
+        mojo.attributes["icons"] = "font"
+        mojo.embedAssets = true
+        mojo.imagesDir = ''
+        mojo.outputDirectory = outputDir
+        mojo.outputFile = outputFile
+        mojo.sourceDirectory = srcDir
+        mojo.sourceDocumentName = 'sample-embedded.adoc'
+        mojo.backend = 'html'
+        mojo.execute()
+        then:
+        outputDir.list().toList().isEmpty() == false
+        outputDir.list().toList().contains('custom_output_file.html')
+
+        File sampleOutput = new File(outputDir, 'custom_output_file.html')
+        sampleOutput.length() > 0
+        String text = sampleOutput.getText()
+        text.contains('Asciidoctor default stylesheet')
+        text.contains('data:image/png;base64,iVBORw0KGgo')
+        text.contains('font-awesome.min.css')
+        text.contains('i class="fa icon-tip"')
     }
 
     def "missing-attribute skip"() {


### PR DESCRIPTION
The asciidoctor CLI allows to override the output filename with the -o, --out-file arguments. This change allows to do the same with the maven plugin.

This allows for example to include the project version in the filename:
```xml
<outputFile>my_lovely_documentation_${project.version}.pdf</outputFile>
```