### PR TITLE
Added basic unit tests for AsciidoctorParser

### DIFF
--- a/src/test/groovy/org/asciidoctor/maven/test/site/AsciidoctorDoxiaParserTest.groovy
+++ b/src/test/groovy/org/asciidoctor/maven/test/site/AsciidoctorDoxiaParserTest.groovy
@@ -1,0 +1,160 @@
+package org.asciidoctor.maven.test.site
+
+import org.apache.maven.doxia.sink.Sink
+import org.apache.maven.project.MavenProject
+import org.asciidoctor.maven.site.AsciidoctorDoxiaParser
+import org.codehaus.plexus.util.xml.Xpp3DomBuilder
+import spock.lang.Specification
+
+class AsciidoctorDoxiaParserTest extends Specification {
+
+    public static final String TEST_DOCS_PATH = 'src/test/resources/src/asciidoctor'
+
+    def "should render html"() {
+        given:
+        final File srcAsciidoc = new File("$TEST_DOCS_PATH/sample.asciidoc")
+        final Sink sink = createSinkMock()
+
+        AsciidoctorDoxiaParser parser = new AsciidoctorDoxiaParser()
+        parser.@project = createMavenProjectMock()
+
+        when:
+        parser.parse(new FileReader(srcAsciidoc), sink)
+
+        then:
+        String outputText = sink.sinkedText
+        outputText.contains '<h1>Document Title</h1>'
+        outputText.contains '<div class="ulist">'
+        outputText.contains '<div class="listingblock">'
+        outputText.contains "require 'asciidoctor'"
+        // icons as text
+        outputText.contains '<div class="title">Note</div>'
+    }
+
+    def "should render html with an attribute"() {
+        given:
+        final File srcAsciidoc = new File("$TEST_DOCS_PATH/sample.asciidoc")
+        Reader reader = new FileReader(srcAsciidoc)
+        final Sink sink = createSinkMock()
+
+        AsciidoctorDoxiaParser parser = new AsciidoctorDoxiaParser()
+        parser.@project = createMavenProjectMock('''
+                    <configuration>
+                        <asciidoc>
+                            <attributes>
+                                <icons>font</icons>
+                            </attributes>
+                        </asciidoc>
+                    </configuration>''')
+
+        when:
+        parser.parse(reader, sink)
+
+        then:
+        String outputText = sink.sinkedText
+        // :icons: font
+        outputText.contains '<i class="fa icon-note" title="Note"></i>'
+    }
+
+    def "should render html with baseDir option"() {
+        given:
+        final File srcAsciidoc = new File("$TEST_DOCS_PATH/main-document.adoc")
+        final Sink sink = createSinkMock()
+
+        AsciidoctorDoxiaParser parser = new AsciidoctorDoxiaParser()
+        parser.@project = createMavenProjectMock("""
+                     <configuration>
+                        <asciidoc>
+                            <baseDir>${new File(srcAsciidoc.parent).absolutePath}</baseDir>
+                        </asciidoc>
+                     </configuration>""")
+
+        when:
+        parser.parse(new FileReader(srcAsciidoc), sink)
+
+        then: 'include works'
+        String outputText = sink.sinkedText
+        outputText.contains '<h1>Include test</h1>'
+        outputText.contains 'println "HelloWorld from Groovy on ${new Date()}"'
+    }
+
+    def "should render html with templateDir option"() {
+        given:
+        final File srcAsciidoc = new File("$TEST_DOCS_PATH/sample.asciidoc")
+        final Sink sink = createSinkMock()
+
+        AsciidoctorDoxiaParser parser = new AsciidoctorDoxiaParser()
+        parser.@project = createMavenProjectMock("""
+                     <configuration>
+                        <asciidoc>
+                            <templateDir>${TEST_DOCS_PATH}/templates</templateDir>
+                        </asciidoc>
+                     </configuration>""")
+
+        when:
+        parser.parse(new FileReader(srcAsciidoc), sink)
+
+        then:
+        String outputText = sink.sinkedText
+        outputText.contains '<h1>Document Title</h1>'
+        outputText.contains '<p class="custom-template ">'
+    }
+
+    def "should render html with attributes and baseDir option"() {
+        given:
+        final File srcAsciidoc = new File("$TEST_DOCS_PATH/main-document.adoc")
+        final Sink sink = createSinkMock()
+
+        AsciidoctorDoxiaParser parser = new AsciidoctorDoxiaParser()
+        parser.@project = createMavenProjectMock("""
+                    <configuration>
+                        <asciidoc>
+                            <baseDir>${new File(srcAsciidoc.parent).absolutePath}</baseDir>
+                            <attributes>
+                                <sectnums></sectnums>
+                                <icons>font</icons>
+                                <my-label>Hello World!!</my-label>
+                            </attributes>
+                        </asciidoc>
+                    </configuration>""")
+
+        when:
+        parser.parse(new FileReader(srcAsciidoc), sink)
+
+        then:
+        String outputText = sink.sinkedText
+        outputText.contains '<h1>Include test</h1>'
+        outputText.contains '<h2 id="code">1. Code</h2>'
+        outputText.contains '<h2 id="optional_section">2. Optional section</h2>'
+        outputText.contains 'println "HelloWorld from Groovy on ${new Date()}"'
+        outputText.contains 'Hello World!!'
+        outputText.contains '<i class="fa icon-tip" title="Tip"></i>'
+    }
+
+
+    private MavenProject createMavenProjectMock(final String configuration = null) {
+        [getGoalConfiguration: { pluginGroupId, pluginArtifactId, executionId, goalId ->
+            configuration ? Xpp3DomBuilder.build(new StringReader(configuration)) : null
+        },
+         getBasedir          : {
+             new File('.')
+         }] as MavenProject
+    }
+
+    /**
+     * Creates a {@link Sink} mock that allows retrieving a text previously sinked.
+     */
+    private Sink createSinkMock() {
+        String text
+        return [rawText : { t ->
+            text = t
+        }, getSinkedText: {
+            text
+        }] as MySink
+    }
+
+    interface MySink extends Sink {
+        String getSinkedText()
+    }
+
+}

--- a/src/test/resources/src/asciidoctor/main-document.adoc
+++ b/src/test/resources/src/asciidoctor/main-document.adoc
@@ -10,3 +10,13 @@ include::includes/new-include.adoc[]
 ----
 include::includes/groovy-include.groovy[]
 ----
+
+ifdef::my-label[]
+== Optional section
+
+This shows how to add optional text.
+For example, this {my-label}.
+
+TIP: Use `ifdef` to control what is shown.
+
+endif::[]

--- a/src/test/resources/src/asciidoctor/templates/block_paragraph.html.slim
+++ b/src/test/resources/src/asciidoctor/templates/block_paragraph.html.slim
@@ -1,0 +1,3 @@
+- if title?
+  .title=title
+p id=id class="custom-template #{role}" =content


### PR DESCRIPTION
This PR adds some basic unit tests to the AsciidoctorDoxiaParser class used for the `site` goal.
Validates options, attributes and templateDir processing, and defines the basic Mocks required to simulate a Maven run.

I wanted to add the testing fundations before implementation and fixing of the site goal features.
  