### PR TITLE
Fix/upgrade TravisCI to trusty

### DIFF
--- a/.travis.yml
+++ b/.travis.yml
@@ -12,7 +12,7 @@ matrix:
         apt:
           packages:
             - oracle-java7-installer
-      jdk: oraclejdk78
+      jdk: oraclejdk7
     - addons:
         apt:
           packages:

--- a/.travis.yml
+++ b/.travis.yml
@@ -4,9 +4,20 @@ before_script:
   - export MAVEN_SKIP_RC=true
 jdk:
   - oraclejdk8
-  - oraclejdk7
+  - openjdk8
   - openjdk7
-  - openjdk6
+matrix:
+  include:
+    - addons:
+        apt:
+          packages:
+            - oracle-java7-installer
+      jdk: oraclejdk78
+    - addons:
+        apt:
+          packages:
+            - openjdk-6-jdk
+      jdk: openjdk6
 # skip installation step entirely
 install: true
 script:

--- a/.travis.yml
+++ b/.travis.yml
@@ -11,11 +11,6 @@ matrix:
     - addons:
         apt:
           packages:
-            - oracle-java7-installer
-      jdk: oraclejdk7
-    - addons:
-        apt:
-          packages:
             - openjdk-6-jdk
       jdk: openjdk6
 # skip installation step entirely

--- a/.travis.yml
+++ b/.travis.yml
@@ -1,18 +1,12 @@
-language: java
+dist: trusty
 sudo: false
+language: java
 before_script:
   - export MAVEN_SKIP_RC=true
 jdk:
   - oraclejdk8
   - openjdk8
   - openjdk7
-matrix:
-  include:
-    - addons:
-        apt:
-          packages:
-            - openjdk-6-jdk
-      jdk: openjdk6
 # skip installation step entirely
 install: true
 script:


### PR DESCRIPTION
*This is not a final PR, open for discussion*

This PR updates the TravisCI configuration to the new images based on Ubuntu Trusty, set as default since September (https://blog.travis-ci.com/2017-08-31-trusty-as-default-status),
The changes from TravisCI are:
- Default support only for Java8 (oracle & openjdk) and OpenJDK 7.
- Default maven version is 3.5.0

This means that:
- We no longer test against oracle 7
- **We should drop support for Java6. This I decided on my own and I'd like to hear feedback.** If we all agree, I'll update the PR removing the current hack to install it.
Thing is AsciidoctorJ no longer supports Java6, so I don't see any reason to support it on the Maven plugin. If we want to support it, some nasty hacks needs to be added to the script, similar to the ones applied to AppVeyour. Nothing impossible, but honestly, it seems a waste of time to me.

Btw, same changes should be applied to AsciidoctorJ build, but I found this issue https://github.com/jruby-gradle/jruby-gradle-plugin/issues/305.
Forcing TravisCI to use `precise` instead of trusty fixes it, but I don't think we should do that. Support for precise is not guaranteed.