### PR TITLE
replaced '_' by '-' as maven properties separator for site mojo

### DIFF
--- a/src/it/maven-site-plugin/pom.xml
+++ b/src/it/maven-site-plugin/pom.xml
@@ -6,6 +6,11 @@
 	<artifactId>maven-site-plugin-it</artifactId>
 	<version>1.0-SNAPSHOT</version>
     <name>Maven Site Plugin IT</name>
+
+    <properties>
+        <docs.version>v1.2.3</docs.version>
+    </properties>
+
     <build>
         <plugins>
             <!-- tag::plugin-decl[] -->

--- a/src/it/maven-site-plugin/src/site/asciidoc/file-with-toc.adoc
+++ b/src/it/maven-site-plugin/src/site/asciidoc/file-with-toc.adoc
@@ -3,6 +3,7 @@
 
 [.lead]
 This is an example file that was processed by the site module in the Asciidoctor Maven Plugin.
+Version {docs-version}.
 
 == First section
 

--- a/src/it/maven-site-plugin/validate.bsh
+++ b/src/it/maven-site-plugin/validate.bsh
@@ -85,6 +85,19 @@ for (String expectedFile : expectedFiles) {
     if (!sourceHighlighted) {
         throw new Exception("Source code was not highlighted.");
     }
+
+    // validate that maven properties are replaced same as attributes
+    boolean foundReplacement = false;
+    for (String line: lines) {
+    System.out.println(line);
+        if (line.contains("v1.2.3")) {
+            foundReplacement = true;
+            break;
+        }
+    }
+    if (!foundReplacement) {
+        throw new Exception("Maven properties not replaced.");
+    }
 }
 
 for (String unexpectedFile : unexpectedFiles) {

--- a/src/main/java/org/asciidoctor/maven/site/AsciidoctorParser.java
+++ b/src/main/java/org/asciidoctor/maven/site/AsciidoctorParser.java
@@ -29,9 +29,6 @@ import org.codehaus.plexus.component.annotations.Requirement;
 import org.codehaus.plexus.util.IOUtil;
 import org.codehaus.plexus.util.xml.Xpp3Dom;
 
-import org.asciidoctor.internal.JRubyRuntimeContext;
-import org.asciidoctor.internal.RubyUtils;
-
 import java.io.File;
 import java.io.IOException;
 import java.io.Reader;
@@ -125,7 +122,7 @@ public class AsciidoctorParser extends XhtmlParser {
 
         if (this.project.getProperties() != null) {
             for ( Map.Entry<Object, Object> entry : this.project.getProperties().entrySet() ) {
-                attributes.attribute(((String) entry.getKey()).replaceAll("\\.", "_"), entry.getValue());
+                attributes.attribute(((String) entry.getKey()).replaceAll("\\.", "-"), entry.getValue());
             }
         }
 


### PR DESCRIPTION
Includes:
- Replaces separator with hyphon as commented by @mojavelinux 
- Integration test to validate properties replacement with site mojo

Note: I did no include the idea of adding `pom-` as prefix. Seems excessive and overly complicated, but I am open to suggestions.