### PR TITLE
Removed old bundler directory

### DIFF
--- a/.bundle/config
+++ b/.bundle/config
@@ -1,4 +1,0 @@
----
-BUNDLE_PATH: src/main/resources
-BUNDLE_DISABLE_SHARED_GEMS: '1'
-BUNDLE_CLEAN: true


### PR DESCRIPTION
Removes old `bundler` folder. I suspect it has been there since the first releases that used the gem directly doing nothing.

PS: now that we are free of Java6 support. I'll do some maintenance in the repo, expect some silly small PRs: updating plugins, refactor tests, and other stuff.