### PR TITLE
fixes #330 - Reused attributes treatment for site goal

### DIFF
--- a/src/main/java/org/asciidoctor/maven/AsciidoctorHelper.java
+++ b/src/main/java/org/asciidoctor/maven/AsciidoctorHelper.java
@@ -1,0 +1,59 @@
+/*
+ * Licensed under the Apache License, Version 2.0 (the &quot;License&quot;);
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ * http://www.apache.org/licenses/LICENSE-2.0
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an &quot;AS IS&quot; BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+
+package org.asciidoctor.maven;
+
+import org.asciidoctor.Attributes;
+import org.asciidoctor.AttributesBuilder;
+
+import java.util.Map;
+
+/**
+ * Utility class for re-usable logic.
+ */
+public class AsciidoctorHelper {
+
+    /**
+     * Adds attributes from a {@link Map} into a {@link AttributesBuilder} taking care of Maven's XML parsing special
+     * cases like toggles, nulls, etc.
+     */
+    public static void addAttributes(final Map<String, Object> attributes, AttributesBuilder attributesBuilder) {
+        // TODO Figure out how to reliably set other values (like boolean values, dates, times, etc)
+        for (Map.Entry<String, Object> attributeEntry : attributes.entrySet()) {
+            addAttribute(attributeEntry.getKey(), attributeEntry.getValue(), attributesBuilder);
+        }
+    }
+
+    /**
+     * Adds an attribute into a {@link AttributesBuilder} taking care of Maven's XML parsing special cases like
+     * toggles toggles, nulls, etc.
+     */
+    public static void addAttribute(String attribute, Object value, AttributesBuilder attributesBuilder) {
+        // NOTE Maven interprets an empty value as null, so we need to explicitly convert it to empty string (see #36)
+        // NOTE In Asciidoctor, an empty string represents a true value
+        if (value == null || "true".equals(value)) {
+            attributesBuilder.attribute(attribute, "");
+        }
+        // NOTE a value of false is effectively the same as a null value, so recommend the use of the string "false"
+        else if ("false".equals(value)) {
+            attributesBuilder.attribute(attribute, null);
+        }
+        // NOTE Maven can't assign a Boolean value from the XML-based configuration, but a client may
+        else if (value instanceof Boolean) {
+            attributesBuilder.attribute(attribute, Attributes.toAsciidoctorFlag((Boolean) value));
+        } else {
+            // Can't do anything about dates and times because all that logic is private in Attributes
+            attributesBuilder.attribute(attribute, value);
+        }
+    }
+
+}

--- a/src/main/java/org/asciidoctor/maven/AsciidoctorMojo.java
+++ b/src/main/java/org/asciidoctor/maven/AsciidoctorMojo.java
@@ -500,26 +500,7 @@ public class AsciidoctorMojo extends AbstractMojo {
             throw new MojoExecutionException(attributeUndefined + " is not valid. Must be one of 'drop' or 'drop-line'");
         }
 
-        // TODO Figure out how to reliably set other values (like boolean values, dates, times, etc)
-        for (Map.Entry<String, Object> attributeEntry : attributes.entrySet()) {
-            Object val = attributeEntry.getValue();
-            // NOTE Maven interprets an empty value as null, so we need to explicitly convert it to empty string (see #36)
-            // NOTE In Asciidoctor, an empty string represents a true value
-            if (val == null || "true".equals(val)) {
-                attributesBuilder.attribute(attributeEntry.getKey(), "");
-            }
-            // NOTE a value of false is effectively the same as a null value, so recommend the use of the string "false"
-            else if ("false".equals(val)) {
-                attributesBuilder.attribute(attributeEntry.getKey(), null);
-            }
-            // NOTE Maven can't assign a Boolean value from the XML-based configuration, but a client may
-            else if (val instanceof Boolean) {
-                attributesBuilder.attribute(attributeEntry.getKey(), Attributes.toAsciidoctorFlag((Boolean) val));
-            } else {
-                // Can't do anything about dates and times because all that logic is private in Attributes
-                attributesBuilder.attribute(attributeEntry.getKey(), val);
-            }
-        }
+        AsciidoctorHelper.addAttributes(attributes, attributesBuilder);
 
         if (!attributesChain.isEmpty()) {
             getLog().info("Attributes: " + attributesChain);

--- a/src/main/java/org/asciidoctor/maven/site/AsciidoctorDoxiaParser.java
+++ b/src/main/java/org/asciidoctor/maven/site/AsciidoctorDoxiaParser.java
@@ -24,6 +24,7 @@ import org.asciidoctor.Asciidoctor;
 import org.asciidoctor.AttributesBuilder;
 import org.asciidoctor.OptionsBuilder;
 import org.asciidoctor.SafeMode;
+import org.asciidoctor.maven.AsciidoctorHelper;
 import org.codehaus.plexus.component.annotations.Component;
 import org.codehaus.plexus.component.annotations.Requirement;
 import org.codehaus.plexus.util.IOUtil;
@@ -132,7 +133,7 @@ public class AsciidoctorDoxiaParser extends XhtmlParser {
             String optName = asciidocOpt.getName();
             if ("attributes".equals(optName)) {
                 for (Xpp3Dom asciidocAttr : asciidocOpt.getChildren()) {
-                    attributes.attribute(asciidocAttr.getName(), asciidocAttr.getValue());
+                    AsciidoctorHelper.addAttribute(asciidocAttr.getName(), asciidocAttr.getValue(), attributes);
                 }
             }
             else if ("requires".equals(optName)) {

--- a/src/test/groovy/org/asciidoctor/maven/test/site/AsciidoctorDoxiaParserTest.groovy
+++ b/src/test/groovy/org/asciidoctor/maven/test/site/AsciidoctorDoxiaParserTest.groovy
@@ -153,6 +153,53 @@ class AsciidoctorDoxiaParserTest extends Specification {
         outputText.contains '<i class="fa icon-tip" title="Tip"></i>'
     }
 
+    def "should process empty self-closing XML attributes"() {
+        given:
+        final File srcAsciidoc = new File("$TEST_DOCS_PATH/sample.asciidoc")
+        final Sink sink = createSinkMock()
+
+        AsciidoctorDoxiaParser parser = new AsciidoctorDoxiaParser()
+        parser.@project = createMavenProjectMock("""
+                     <configuration>
+                       <asciidoc>
+                         <attributes>
+                           <sectnums/>
+                         </attributes>
+                       </asciidoc>
+                     </configuration>""")
+
+        when:
+        parser.parse(new FileReader(srcAsciidoc), sink)
+
+        then:
+        String outputText = sink.sinkedText
+        outputText.contains '<h2 id="id_section_a">1. Section A</h2>'
+        outputText.contains '<h3 id="id_section_a_subsection">1.1. Section A Subsection</h3>'
+    }
+
+    def "should process empty value XML attributes"() {
+        given:
+        final File srcAsciidoc = new File("$TEST_DOCS_PATH/sample.asciidoc")
+        final Sink sink = createSinkMock()
+
+        AsciidoctorDoxiaParser parser = new AsciidoctorDoxiaParser()
+        parser.@project = createMavenProjectMock("""
+                     <configuration>
+                       <asciidoc>
+                         <attributes>
+                           <sectnums></sectnums>
+                         </attributes>
+                       </asciidoc>
+                     </configuration>""")
+
+        when:
+        parser.parse(new FileReader(srcAsciidoc), sink)
+
+        then:
+        String outputText = sink.sinkedText
+        outputText.contains '<h2 id="id_section_a">1. Section A</h2>'
+        outputText.contains '<h3 id="id_section_a_subsection">1.1. Section A Subsection</h3>'
+    }
 
     private MavenProject createMavenProjectMock(final String configuration = null) {
         [getGoalConfiguration: { pluginGroupId, pluginArtifactId, executionId, goalId ->


### PR DESCRIPTION
Just created and utility class to reuse the fix already present in the main mojo.

I have left the code unchanged but I have two notes:
1. I think that "true", "false" and Boolean could be treated together with AsciidoctorJ's `Attributes.toAsciidoctorFlag`. Imho, it makes the code more readable.
2. I don't see why this logic could not be included directly in AsciidoctorJ AttributesBuilder. Attributes class should not do anything, but the Builder purposes is to help and make configuration easier right?
/c @robertpanzer 