### PR TITLE
Added TSLv1.2 flag to appveyor build

### DIFF
--- a/appveyor.yml
+++ b/appveyor.yml
@@ -18,7 +18,8 @@ install:
   - cmd: SET M2_HOME=C:\maven\apache-maven-%MAVEN_VERSION%
   # Prepend Java entry, remove Ruby entry (C:\Ruby193\bin;) from PATH
   - cmd: SET PATH=%M2_HOME%\bin;%JAVA_HOME%\bin;%PATH:C:\Ruby193\bin;=%;
-  - cmd: SET MAVEN_OPTS=-XX:MaxPermSize=1g -Xmx2g
+  # `https.protocols` is required by Java7 since June 18 because TSL 1.0 & 1.1 support was removed
+  - cmd: SET MAVEN_OPTS=-XX:MaxPermSize=1g -Xmx2g -Dhttps.protocols=TLSv1.2
   - cmd: SET JAVA_OPTS=-XX:MaxPermSize=1g -Xmx2g
   - cmd: mvn --version
   - cmd: java -version


### PR DESCRIPTION
Since June 18 TSL 1.0 & 1.1 are not supported by Maven Central and that causes the Java7 build to fail in AppVeyour.
Added `-Dhttps.protocols=TLSv1.2` to force use of TSL v1.2 and a note to remind us to remove it once we don't support Java7.
