### PR TITLE
fixes #329 - adds treatment to allow relative baseDir on the site

### DIFF
--- a/src/it/maven-site-plugin/pom.xml
+++ b/src/it/maven-site-plugin/pom.xml
@@ -22,6 +22,7 @@
                 <version>3.4</version>
                 <configuration>
                     <asciidoc>
+                        <baseDir>${project.basedir}/src/site/asciidoc</baseDir>
                         <templateDirs>
                             <dir>src/site/asciidoc/templates</dir>
                         </templateDirs>

--- a/src/main/java/org/asciidoctor/maven/site/AsciidoctorDoxiaParser.java
+++ b/src/main/java/org/asciidoctor/maven/site/AsciidoctorDoxiaParser.java
@@ -155,16 +155,19 @@ public class AsciidoctorDoxiaParser extends XhtmlParser {
                 }
             }
             else if ("templateDir".equals(optName) || "template_dir".equals(optName)) {
-                options.templateDir(resolveTemplateDir(project, asciidocOpt.getValue()));
+                options.templateDir(resolveProjectDir(project, asciidocOpt.getValue()));
             }
             else if ("templateDirs".equals(optName) || "template_dirs".equals(optName)) {
                 List<File> templateDirs = new ArrayList<File>();
                 for (Xpp3Dom dir : asciidocOpt.getChildren("dir")) {
-                    templateDirs.add(resolveTemplateDir(project, dir.getValue()));
+                    templateDirs.add(resolveProjectDir(project, dir.getValue()));
                 }
                 if (!templateDirs.isEmpty()) {
                     options.templateDirs(templateDirs.toArray(new File[templateDirs.size()]));
                 }
+            }
+            else if ("baseDir".equals(optName)) {
+                options.baseDir(resolveProjectDir(project, asciidocOpt.getValue()));
             }
             else {
                 options.option(optName.replaceAll("(?<!_)([A-Z])", "_$1").toLowerCase(), asciidocOpt.getValue());
@@ -177,12 +180,12 @@ public class AsciidoctorDoxiaParser extends XhtmlParser {
         return asciidoctor.convert(source, options);
     }
 
-    protected File resolveTemplateDir(MavenProject project, String path) {
-        File templateDir = new File(path);
-        if (!templateDir.isAbsolute()) {
-            templateDir = new File(project.getBasedir(), templateDir.toString());
+    protected File resolveProjectDir(MavenProject project, String path) {
+        File filePath = new File(path);
+        if (!filePath.isAbsolute()) {
+            filePath = new File(project.getBasedir(), filePath.toString());
         }
-        return templateDir;
+        return filePath;
     }
 
     private void requireLibrary(String require) {

--- a/src/test/groovy/org/asciidoctor/maven/test/site/AsciidoctorDoxiaParserTest.groovy
+++ b/src/test/groovy/org/asciidoctor/maven/test/site/AsciidoctorDoxiaParserTest.groovy
@@ -78,6 +78,28 @@ class AsciidoctorDoxiaParserTest extends Specification {
         outputText.contains 'println "HelloWorld from Groovy on ${new Date()}"'
     }
 
+    def "should render html with relative baseDir option"() {
+        given:
+        final File srcAsciidoc = new File("$TEST_DOCS_PATH/main-document.adoc")
+        final Sink sink = createSinkMock()
+
+        AsciidoctorDoxiaParser parser = new AsciidoctorDoxiaParser()
+        parser.@project = createMavenProjectMock("""
+                     <configuration>
+                        <asciidoc>
+                            <baseDir>${TEST_DOCS_PATH}</baseDir>
+                        </asciidoc>
+                     </configuration>""")
+
+        when:
+        parser.parse(new FileReader(srcAsciidoc), sink)
+
+        then: 'include works'
+        String outputText = sink.sinkedText
+        outputText.contains '<h1>Include test</h1>'
+        outputText.contains 'println "HelloWorld from Groovy on ${new Date()}"'
+    }
+
     def "should render html with templateDir option"() {
         given:
         final File srcAsciidoc = new File("$TEST_DOCS_PATH/sample.asciidoc")


### PR DESCRIPTION
* Just added treatment for `baseDir` in the site plugin.
* Maven replacement DO work, added that to the integration test.

As a note to self, in case we need to apply replacements manually, can be done with `PluginParameterExpressionEvaluator`.