### PR TITLE
Set default encoding to UTF-8 for resource copy plugin

### DIFF
--- a/src/test/groovy/org/asciidoctor/maven/test/plexus/MockPlexusContainer.groovy
+++ b/src/test/groovy/org/asciidoctor/maven/test/plexus/MockPlexusContainer.groovy
@@ -43,6 +43,7 @@ class MockPlexusContainer {
         resourceFilter.@buildContext = mojo.@buildContext
         resourceFilter.initialize()
         resourceFilter.enableLogging(logger)
+        mojo.encoding = "UTF-8"
         mojo.@outputResourcesFiltering = resourceFilter
 
     }


### PR DESCRIPTION
Set default encoding for mock Mojo