### PR TITLE
fixes #303 - adds warning every time rendered file is overwritten by …

### DIFF
--- a/README.adoc
+++ b/README.adoc
@@ -130,7 +130,7 @@ When converting to HTML, images must be copied to the output location so that th
     <resources>
 ----
 outputDirectory:: defaults to `${project.build.directory}/generated-docs`
-outputFile:: defaults to `null`, can be used to override the name of the generated output file. This is useful for backends, that create a single file, e.g. the pdf backend. All output will be redirected to the same file, the same way as the `-o, --out-file=OUT_FILE` option from the `asciidoctor` CLI command.
+outputFile:: defaults to `null`, used to override the name of the generated output file, can be a relative or absolute path. Useful for backends that create a single file, e.g. the pdf backend. All output will be redirected to the same file, the same way as the `-o, --out-file=OUT_FILE` option from the `asciidoctor` CLI command.
 baseDir:: (not Maven's basedir) enables to set the root path for resources (e.g. included files), defaults to `${sourceDirectory}`
 skip:: set this to `true` to bypass generation, defaults to `false`
 preserveDirectories:: enables to specify whether the documents should be rendered in the same folder structure as in the source directory or not, defaults to `false`.

--- a/src/test/groovy/org/asciidoctor/maven/test/AsciidoctorMojoTest.groovy
+++ b/src/test/groovy/org/asciidoctor/maven/test/AsciidoctorMojoTest.groovy
@@ -277,6 +277,38 @@ class AsciidoctorMojoTest extends Specification {
         text.contains('i class="fa icon-tip"')
     }
 
+    def "override output file with absolute path"() {
+        setup:
+        File srcDir = new File(DEFAULT_SOURCE_DIRECTORY)
+        File outputDir = new File('target/asciidoctor-output')
+        File outputFile = new File(System.getProperty('java.io.tmpdir'), 'custom_output_file.html')
+
+        if (!outputDir.exists())
+            outputDir.mkdir()
+        when:
+        AsciidoctorMojo mojo = new AsciidoctorMojo()
+        mojo.attributes["icons"] = "font"
+        mojo.embedAssets = true
+        mojo.imagesDir = ''
+        mojo.outputDirectory = outputDir
+        mojo.outputFile = outputFile
+        mojo.sourceDirectory = srcDir
+        mojo.sourceDocumentName = 'sample-embedded.adoc'
+        mojo.backend = 'html'
+        mojo.execute()
+        then:
+        outputDir.list().toList().isEmpty() == false
+        outputDir.list().toList().contains('custom_output_file.html')
+
+        File sampleOutput = new File(outputDir, 'custom_output_file.html')
+        sampleOutput.length() > 0
+        String text = sampleOutput.getText()
+        text.contains('Asciidoctor default stylesheet')
+        text.contains('data:image/png;base64,iVBORw0KGgo')
+        text.contains('font-awesome.min.css')
+        text.contains('i class="fa icon-tip"')
+    }
+
     def "missing-attribute skip"() {
         given:
             File srcDir = new File(DEFAULT_SOURCE_DIRECTORY)
@@ -1092,7 +1124,7 @@ class AsciidoctorMojoTest extends Specification {
                                       directory: relativeTestsPath,
                                       excludes : ['**/*.jpg']
                               ] as Resource]
-            mojo.preserveDirertories = true
+            mojo.preserveDirectories = true
             mojo.backend = 'html5'
             mojo.outputDirectory = outputDir
             mojo.execute()
@@ -1147,7 +1179,7 @@ class AsciidoctorMojoTest extends Specification {
         when:
             AsciidoctorMojo mojo = new AsciidoctorMojo()
             mojo.sourceDirectory = new File(relativeTestsPath)
-            mojo.preserveDirertories = true
+            mojo.preserveDirectories = true
             mojo.backend = 'html5'
             mojo.outputDirectory = outputDir
             mojo.execute()
@@ -1208,6 +1240,107 @@ class AsciidoctorMojoTest extends Specification {
             // includes only 1 rendered AsciiDoc document
             def file = new File(outputDir, 'sample.html')
             file.text.contains('Asciidoctor default stylesheet')
+    }
+
+    def "should show message when overwriting files without outputFile"() {
+        setup:
+            def originalOut = System.out
+            def newOut = new ByteArrayOutputStream()
+            System.setOut(new PrintStream(newOut))
+            def originalErr = System.err
+            def newErr = new ByteArrayOutputStream()
+            System.setErr(new PrintStream(newErr))
+
+            // srcDir contains 6 documents, 2 of them with the same name (HellowWorld3.adoc)
+            File srcDir = new File("$DEFAULT_SOURCE_DIRECTORY/relative-path-treatment/")
+            File outputDir = new File("target/asciidoctor-output/overlapping-outputFile/${System.currentTimeMillis()}")
+            if (!outputDir.exists())
+                outputDir.mkdir()
+        when:
+            AsciidoctorMojo mojo = new AsciidoctorMojo()
+            mojo.sourceDirectory = srcDir
+            mojo.backend = 'html5'
+            mojo.outputDirectory = outputDir
+            mojo.execute()
+        then:
+            def asciidocs = []
+            outputDir.eachFileRecurse(FileType.FILES) {
+                if (it.getName() ==~ /.+html/) asciidocs << it
+            }
+            asciidocs.size() == 5
+            newOut.toString().count("Rendered") == 6
+            newOut.toString().count("Duplicated destination found") == 1
+        cleanup:
+            System.setOut(originalOut)
+            System.setErr(originalErr)
+    }
+
+    def "should show message when overwriting files using outputFile"() {
+        setup:
+            def originalOut = System.out
+            def newOut = new ByteArrayOutputStream()
+            System.setOut(new PrintStream(newOut))
+            def originalErr = System.err
+            def newErr = new ByteArrayOutputStream()
+            System.setErr(new PrintStream(newErr))
+
+            File srcDir = new File("$DEFAULT_SOURCE_DIRECTORY/relative-path-treatment/")
+            File outputDir = new File("target/asciidoctor-output/overlapping-outputFile/${System.currentTimeMillis()}")
+            if (!outputDir.exists())
+                outputDir.mkdir()
+        when:
+            AsciidoctorMojo mojo = new AsciidoctorMojo()
+            mojo.sourceDirectory = srcDir
+            mojo.backend = 'html5'
+            mojo.outputDirectory = outputDir
+            mojo.outputFile = new File('single-output.html')
+            mojo.execute()
+        then:
+            def asciidocs = []
+            outputDir.eachFileRecurse(FileType.FILES) {
+                if (it.getName() ==~ /.+html/) asciidocs << it
+            }
+            asciidocs.size() == 1
+            newOut.toString().count("Rendered") == 6
+            newOut.toString().count("Duplicated destination found") == 5
+        cleanup:
+            System.setOut(originalOut)
+            System.setErr(originalErr)
+    }
+
+    def "should not show message when overwriting files using outputFile and preserveDirectories"() {
+        setup:
+            def originalOut = System.out
+            def newOut = new ByteArrayOutputStream()
+            System.setOut(new PrintStream(newOut))
+            def originalErr = System.err
+            def newErr = new ByteArrayOutputStream()
+            System.setErr(new PrintStream(newErr))
+
+            File srcDir = new File("$DEFAULT_SOURCE_DIRECTORY/relative-path-treatment/")
+            File outputDir = new File("target/asciidoctor-output/overlapping-outputFile/${System.currentTimeMillis()}")
+            if (!outputDir.exists())
+                outputDir.mkdir()
+        when:
+            AsciidoctorMojo mojo = new AsciidoctorMojo()
+            mojo.getLog().errorEnabled
+            mojo.sourceDirectory = srcDir
+            mojo.backend = 'html5'
+            mojo.outputDirectory = outputDir
+            mojo.preserveDirectories = true
+            mojo.outputFile = new File('single-output.html')
+            mojo.execute()
+        then:
+            def asciidocs = []
+            outputDir.eachFileRecurse(FileType.FILES) {
+                if (it.getName() ==~ /.+html/) asciidocs << it
+            }
+            asciidocs.size() == 5
+            newOut.toString().count("Rendered") == 6
+            newOut.toString().count("Duplicated destination found") == 1
+        cleanup:
+            System.setOut(originalOut)
+            System.setErr(originalErr)
     }
 
 }


### PR DESCRIPTION
As title suggests, adds the warning message below every time it detects that it will overwrite an existing file 
 `"Duplicated destination found: overwriting file: " + destinationPath.getAbsolutePath()` 
The file get overwritten any way to keep current behavior, but it can be very easily changed to skip the rendering, opinions?
Also not sure if we should use Warn or Err level. ERR seems to harsh, but I also think that overwriting files is a sign of a bad build and should be fixes, same as a code bug.


The idea was to address the use of `outputFile` option easily, but I found the issue may happen in other cases. For example, rendering AsciiDoc docs that are in different source paths into the same target directory (which is the default behauvior). That's why I decided to go for a full feature that checks all files.

Now, before rendering each file, it will check if the target path has already been used. I wanted to pre-process all target paths in a similar way as how resources are prepared before copying them. But the current code makes it very complicated and inefficient. Doing that would allow for some optimization in the future.
I really want to do a major refactor for 1.5.7. I am not afraid to admit that current code is a good example of `spaghetti code`

PR also includes:
- code typo fix
- Note on usage of absolute paths in `outputFile` + test