### PR TITLE
fix maven site plugin it tests

### DIFF
--- a/pom.xml
+++ b/pom.xml
@@ -162,7 +162,7 @@
             <plugin>
                 <groupId>org.apache.maven.plugins</groupId>
                 <artifactId>maven-enforcer-plugin</artifactId>
-                <version>1.0</version>
+                <version>1.4.1</version>
                 <executions>
                     <execution>
                         <id>enforce-maven</id>
@@ -172,7 +172,7 @@
                         <configuration>
                             <rules>
                                 <requireMavenVersion>
-                                    <version>3.0.4</version>
+                                    <version>3.0.5</version>
                                 </requireMavenVersion>
                             </rules>
                         </configuration>

--- a/src/it/maven-site-plugin/pom.xml
+++ b/src/it/maven-site-plugin/pom.xml
@@ -14,6 +14,16 @@
 
     <build>
         <plugins>
+            <!--
+             Workaround to prevent `java.lang.ClassNotFoundException: org.apache.maven.doxia.siterenderer.DocumentContent`
+             with `maven-site-plugin` v3.6 or lower.
+             This only affects the it tests, normal executions (e.g. in asciidoctor-maven-examples) work fine.
+            -->
+            <plugin>
+                <groupId>org.apache.maven.plugins</groupId>
+                <artifactId>maven-project-info-reports-plugin</artifactId>
+                <version>2.8.1</version>
+            </plugin>
             <!-- tag::plugin-decl[] -->
             <plugin>
                 <groupId>org.apache.maven.plugins</groupId>


### PR DESCRIPTION
Added a workarround (not proud of it) to ensure it-tests work fine with maven-site-plugin 3.4.
