### PR TITLE
fixes #348  outputFile is now relative to outputDirectory + README improvements

### DIFF
--- a/README.adoc
+++ b/README.adoc
@@ -143,7 +143,7 @@ When converting to HTML, images must be copied to the output location so that th
     ...
 <resources>
 ----
-outputDirectory:: defaults to [.path]_${project.build.directory}/generated-docs_
+outputDirectory:: relative paths are added to the project root path. Defaults to [.path]_${project.build.directory}/generated-docs_.
 outputFile:: defaults to `null`, used to override the name of the generated output file, can be a relative or absolute path.
 Useful for backends that create a single file, e.g. the pdf backend.
 All output will be redirected to the same file, the same way as the `-o, --out-file=OUT_FILE` option from the `asciidoctor` CLI command.
@@ -539,15 +539,20 @@ Standard Maven build:
 
 == Testing
 
-http://spockframework.org/[Spock] is used for testing the calling of the Mojo.
-This will be downloaded by Maven.
+Unit tests are written with http://spockframework.org/[Spock].
+This will be downloaded by Maven and can be run from IntelliJ without any additional setup.
 Tests are run simply by:
 
  mvn clean test
 
 Or any of the other goals which run tests.
 
-NOTE: If I can figure out a good way to setup a Ruby testing environment I'll do that as well, but none exists at this time.
+Integration tests under `src/it` are run using link:https://maven.apache.org/plugins/maven-invoker-plugin/[maven-invoker-plugin] and the `runt-its` profile.
+To only run them without excluding unit tests, use:
+
+ mvn clean verify -DskipTests -Prun-its
+
+To run all tests at once just use `mvn clean verify -DskipTests -Prun-its`.
 
 == Tips & Tricks
 

--- a/src/it/rendering-single-html-with-relative-outputDirectory-and-outputFile/invoker.properties
+++ b/src/it/rendering-single-html-with-relative-outputDirectory-and-outputFile/invoker.properties
@@ -1,0 +1,1 @@
+invoker.goals=clean asciidoctor:process-asciidoc

--- a/src/it/rendering-single-html-with-relative-outputDirectory-and-outputFile/pom.xml
+++ b/src/it/rendering-single-html-with-relative-outputDirectory-and-outputFile/pom.xml
@@ -1,0 +1,31 @@
+<project xmlns="http://maven.apache.org/POM/4.0.0" xmlns:xsi="http://www.w3.org/2001/XMLSchema-instance"
+	xsi:schemaLocation="http://maven.apache.org/POM/4.0.0 http://maven.apache.org/maven-v4_0_0.xsd">
+	<modelVersion>4.0.0</modelVersion>
+
+	<groupId>org.asciidoctor</groupId>
+	<artifactId>test</artifactId>
+	<version>1.0-SNAPSHOT</version>
+
+	<name>Converts Asciidoctor Article to Html</name>
+	<description>Runs asciidoctor-maven-plugin:process-asciidoc</description>
+
+	<properties>
+		<project.build.sourceEncoding>UTF-8</project.build.sourceEncoding>
+	</properties>
+
+	<build>
+		<plugins>
+			<plugin>
+				<groupId>org.asciidoctor</groupId>
+				<artifactId>asciidoctor-maven-plugin</artifactId>
+				<version>@project.version@</version>
+				<configuration>
+					<sourceDirectory>src/main/doc</sourceDirectory>
+					<outputDirectory>target/output_path</outputDirectory>
+					<outputFile>a_path/custom-filename.html</outputFile>
+					<backend>html</backend>
+				</configuration>
+			</plugin>
+		</plugins>
+	</build>
+</project>

--- a/src/it/rendering-single-html-with-relative-outputDirectory-and-outputFile/src/main/doc/sample.asciidoc
+++ b/src/it/rendering-single-html-with-relative-outputDirectory-and-outputFile/src/main/doc/sample.asciidoc
@@ -1,0 +1,25 @@
+Document Title
+==============
+Doc Writer <thedoc@asciidoctor.org>
+:idprefix: id_
+
+Preamble paragraph.
+
+NOTE: This is test, only a test.
+
+== Section A
+
+*Section A* paragraph.
+
+=== Section A Subsection
+
+*Section A* 'subsection' paragraph.
+
+== Section B
+
+*Section B* paragraph.
+
+.Section B list
+* Item 1
+* Item 2
+* Item 3

--- a/src/it/rendering-single-html-with-relative-outputDirectory-and-outputFile/validate.groovy
+++ b/src/it/rendering-single-html-with-relative-outputDirectory-and-outputFile/validate.groovy
@@ -1,0 +1,8 @@
+final File outputDir = new File(basedir, 'target/output_path')
+final File expectedFile = new File(outputDir, 'a_path/custom-filename.html')
+
+if (!expectedFile.exists()) {
+    throw new Exception("Missing file " + file)
+}
+
+return true

--- a/src/it/rendering-single-html-with-relative-outputFile/invoker.properties
+++ b/src/it/rendering-single-html-with-relative-outputFile/invoker.properties
@@ -1,0 +1,1 @@
+invoker.goals=clean asciidoctor:process-asciidoc

--- a/src/it/rendering-single-html-with-relative-outputFile/pom.xml
+++ b/src/it/rendering-single-html-with-relative-outputFile/pom.xml
@@ -1,0 +1,30 @@
+<project xmlns="http://maven.apache.org/POM/4.0.0" xmlns:xsi="http://www.w3.org/2001/XMLSchema-instance"
+	xsi:schemaLocation="http://maven.apache.org/POM/4.0.0 http://maven.apache.org/maven-v4_0_0.xsd">
+	<modelVersion>4.0.0</modelVersion>
+
+	<groupId>org.asciidoctor</groupId>
+	<artifactId>test</artifactId>
+	<version>1.0-SNAPSHOT</version>
+
+	<name>Converts Asciidoctor Article to Html</name>
+	<description>Runs asciidoctor-maven-plugin:process-asciidoc</description>
+
+	<properties>
+		<project.build.sourceEncoding>UTF-8</project.build.sourceEncoding>
+	</properties>
+
+	<build>
+		<plugins>
+			<plugin>
+				<groupId>org.asciidoctor</groupId>
+				<artifactId>asciidoctor-maven-plugin</artifactId>
+				<version>@project.version@</version>
+				<configuration>
+					<sourceDirectory>src/main/doc</sourceDirectory>
+					<outputFile>a_path/custom-filename.html</outputFile>
+					<backend>html</backend>
+				</configuration>
+			</plugin>
+		</plugins>
+	</build>
+</project>

--- a/src/it/rendering-single-html-with-relative-outputFile/src/main/doc/sample.asciidoc
+++ b/src/it/rendering-single-html-with-relative-outputFile/src/main/doc/sample.asciidoc
@@ -1,0 +1,25 @@
+Document Title
+==============
+Doc Writer <thedoc@asciidoctor.org>
+:idprefix: id_
+
+Preamble paragraph.
+
+NOTE: This is test, only a test.
+
+== Section A
+
+*Section A* paragraph.
+
+=== Section A Subsection
+
+*Section A* 'subsection' paragraph.
+
+== Section B
+
+*Section B* paragraph.
+
+.Section B list
+* Item 1
+* Item 2
+* Item 3

--- a/src/it/rendering-single-html-with-relative-outputFile/validate.groovy
+++ b/src/it/rendering-single-html-with-relative-outputFile/validate.groovy
@@ -1,0 +1,8 @@
+final File outputDir = new File(basedir, 'target/generated-docs')
+final File expectedFile = new File(outputDir, 'a_path/custom-filename.html')
+
+if (!expectedFile.exists()) {
+    throw new Exception("Missing file " + file)
+}
+
+return true

--- a/src/main/java/org/asciidoctor/maven/AsciidoctorMojo.java
+++ b/src/main/java/org/asciidoctor/maven/AsciidoctorMojo.java
@@ -529,8 +529,13 @@ public class AsciidoctorMojo extends AbstractMojo {
         return outputFile;
     }
 
-    public void setOutputFile(File outputFile) {
-        this.outputFile = outputFile;
+    /**
+     * Maven sets it as an absolute path relative to project root.
+     * Using a string circumvents it.
+     * Maven properties (e.g. ${project.build.directory}) are resolved as string into absolute paths.
+     */
+    public void setOutputFile(String outputFile) {
+        this.outputFile = new File(outputFile);
     }
 
     public String getBackend() {


### PR DESCRIPTION
The final solutions has been extremely simple.
Just use a String in the setter to keep relative path when set, otherwise maven always inserts an absolute path, rest was already implemented.

Added two integration tests and some notes to the README about `outputDirectory` and how to run tests.