### PR TITLE
Added an option to replace the constant "@{project.basedir}" with the current modules base directory

### DIFF
--- a/pom.xml
+++ b/pom.xml
@@ -73,7 +73,8 @@
         <plexus.component.metadata.version>1.5.5</plexus.component.metadata.version>
         <netty.version>4.0.38.Final</netty.version>
         <commons.io.version>2.5</commons.io.version>
-        <doxia.version>1.7</doxia.version>
+        <!-- Updated to 1.8 in order to have RenderingContext.getBasedirRelativePath() -->
+        <doxia.version>1.8</doxia.version>
         <gmaven.version>1.5</gmaven.version>
     </properties>
 
@@ -143,6 +144,11 @@
         <dependency>
             <groupId>org.apache.maven.doxia</groupId>
             <artifactId>doxia-core</artifactId>
+            <version>${doxia.version}</version>
+        </dependency>
+        <dependency>
+            <groupId>org.apache.maven.doxia</groupId>
+            <artifactId>doxia-site-renderer</artifactId>
             <version>${doxia.version}</version>
         </dependency>
         <dependency>

--- a/pom.xml
+++ b/pom.xml
@@ -452,8 +452,6 @@
                             <preBuildHookScript>setup</preBuildHookScript>
                             <postBuildHookScript>validate</postBuildHookScript>
                             <showErrors>true</showErrors>
-                          <!-- Try to find out why the ci builds are failing -->
-                          <streamLogs>true</streamLogs>
                             <debug>true</debug>
                             <!-- <localRepositoryPath>${project.build.directory}/local-repo</localRepositoryPath>-->
                             <!-- <settingsFile>src/it/settings.xml</settingsFile>-->

--- a/pom.xml
+++ b/pom.xml
@@ -73,8 +73,7 @@
         <plexus.component.metadata.version>1.5.5</plexus.component.metadata.version>
         <netty.version>4.0.38.Final</netty.version>
         <commons.io.version>2.5</commons.io.version>
-        <!-- Updated to 1.8 in order to have RenderingContext.getBasedirRelativePath() -->
-        <doxia.version>1.8</doxia.version>
+        <doxia.version>1.7</doxia.version>
         <gmaven.version>1.5</gmaven.version>
     </properties>
 

--- a/pom.xml
+++ b/pom.xml
@@ -452,6 +452,8 @@
                             <preBuildHookScript>setup</preBuildHookScript>
                             <postBuildHookScript>validate</postBuildHookScript>
                             <showErrors>true</showErrors>
+                          <!-- Try to find out why the ci builds are failing -->
+                          <streamLogs>true</streamLogs>
                             <debug>true</debug>
                             <!-- <localRepositoryPath>${project.build.directory}/local-repo</localRepositoryPath>-->
                             <!-- <settingsFile>src/it/settings.xml</settingsFile>-->


### PR DESCRIPTION
Especially when generating the output of the diagram asciidoctor plugin into the correct directory, all output is always output into the root modules site directory. This breaks things for child modules. 

Unfortunately there doesn't seem to be a maven way to provide the local modules output directory without modifying the plugin. 

This Pull-Request enables the plugin to replace the constant string "@{project.basedir}" with the current modules base directory. Allowing to provide things like this:

`    <plugin>
          <groupId>org.apache.maven.plugins</groupId>
          <artifactId>maven-site-plugin</artifactId>
          <version>3.7.1</version>
          <configuration>
            <!--templateFile>${session.executionRootDirectory}/src/site/template/maven-site.vm</templateFile-->
            <generateReports>true</generateReports>
            <generateSitemap>true</generateSitemap>
            <relativizeDecorationLinks>false</relativizeDecorationLinks>
            <locales>en</locales>
            <inputEncoding>${project.build.sourceEncoding}</inputEncoding>
            <outputEncoding>${project.reporting.outputencoding}</outputEncoding>
            <asciidoc>
              <attributes>
                <source-highlighter>prettify</source-highlighter>
                <imagesoutdir>@{project.basedir}/target/site/img</imagesoutdir>
              </attributes>
              <requires>
                <require>asciidoctor-diagram</require>
              </requires>
            </asciidoc>
          </configuration>
       ...
`
It's not a pretty solution, but it works for my use-cases. Unfortunately Doxia doesn't seem to provide a clean way to handle this.



