### PR TITLE
Added new feature to fail based on different conditions

### DIFF
--- a/README.adoc
+++ b/README.adoc
@@ -227,6 +227,45 @@ Here follows a configuration example:
 NOTE: Extensions can also be integrated through the SPI interface implementation.
 This method does not require any configuration in the [.path]_pom.xml_, see link:https://github.com/asciidoctor/asciidoctorj#extension-spi[Extension SPI] for details.
 
+logHandler:: enables processing of Asciidoctor messages (e.g. errors on missing included files), to hide messages as well setup build fail conditions based on them.
+Contains the following configuration elements:
+
+* `outputToConsole`: `Boolean`, defaults to `true`.
+Redirects all Asciidoctor messages to Maven's console logger as INFO during renderization.
+* `failIf`: build fail conditions, disabled by default.
+Allows setting one or many conditions that when met, abort the Maven build with `BUILD FAILURE` status.
++
+[NOTE]
+====
+Note that the plugin matches that all conditions are met together.
+Unless you are controlling a very specific case, setting one condition should be enough. +
+Also, messages matching fail conditions will be sent to Maven's logger as ERROR.
+So, when enabling `outputToConsole`, some messages will appear duplicated as both INFO and ERROR.
+====
++
+Currently, two conditions can be defined:
+
+** `severity`: severity of the Asciidoctor message, in order: `INFO`,`WARN`,`ERROR`,`FATAL`,`UNKNOWN`.
+Build will fail if a message is found of severity equal or higher.
+
+** `containsText`: text to search inside messages.
+Build will fail if the text is found. +
+For example, set `include` to fail on any issue related to included files regardless the severity level.
++
+[source,xml]
+.example: fail on any message
+----
+<logHandler>
+    <outputToConsole>false</outputToConsole> <!--1-->
+    <failIf>
+        <severity>DEBUG</severity> <!--2-->
+    </failIf>
+</logHandler>
+----
+<1> Do not show messages as INFO in Maven output
+<2> Build will fail on any message of severity `DEBUG` or higher, that includes all.
+All matching messages will appear as ERROR in Maven output.
+
 ==== Built-in attributes
 
 There are various attributes Asciidoctor recognizes.

--- a/pom.xml
+++ b/pom.xml
@@ -61,11 +61,11 @@
         <project.execution.environment>JavaSE-1.7</project.execution.environment>
         <spock.version>0.7-groovy-2.0</spock.version>
         <groovy.version>2.1.3</groovy.version>
-        <asciidoctorj.version>1.5.6</asciidoctorj.version>
+        <asciidoctorj.version>1.5.7</asciidoctorj.version>
         <maven.coveralls.plugin.version>4.3.0</maven.coveralls.plugin.version>
         <maven.jacoco.plugin.version>0.7.9</maven.jacoco.plugin.version>
-        <jruby.version>1.7.26</jruby.version>
-        <maven.plugin.plugin.version>3.4</maven.plugin.plugin.version>
+        <jruby.version>9.1.16.0</jruby.version>
+        <maven.plugin.plugin.version>3.5</maven.plugin.plugin.version>
         <maven.project.version>3.0.5</maven.project.version>
         <maven.compiler.plugin.version>3.7.0</maven.compiler.plugin.version>
         <maven.filtering.version>3.1.1</maven.filtering.version>

--- a/src/it/spi-registered-log/asciidoctor-project/pom.xml
+++ b/src/it/spi-registered-log/asciidoctor-project/pom.xml
@@ -1,0 +1,52 @@
+<project xmlns="http://maven.apache.org/POM/4.0.0" xmlns:xsi="http://www.w3.org/2001/XMLSchema-instance"
+         xsi:schemaLocation="http://maven.apache.org/POM/4.0.0 http://maven.apache.org/maven-v4_0_0.xsd">
+    <modelVersion>4.0.0</modelVersion>
+
+    <groupId>org.asciidoctor</groupId>
+    <artifactId>asciidoctor-project</artifactId>
+    <version>1.0-SNAPSHOT</version>
+
+    <parent>
+        <groupId>org.asciidoctor</groupId>
+        <artifactId>test-parent</artifactId>
+        <version>1.0-SNAPSHOT</version>
+    </parent>
+
+    <description>Runs asciidoctor-maven-plugin:process-asciidoc</description>
+
+    <properties>
+        <project.build.sourceEncoding>UTF-8</project.build.sourceEncoding>
+    </properties>
+
+    <build>
+        <plugins>
+            <plugin>
+                <groupId>org.asciidoctor</groupId>
+                <artifactId>asciidoctor-maven-plugin</artifactId>
+                <version>@project.version@</version>
+                <executions>
+                    <execution>
+                        <id>html</id>
+                        <phase>generate-resources</phase>
+                        <goals>
+                            <goal>process-asciidoc</goal>
+                        </goals>
+                        <configuration>
+                            <sourceDirectory>src/main/doc</sourceDirectory>
+                            <outputDirectory>target/docs</outputDirectory>
+                            <backend>html</backend>
+                        </configuration>
+                    </execution>
+                </executions>
+                <dependencies>
+                    <dependency>
+                        <groupId>org.asciidoctor</groupId>
+                        <artifactId>log-handler</artifactId>
+                        <version>1.0-SNAPSHOT</version>
+                    </dependency>
+                </dependencies>
+            </plugin>
+        </plugins>
+    </build>
+
+</project>

--- a/src/it/spi-registered-log/asciidoctor-project/src/main/doc/sample.asciidoc
+++ b/src/it/spi-registered-log/asciidoctor-project/src/main/doc/sample.asciidoc
@@ -1,0 +1,29 @@
+Document Title
+==============
+Doc Writer <thedoc@asciidoctor.org>
+:idprefix: id_
+
+Preamble paragraph.
+
+NOTE: This is test, only a test.
+
+== Section A
+
+*Section A* paragraph.
+
+=== Section A Subsection
+
+*Section A* 'subsection' paragraph.
+
+== Section B
+
+*Section B* paragraph.
+
+.Section B list
+* Item 1
+* Item 2
+* Item 3
+
+== Missing include
+
+include::something.adoc[]

--- a/src/it/spi-registered-log/invoker.properties
+++ b/src/it/spi-registered-log/invoker.properties
@@ -1,0 +1,1 @@
+invoker.goals=clean compile

--- a/src/it/spi-registered-log/log-handler/pom.xml
+++ b/src/it/spi-registered-log/log-handler/pom.xml
@@ -1,0 +1,52 @@
+<project xmlns="http://maven.apache.org/POM/4.0.0" xmlns:xsi="http://www.w3.org/2001/XMLSchema-instance"
+         xsi:schemaLocation="http://maven.apache.org/POM/4.0.0 http://maven.apache.org/maven-v4_0_0.xsd">
+    <modelVersion>4.0.0</modelVersion>
+
+    <groupId>org.asciidoctor</groupId>
+    <artifactId>log-handler</artifactId>
+    <version>1.0-SNAPSHOT</version>
+
+    <parent>
+        <groupId>org.asciidoctor</groupId>
+        <artifactId>test-parent</artifactId>
+        <version>1.0-SNAPSHOT</version>
+    </parent>
+
+    <description>Implements a custom AsciidoctorJ LogHandler</description>
+
+    <properties>
+        <project.build.sourceEncoding>UTF-8</project.build.sourceEncoding>
+        <project.java.version>1.7</project.java.version>
+        <maven.compiler.plugin.version>3.7.0</maven.compiler.plugin.version>
+        <asciidoctorj.version>1.5.7</asciidoctorj.version>
+    </properties>
+
+    <build>
+        <plugins>
+            <plugin>
+                <groupId>org.apache.maven.plugins</groupId>
+                <artifactId>maven-compiler-plugin</artifactId>
+                <version>${maven.compiler.plugin.version}</version>
+                <configuration>
+                    <source>${project.java.version}</source>
+                    <target>${project.java.version}</target>
+                </configuration>
+            </plugin>
+        </plugins>
+    </build>
+
+    <dependencies>
+        <dependency>
+            <groupId>org.asciidoctor</groupId>
+            <artifactId>asciidoctorj</artifactId>
+            <version>${asciidoctorj.version}</version>
+        </dependency>
+        <!-- Include to use MojoExecutionException, MojoFailureException and cause Build failures integrated with maven -->
+        <dependency>
+            <groupId>org.apache.maven</groupId>
+            <artifactId>maven-plugin-api</artifactId>
+            <version>3.0.5</version>
+        </dependency>
+    </dependencies>
+
+</project>

--- a/src/it/spi-registered-log/log-handler/src/main/java/org/asciidoctor/maven/test/TestLogHandlerService.java
+++ b/src/it/spi-registered-log/log-handler/src/main/java/org/asciidoctor/maven/test/TestLogHandlerService.java
@@ -1,0 +1,53 @@
+package org.asciidoctor.maven.test;
+
+import org.asciidoctor.log.LogHandler;
+import org.asciidoctor.log.LogRecord;
+
+import java.io.File;
+import java.io.FileNotFoundException;
+import java.io.FileOutputStream;
+import java.io.IOException;
+import java.util.ArrayList;
+import java.util.List;
+
+public class TestLogHandlerService implements LogHandler {
+
+    public static final String CUSTOM_LOG = "custom_log.log";
+
+    final FileOutputStream logFile;
+
+    private static List<LogRecord> logRecords = new ArrayList<>();
+
+    public static List<LogRecord> getLogRecords() {
+        return logRecords;
+    }
+
+    public static void clear() {
+        logRecords.clear();
+    }
+
+    public TestLogHandlerService() {
+        try {
+            logFile = new FileOutputStream(new File(CUSTOM_LOG));
+        } catch (FileNotFoundException e) {
+            throw new RuntimeException(e);
+        }
+    }
+
+    @Override
+    public void log(LogRecord logRecord) {
+        writeLine("Logging from TestLogHandlerService: " + logRecord.getMessage());
+        logRecords.add(logRecord);
+    }
+
+    private void writeLine(String message) {
+        try {
+            logFile.write(message.getBytes());
+            logFile.flush();
+            logFile.close();
+        } catch (IOException e) {
+            e.printStackTrace();
+        }
+    }
+
+}

--- a/src/it/spi-registered-log/log-handler/src/main/resources/META-INF/services/_org.asciidoctor.extension.spi.ExtensionRegistry
+++ b/src/it/spi-registered-log/log-handler/src/main/resources/META-INF/services/_org.asciidoctor.extension.spi.ExtensionRegistry
@@ -1,0 +1,1 @@
+org.asciidoctor.maven.test.processors.AutoregisteredProcessor

--- a/src/it/spi-registered-log/log-handler/src/main/resources/META-INF/services/org.asciidoctor.log.LogHandler
+++ b/src/it/spi-registered-log/log-handler/src/main/resources/META-INF/services/org.asciidoctor.log.LogHandler
@@ -1,0 +1,1 @@
+org.asciidoctor.maven.test.TestLogHandlerService

--- a/src/it/spi-registered-log/pom.xml
+++ b/src/it/spi-registered-log/pom.xml
@@ -1,0 +1,21 @@
+<project xmlns="http://maven.apache.org/POM/4.0.0" xmlns:xsi="http://www.w3.org/2001/XMLSchema-instance"
+         xsi:schemaLocation="http://maven.apache.org/POM/4.0.0 http://maven.apache.org/maven-v4_0_0.xsd">
+    <modelVersion>4.0.0</modelVersion>
+
+    <groupId>org.asciidoctor</groupId>
+    <artifactId>test-parent</artifactId>
+    <version>1.0-SNAPSHOT</version>
+    <packaging>pom</packaging>
+
+    <description>Tests SPI registration of an AsciidoctorJ LogHandler</description>
+
+    <properties>
+        <project.build.sourceEncoding>UTF-8</project.build.sourceEncoding>
+    </properties>
+
+    <modules>
+        <module>log-handler</module>
+        <module>asciidoctor-project</module>
+    </modules>
+
+</project>

--- a/src/it/spi-registered-log/validate.groovy
+++ b/src/it/spi-registered-log/validate.groovy
@@ -1,0 +1,9 @@
+final def file = new File(basedir, "custom_log.log")
+
+if (!file.exists())
+    throw new Exception("Log file not initialized")
+
+if (!file.text.contains("Logging from TestLogHandlerService: include file not found:"))
+    throw new Exception("Expected LogHandler message not found in log file")
+
+return true

--- a/src/main/java/org/asciidoctor/maven/AsciidoctorMojo.java
+++ b/src/main/java/org/asciidoctor/maven/AsciidoctorMojo.java
@@ -256,7 +256,7 @@ public class AsciidoctorMojo extends AbstractMojo {
                     for (LogRecord record : records) {
                         getLog().error(LogRecordHelper.format(record, sourceDirectory));
                     }
-                    throw new MojoExecutionException(String.format("Found %s issue(s) matching severity %s and text '%s'", records.size(), severity, textToSearch));
+                    throw new MojoExecutionException(String.format("Found %s issue(s) matching severity %s or higher and text '%s'", records.size(), severity, textToSearch));
                 }
             } else if (logHandler.isSeveritySet()) {
                 final Severity severity = logHandler.getFailIf().getSeverity();
@@ -265,7 +265,7 @@ public class AsciidoctorMojo extends AbstractMojo {
                     for (LogRecord record : records) {
                         getLog().error(LogRecordHelper.format(record, sourceDirectory));
                     }
-                    throw new MojoExecutionException(String.format("Found %s issue(s) of severity %s during rendering", records.size(), severity));
+                    throw new MojoExecutionException(String.format("Found %s issue(s) of severity %s or higher during rendering", records.size(), severity));
                 }
             } else if (logHandler.isContainsTextNotBlank()) {
                 final String textToSearch = logHandler.getFailIf().getContainsText();

--- a/src/main/java/org/asciidoctor/maven/AsciidoctorMojo.java
+++ b/src/main/java/org/asciidoctor/maven/AsciidoctorMojo.java
@@ -42,6 +42,7 @@ import org.sonatype.plexus.build.incremental.BuildContext;
 import java.io.File;
 import java.io.IOException;
 import java.util.*;
+import java.util.logging.Logger;
 
 
 /**
@@ -234,6 +235,8 @@ public class AsciidoctorMojo extends AbstractMojo {
         final MemoryLogHandler memoryLogHandler = new MemoryLogHandler(outputToConsole, sourceDirectory, getLog());
         if (!sourceFiles.isEmpty()) {
             asciidoctor.registerLogHandler(memoryLogHandler);
+            // disable default console output of AsciidoctorJ
+            Logger.getLogger("asciidoctor").setUseParentHandlers(false);
         }
 
         for (final File source : sourceFiles) {

--- a/src/main/java/org/asciidoctor/maven/AsciidoctorMojo.java
+++ b/src/main/java/org/asciidoctor/maven/AsciidoctorMojo.java
@@ -27,10 +27,15 @@ import org.apache.maven.shared.filtering.MavenResourcesExecution;
 import org.apache.maven.shared.filtering.MavenResourcesFiltering;
 import org.asciidoctor.*;
 import org.asciidoctor.internal.JRubyRuntimeContext;
+import org.asciidoctor.log.LogRecord;
+import org.asciidoctor.log.Severity;
 import org.asciidoctor.maven.extensions.AsciidoctorJExtensionRegistry;
 import org.asciidoctor.maven.extensions.ExtensionConfiguration;
 import org.asciidoctor.maven.extensions.ExtensionRegistry;
 import org.asciidoctor.maven.io.AsciidoctorFileScanner;
+import org.asciidoctor.maven.log.LogHandler;
+import org.asciidoctor.maven.log.LogRecordHelper;
+import org.asciidoctor.maven.log.MemoryLogHandler;
 import org.jruby.Ruby;
 import org.sonatype.plexus.build.incremental.BuildContext;
 
@@ -157,6 +162,9 @@ public class AsciidoctorMojo extends AbstractMojo {
     @Parameter(defaultValue = "${session}", readonly = true, required = true)
     protected MavenSession session;
 
+    @Parameter
+    private LogHandler logHandler = new LogHandler();
+
     @Component
     protected MavenResourcesFiltering outputResourcesFiltering;
 
@@ -220,12 +228,52 @@ public class AsciidoctorMojo extends AbstractMojo {
                 scanSourceFiles() : Arrays.asList(new File(sourceDirectory, sourceDocumentName));
 
         final Set<File> dirs = new HashSet<File>();
+
+        // register LogHandler to capture asciidoctor messages
+        final Boolean outputToConsole = logHandler == null ? Boolean.TRUE : logHandler.getOutputToConsole();
+        final MemoryLogHandler memoryLogHandler = new MemoryLogHandler(outputToConsole, sourceDirectory, getLog());
+        if (!sourceFiles.isEmpty()) {
+            asciidoctor.registerLogHandler(memoryLogHandler);
+        }
+
         for (final File source : sourceFiles) {
             final File destinationPath = setDestinationPaths(optionsBuilder, source);
             if (!dirs.add(destinationPath))
                 getLog().warn("Duplicated destination found: overwriting file: " + destinationPath.getAbsolutePath());
 
             renderFile(asciidoctor, optionsBuilder.asMap(), source);
+
+            // process log messages according to mojo configuration
+            if (logHandler.isSeveritySet() && logHandler.isContainsTextNotBlank()) {
+                final Severity severity = logHandler.getFailIf().getSeverity();
+                final String textToSearch = logHandler.getFailIf().getContainsText();
+
+                final List<LogRecord> records = memoryLogHandler.filter(severity, textToSearch);
+                if (records.size() > 0) {
+                    for (LogRecord record : records) {
+                        getLog().error(LogRecordHelper.format(record, sourceDirectory));
+                    }
+                    throw new MojoExecutionException(String.format("Found %s issue(s) matching severity %s and text '%s'", records.size(), severity, textToSearch));
+                }
+            } else if (logHandler.isSeveritySet()) {
+                final Severity severity = logHandler.getFailIf().getSeverity();
+                final List<LogRecord> records = memoryLogHandler.filter(severity);
+                if (records.size() > 0) {
+                    for (LogRecord record : records) {
+                        getLog().error(LogRecordHelper.format(record, sourceDirectory));
+                    }
+                    throw new MojoExecutionException(String.format("Found %s issue(s) of severity %s during rendering", records.size(), severity));
+                }
+            } else if (logHandler.isContainsTextNotBlank()) {
+                final String textToSearch = logHandler.getFailIf().getContainsText();
+                final List<LogRecord> records = memoryLogHandler.filter(textToSearch);
+                if (records.size() > 0) {
+                    for (LogRecord record : records) {
+                        getLog().error(LogRecordHelper.format(record, sourceDirectory));
+                    }
+                    throw new MojoExecutionException(String.format("Found %s issue(s) containing '%s'", records.size(), textToSearch));
+                }
+            }
         }
 
         if (synchronizations != null && !synchronizations.isEmpty()) {

--- a/src/main/java/org/asciidoctor/maven/log/FailIf.java
+++ b/src/main/java/org/asciidoctor/maven/log/FailIf.java
@@ -1,0 +1,25 @@
+package org.asciidoctor.maven.log;
+
+import org.asciidoctor.log.Severity;
+
+public class FailIf {
+
+    private Severity severity;
+    private String containsText;
+
+    public Severity getSeverity() {
+        return severity;
+    }
+
+    public void setSeverity(Severity severity) {
+        this.severity = severity;
+    }
+
+    public String getContainsText() {
+        return containsText;
+    }
+
+    public void setContainsText(String containsText) {
+        this.containsText = containsText;
+    }
+}

--- a/src/main/java/org/asciidoctor/maven/log/LogHandler.java
+++ b/src/main/java/org/asciidoctor/maven/log/LogHandler.java
@@ -1,0 +1,34 @@
+package org.asciidoctor.maven.log;
+
+import org.apache.commons.lang.StringUtils;
+
+public class LogHandler {
+
+    private Boolean outputToConsole;
+    private FailIf failIf;
+
+    public Boolean getOutputToConsole() {
+        return outputToConsole;
+    }
+
+    public void setOutputToConsole(Boolean outputToConsole) {
+        this.outputToConsole = outputToConsole;
+    }
+
+    public FailIf getFailIf() {
+        return failIf;
+    }
+
+    public void setFailIf(FailIf failIf) {
+        this.failIf = failIf;
+    }
+
+    public boolean isSeveritySet() {
+        return failIf != null && failIf.getSeverity() != null;
+    }
+
+    public boolean isContainsTextNotBlank() {
+        return failIf != null && StringUtils.isNotBlank(failIf.getContainsText());
+    }
+
+}

--- a/src/main/java/org/asciidoctor/maven/log/LogRecordHelper.java
+++ b/src/main/java/org/asciidoctor/maven/log/LogRecordHelper.java
@@ -1,0 +1,42 @@
+package org.asciidoctor.maven.log;
+
+import org.asciidoctor.ast.Cursor;
+import org.asciidoctor.log.LogRecord;
+
+import java.io.File;
+import java.io.IOException;
+
+/**
+ * Utility class to manage AsciidoctorJ LogRecords.
+ */
+public class LogRecordHelper {
+
+    public static final String ASCIIDOCTOR_LOG_FORMAT = "asciidoctor: %s: %s: line %s: %s";
+
+    /**
+     * Formats the logRecords in a similar manner to original Asciidoctor.
+     * Note: prints the absolute path of the file.
+     */
+    public static String format(LogRecord logRecord) {
+        final Cursor cursor = logRecord.getCursor();
+        return String.format(ASCIIDOCTOR_LOG_FORMAT, logRecord.getSeverity(), cursor.getFile(), cursor.getLineNumber(), logRecord.getMessage());
+    }
+
+    /**
+     * Formats the logRecords in a similar manner to original Asciidoctor.
+     * Note: prints the relative path of the file to `sourceDirectory`.
+     */
+    public static String format(LogRecord logRecord, File sourceDirectory) {
+        final Cursor cursor = logRecord.getCursor();
+        String relativePath;
+        try {
+            relativePath = new File(cursor.getFile()).getCanonicalPath()
+                    .substring(sourceDirectory.getCanonicalPath().length() + 1);
+        } catch (IOException e) {
+            // use the absolute path as fail-safe
+            relativePath = cursor.getFile();
+        }
+        return String.format(ASCIIDOCTOR_LOG_FORMAT, logRecord.getSeverity(), relativePath, cursor.getLineNumber(), logRecord.getMessage());
+    }
+
+}

--- a/src/main/java/org/asciidoctor/maven/log/MemoryLogHandler.java
+++ b/src/main/java/org/asciidoctor/maven/log/MemoryLogHandler.java
@@ -1,0 +1,78 @@
+package org.asciidoctor.maven.log;
+
+import org.apache.maven.plugin.logging.Log;
+import org.asciidoctor.log.LogHandler;
+import org.asciidoctor.log.LogRecord;
+import org.asciidoctor.log.Severity;
+
+import java.io.File;
+import java.util.ArrayList;
+import java.util.List;
+
+
+/**
+ * AsciidoctorJ LogHandler that stores records in memory.
+ */
+public class MemoryLogHandler implements LogHandler {
+
+    final List<LogRecord> records = new ArrayList<>();
+
+    private final Boolean outputToConsole;
+    private final File sourceDirectory;
+    private final Log log;
+
+    public MemoryLogHandler(Boolean outputToConsole, File sourceDirectory, Log log) {
+        this.outputToConsole = outputToConsole == null ? Boolean.FALSE : outputToConsole;
+        this.sourceDirectory = sourceDirectory;
+        this.log = log;
+    }
+
+    @Override
+    public void log(LogRecord logRecord) {
+        records.add(logRecord);
+        if (outputToConsole)
+            log.info(LogRecordHelper.format(logRecord, sourceDirectory));
+    }
+
+    public void clear() {
+        records.clear();
+    }
+
+    /**
+     * Returns LogRecords that belong to a severity level
+     */
+    public List<LogRecord> filter(Severity severity) {
+        // FIXME: find better name or replace with stream
+        final List<LogRecord> records = new ArrayList<>();
+        for (LogRecord record : this.records) {
+            if (record.getSeverity().equals(severity))
+                records.add(record);
+        }
+        return records;
+    }
+
+    /**
+     * Returns LogRecords whose message contains a text
+     */
+    public List<LogRecord> filter(String text) {
+        final List<LogRecord> records = new ArrayList<>();
+        for (LogRecord record : this.records) {
+            if (record.getMessage().contains(text))
+                records.add(record);
+        }
+        return records;
+    }
+
+    /**
+     * Returns LogRecords that belong to a severity level & whose message contains a text
+     */
+    public List<LogRecord> filter(Severity severity, String text) {
+        final List<LogRecord> records = new ArrayList<>();
+        for (LogRecord record : this.records) {
+            if (record.getSeverity().equals(severity) && record.getMessage().contains(text))
+                records.add(record);
+        }
+        return records;
+    }
+
+}

--- a/src/main/java/org/asciidoctor/maven/log/MemoryLogHandler.java
+++ b/src/main/java/org/asciidoctor/maven/log/MemoryLogHandler.java
@@ -39,20 +39,20 @@ public class MemoryLogHandler implements LogHandler {
     }
 
     /**
-     * Returns LogRecords that belong to a severity level
+     * Returns LogRecords that are equal or above the severity level
      */
     public List<LogRecord> filter(Severity severity) {
         // FIXME: find better name or replace with stream
         final List<LogRecord> records = new ArrayList<>();
         for (LogRecord record : this.records) {
-            if (record.getSeverity().equals(severity))
+            if (record.getSeverity().getRubyId() >= severity.getRubyId())
                 records.add(record);
         }
         return records;
     }
 
     /**
-     * Returns LogRecords whose message contains a text
+     * Returns LogRecords whose message contains text
      */
     public List<LogRecord> filter(String text) {
         final List<LogRecord> records = new ArrayList<>();
@@ -64,12 +64,12 @@ public class MemoryLogHandler implements LogHandler {
     }
 
     /**
-     * Returns LogRecords that belong to a severity level & whose message contains a text
+     * Returns LogRecords that are equal or above the severity level & whose message contains text
      */
     public List<LogRecord> filter(Severity severity, String text) {
         final List<LogRecord> records = new ArrayList<>();
         for (LogRecord record : this.records) {
-            if (record.getSeverity().equals(severity) && record.getMessage().contains(text))
+            if (record.getSeverity().getRubyId() >= severity.getRubyId() && record.getMessage().contains(text))
                 records.add(record);
         }
         return records;

--- a/src/test/groovy/org/asciidoctor/maven/test/AsciidoctorHttpMojoTest.groovy
+++ b/src/test/groovy/org/asciidoctor/maven/test/AsciidoctorHttpMojoTest.groovy
@@ -11,19 +11,8 @@ import java.util.concurrent.CountDownLatch
 
 class AsciidoctorHttpMojoTest extends Specification {
 
-    /**
-     * Intercept Asciidoctor mojo constructor to mock and inject required
-     * plexus objects
-     */
     def setupSpec() {
-        MockPlexusContainer mockPlexusContainer = new MockPlexusContainer()
-        def oldConstructor = AsciidoctorHttpMojo.constructors[0]
-
-        AsciidoctorHttpMojo.metaClass.constructor = {
-            def mojo = oldConstructor.newInstance()
-            mockPlexusContainer.initializeContext(mojo)
-            return mojo
-        }
+        MockPlexusContainer.initializeMockContext(AsciidoctorHttpMojo)
     }
 
     def "http front should let access rendered files"() {

--- a/src/test/groovy/org/asciidoctor/maven/test/AsciidoctorMojoExtensionsTest.groovy
+++ b/src/test/groovy/org/asciidoctor/maven/test/AsciidoctorMojoExtensionsTest.groovy
@@ -2,7 +2,6 @@ package org.asciidoctor.maven.test
 
 import org.apache.maven.plugin.MojoExecutionException
 import org.asciidoctor.maven.AsciidoctorMojo
-import org.asciidoctor.maven.AsciidoctorZipMojo
 import org.asciidoctor.maven.extensions.ExtensionConfiguration
 import org.asciidoctor.maven.test.plexus.MockPlexusContainer
 import org.asciidoctor.maven.test.processors.ChangeAttributeValuePreprocessor
@@ -26,19 +25,8 @@ import spock.lang.Unroll
  */
 class AsciidoctorMojoExtensionsTest extends Specification {
 
-    /**
-     * Intercept Asciidoctor mojo constructor to mock and inject required
-     * plexus objects
-     */
     def setupSpec() {
-        MockPlexusContainer mockPlexusContainer = new MockPlexusContainer()
-        def oldConstructor = AsciidoctorMojo.constructors[0]
-
-        AsciidoctorMojo.metaClass.constructor = {
-            def mojo = oldConstructor.newInstance()
-            mockPlexusContainer.initializeContext(mojo)
-            return mojo
-        }
+        MockPlexusContainer.initializeMockContext(AsciidoctorMojo)
     }
 
     static final String SRC_DIR = 'target/test-classes/src/asciidoctor/'
@@ -397,7 +385,7 @@ class AsciidoctorMojoExtensionsTest extends Specification {
 
     /**
      *  Manual test to validate automatic extension registration.
-     *  To execute, copy org.asciidoctor.extension.spi.ExtensionRegistry to 
+     *  To execute, copy _org.asciidoctor.extension.spi.ExtensionRegistry to
      *  /src/test/resources/META-INF/services/ and execute
      */
     @spock.lang.Ignore

--- a/src/test/groovy/org/asciidoctor/maven/test/AsciidoctorMojoLogHandlerTest.groovy
+++ b/src/test/groovy/org/asciidoctor/maven/test/AsciidoctorMojoLogHandlerTest.groovy
@@ -1,0 +1,235 @@
+package org.asciidoctor.maven.test
+
+import org.apache.maven.plugin.MojoExecutionException
+import org.asciidoctor.maven.AsciidoctorMojo
+import org.asciidoctor.maven.log.LogHandler
+import org.asciidoctor.maven.test.plexus.MockPlexusContainer
+import spock.lang.Specification
+
+import static org.asciidoctor.log.Severity.ERROR
+import static org.asciidoctor.log.Severity.WARN
+
+/**
+ *
+ */
+class AsciidoctorMojoLogHandlerTest extends Specification {
+
+    static final String DEFAULT_SOURCE_DIRECTORY = 'target/test-classes/src/asciidoctor'
+
+    def setupSpec() {
+        MockPlexusContainer.initializeMockContext(AsciidoctorMojo)
+    }
+
+    def "should not fail when logHandler is not set"() {
+        setup:
+        String sourceDocument = 'errors/document-with-missing-include.adoc'
+        File srcDir = new File(DEFAULT_SOURCE_DIRECTORY)
+        File outputDir = new File("target/asciidoctor-output/${System.currentTimeMillis()}")
+
+        when:
+        AsciidoctorMojo mojo = new AsciidoctorMojo()
+        mojo.backend = 'html'
+        mojo.sourceDirectory = srcDir
+        mojo.sourceDocumentName = sourceDocument
+        mojo.outputDirectory = outputDir
+        mojo.headerFooter = true
+        mojo.attributes['toc'] = null
+        mojo.execute()
+
+        then: 'process completes but the document contains errors'
+        def file = new File(outputDir, 'document-with-missing-include.html')
+        file.exists()
+        file.text.contains('<p>Unresolved directive in document-with-missing-include.adoc - include::unexistingdoc.adoc[]</p>')
+    }
+
+    def "should not fail & log errors as INFO when outputToConsole is set"() {
+        setup:
+        def originalOut = System.out
+        def newOut = new ByteArrayOutputStream()
+        System.setOut(new PrintStream(newOut))
+
+        String sourceDocument = 'errors/document-with-missing-include.adoc'
+        File srcDir = new File(DEFAULT_SOURCE_DIRECTORY)
+        File outputDir = new File("target/asciidoctor-output/${System.currentTimeMillis()}")
+        def handler = new LogHandler()
+        handler.outputToConsole = true
+
+        when:
+        AsciidoctorMojo mojo = new AsciidoctorMojo()
+        mojo.backend = 'html'
+        mojo.sourceDirectory = srcDir
+        mojo.sourceDocumentName = sourceDocument
+        mojo.outputDirectory = outputDir
+        mojo.headerFooter = true
+        mojo.attributes['toc'] = null
+        mojo.logHandler = handler
+        mojo.execute()
+
+        then: 'output file exists & shows include error'
+        def file = new File(outputDir, 'document-with-missing-include.html')
+        file.exists()
+        file.text.contains('<p>Unresolved directive in document-with-missing-include.adoc - include::unexistingdoc.adoc[]</p>')
+
+        and: 'all messages (ERR & WARN) are logged as info'
+        def consoleOutput = newOut.toString()
+        consoleOutput.contains('[info] asciidoctor: ERROR: errors\\document-with-missing-include.adoc: line 3: include file not found:')
+        consoleOutput.contains('[info] asciidoctor: ERROR: errors\\document-with-missing-include.adoc: line 5: include file not found:')
+        consoleOutput.contains('[info] asciidoctor: ERROR: errors\\document-with-missing-include.adoc: line 9: include file not found:')
+        consoleOutput.contains('[info] asciidoctor: WARN: errors\\document-with-missing-include.adoc: line 25: no callout found for <1>')
+
+        cleanup:
+        System.setOut(originalOut)
+    }
+
+    def "should fail when logHandler failIf = WARNING"() {
+        setup:
+        String sourceDocument = 'errors/document-with-missing-include.adoc'
+        File srcDir = new File(DEFAULT_SOURCE_DIRECTORY)
+        File outputDir = new File("target/asciidoctor-output/${System.currentTimeMillis()}")
+        def handler = new LogHandler()
+        handler.failIf = [severity: WARN]
+
+        when:
+        AsciidoctorMojo mojo = new AsciidoctorMojo()
+        mojo.backend = 'html'
+        mojo.sourceDirectory = srcDir
+        mojo.sourceDocumentName = sourceDocument
+        mojo.outputDirectory = outputDir
+        mojo.headerFooter = true
+        mojo.attributes['toc'] = null
+        mojo.logHandler = handler
+        mojo.execute()
+
+        then:
+        def e = thrown(MojoExecutionException)
+        e.message.contains('Found 1 issue(s) of severity WARN during rendering')
+    }
+
+    def "should fail when logHandler failIf = ERROR"() {
+        setup:
+        String sourceDocument = 'errors/document-with-missing-include.adoc'
+        File srcDir = new File(DEFAULT_SOURCE_DIRECTORY)
+        File outputDir = new File("target/asciidoctor-output/${System.currentTimeMillis()}")
+        def handler = new LogHandler()
+        handler.failIf = [severity: ERROR]
+
+        when:
+        AsciidoctorMojo mojo = new AsciidoctorMojo()
+        mojo.backend = 'html'
+        mojo.sourceDirectory = srcDir
+        mojo.sourceDocumentName = sourceDocument
+        mojo.outputDirectory = outputDir
+        mojo.headerFooter = true
+        mojo.attributes['toc'] = null
+        mojo.logHandler = handler
+        mojo.execute()
+
+        then:
+        def e = thrown(MojoExecutionException)
+        e.message.contains('Found 3 issue(s) of severity ERROR during rendering')
+    }
+
+    def "should not fail if containsText does not match any message"() {
+        setup:
+        String sourceDocument = 'errors/document-with-missing-include.adoc'
+        File srcDir = new File(DEFAULT_SOURCE_DIRECTORY)
+        File outputDir = new File("target/asciidoctor-output/${System.currentTimeMillis()}")
+        def handler = new LogHandler()
+        handler.failIf = [containsText: 'here is some random text']
+
+        when:
+        AsciidoctorMojo mojo = new AsciidoctorMojo()
+        mojo.backend = 'html'
+        mojo.sourceDirectory = srcDir
+        mojo.sourceDocumentName = sourceDocument
+        mojo.outputDirectory = outputDir
+        mojo.headerFooter = true
+        mojo.attributes['toc'] = null
+        mojo.logHandler = handler
+        mojo.execute()
+
+        then:
+        def file = new File(outputDir, 'document-with-missing-include.html')
+        file.exists()
+        file.text.contains('<p>Unresolved directive in document-with-missing-include.adoc - include::unexistingdoc.adoc[]</p>')
+    }
+
+    def "should fail when containsText matches"() {
+        setup:
+        def originalOut = System.out
+        def newOut = new ByteArrayOutputStream()
+        System.setErr(new PrintStream(newOut))
+
+        String sourceDocument = 'errors/document-with-missing-include.adoc'
+        File srcDir = new File(DEFAULT_SOURCE_DIRECTORY)
+        File outputDir = new File("target/asciidoctor-output/${System.currentTimeMillis()}")
+        def handler = new LogHandler()
+        handler.failIf = [containsText: 'include file not found']
+
+        when:
+        AsciidoctorMojo mojo = new AsciidoctorMojo()
+        mojo.backend = 'html'
+        mojo.sourceDirectory = srcDir
+        mojo.sourceDocumentName = sourceDocument
+        mojo.outputDirectory = outputDir
+        mojo.headerFooter = true
+        mojo.attributes['toc'] = null
+        mojo.logHandler = handler
+        mojo.execute()
+
+        then:
+        new File(outputDir, 'document-with-missing-include.html').exists()
+        def e = thrown(MojoExecutionException)
+        e.message.contains("Found 3 issue(s) containing 'include file not found'")
+
+        and: 'all messages (ERR & WARN) are logged as error'
+        def consoleError = newOut.toString()
+
+        consoleError.contains('[error] asciidoctor: ERROR: errors\\document-with-missing-include.adoc: line 3: include file not found:')
+        consoleError.contains('[error] asciidoctor: ERROR: errors\\document-with-missing-include.adoc: line 5: include file not found:')
+        consoleError.contains('[error] asciidoctor: ERROR: errors\\document-with-missing-include.adoc: line 9: include file not found:')
+
+        cleanup:
+        System.setErr(originalOut)
+    }
+
+    def "should fail and filter errors that match both severity and text"() {
+        setup:
+        def originalOut = System.out
+        def newOut = new ByteArrayOutputStream()
+        System.setErr(new PrintStream(newOut))
+
+        String sourceDocument = 'errors/document-with-missing-include.adoc'
+        File srcDir = new File(DEFAULT_SOURCE_DIRECTORY)
+        File outputDir = new File("target/asciidoctor-output/${System.currentTimeMillis()}")
+        def handler = new LogHandler()
+        handler.failIf = [
+                severity       : WARN,
+                containsText: 'no'
+        ]
+
+        when:
+        AsciidoctorMojo mojo = new AsciidoctorMojo()
+        mojo.backend = 'html'
+        mojo.sourceDirectory = srcDir
+        mojo.sourceDocumentName = sourceDocument
+        mojo.outputDirectory = outputDir
+        mojo.headerFooter = true
+        mojo.attributes['toc'] = null
+        mojo.logHandler = handler
+        mojo.execute()
+
+        then:
+        new File(outputDir, 'document-with-missing-include.html').exists()
+        def e = thrown(MojoExecutionException)
+        e.message.contains("Found 1 issue(s) matching severity WARN and text 'no'")
+
+        and:
+        def consoleError = newOut.toString()
+        consoleError.contains('[error] asciidoctor: WARN: errors\\document-with-missing-include.adoc: line 25: no callout found for <1>')
+
+        cleanup:
+        System.setErr(originalOut)
+    }
+
+}

--- a/src/test/groovy/org/asciidoctor/maven/test/AsciidoctorMojoLogHandlerTest.groovy
+++ b/src/test/groovy/org/asciidoctor/maven/test/AsciidoctorMojoLogHandlerTest.groovy
@@ -100,9 +100,9 @@ class AsciidoctorMojoLogHandlerTest extends Specification {
         mojo.logHandler = handler
         mojo.execute()
 
-        then:
+        then: 'issues with WARN and ERROR are returned'
         def e = thrown(MojoExecutionException)
-        e.message.contains('Found 1 issue(s) of severity WARN during rendering')
+        e.message.contains('Found 4 issue(s) of severity WARN or higher during rendering')
     }
 
     def "should fail when logHandler failIf = ERROR"() {
@@ -126,7 +126,7 @@ class AsciidoctorMojoLogHandlerTest extends Specification {
 
         then:
         def e = thrown(MojoExecutionException)
-        e.message.contains('Found 3 issue(s) of severity ERROR during rendering')
+        e.message.contains('Found 3 issue(s) of severity ERROR or higher during rendering')
     }
 
     def "should not fail if containsText does not match any message"() {
@@ -222,7 +222,7 @@ class AsciidoctorMojoLogHandlerTest extends Specification {
         then:
         new File(outputDir, 'document-with-missing-include.html').exists()
         def e = thrown(MojoExecutionException)
-        e.message.contains("Found 1 issue(s) matching severity WARN and text 'no'")
+        e.message.contains("Found 4 issue(s) matching severity WARN or higher and text 'no'")
 
         and:
         def consoleError = newOut.toString()

--- a/src/test/groovy/org/asciidoctor/maven/test/AsciidoctorMojoLogHandlerTest.groovy
+++ b/src/test/groovy/org/asciidoctor/maven/test/AsciidoctorMojoLogHandlerTest.groovy
@@ -72,10 +72,10 @@ class AsciidoctorMojoLogHandlerTest extends Specification {
 
         and: 'all messages (ERR & WARN) are logged as info'
         def consoleOutput = newOut.toString()
-        consoleOutput.contains('[info] asciidoctor: ERROR: errors\\document-with-missing-include.adoc: line 3: include file not found:')
-        consoleOutput.contains('[info] asciidoctor: ERROR: errors\\document-with-missing-include.adoc: line 5: include file not found:')
-        consoleOutput.contains('[info] asciidoctor: ERROR: errors\\document-with-missing-include.adoc: line 9: include file not found:')
-        consoleOutput.contains('[info] asciidoctor: WARN: errors\\document-with-missing-include.adoc: line 25: no callout found for <1>')
+        consoleOutput.contains(fixOSseparator('[info] asciidoctor: ERROR: errors/document-with-missing-include.adoc: line 3: include file not found:'))
+        consoleOutput.contains(fixOSseparator('[info] asciidoctor: ERROR: errors/document-with-missing-include.adoc: line 5: include file not found:'))
+        consoleOutput.contains(fixOSseparator('[info] asciidoctor: ERROR: errors/document-with-missing-include.adoc: line 9: include file not found:'))
+        consoleOutput.contains(fixOSseparator('[info] asciidoctor: WARN: errors/document-with-missing-include.adoc: line 25: no callout found for <1>'))
 
         cleanup:
         System.setOut(originalOut)
@@ -185,9 +185,9 @@ class AsciidoctorMojoLogHandlerTest extends Specification {
         and: 'all messages (ERR & WARN) are logged as error'
         def consoleError = newOut.toString()
 
-        consoleError.contains('[error] asciidoctor: ERROR: errors\\document-with-missing-include.adoc: line 3: include file not found:')
-        consoleError.contains('[error] asciidoctor: ERROR: errors\\document-with-missing-include.adoc: line 5: include file not found:')
-        consoleError.contains('[error] asciidoctor: ERROR: errors\\document-with-missing-include.adoc: line 9: include file not found:')
+        consoleError.contains(fixOSseparator('[error] asciidoctor: ERROR: errors/document-with-missing-include.adoc: line 3: include file not found:'))
+        consoleError.contains(fixOSseparator('[error] asciidoctor: ERROR: errors/document-with-missing-include.adoc: line 5: include file not found:'))
+        consoleError.contains(fixOSseparator('[error] asciidoctor: ERROR: errors/document-with-missing-include.adoc: line 9: include file not found:'))
 
         cleanup:
         System.setErr(originalOut)
@@ -204,7 +204,7 @@ class AsciidoctorMojoLogHandlerTest extends Specification {
         File outputDir = new File("target/asciidoctor-output/${System.currentTimeMillis()}")
         def handler = new LogHandler()
         handler.failIf = [
-                severity       : WARN,
+                severity    : WARN,
                 containsText: 'no'
         ]
 
@@ -226,10 +226,14 @@ class AsciidoctorMojoLogHandlerTest extends Specification {
 
         and:
         def consoleError = newOut.toString()
-        consoleError.contains('[error] asciidoctor: WARN: errors\\document-with-missing-include.adoc: line 25: no callout found for <1>')
+        consoleError.contains(fixOSseparator('[error] asciidoctor: WARN: errors/document-with-missing-include.adoc: line 25: no callout found for <1>'))
 
         cleanup:
         System.setErr(originalOut)
+    }
+
+    private String fixOSseparator(String text) {
+        File.separatorChar == '\\' ? text.replaceAll("/", "\\\\") : text
     }
 
 }

--- a/src/test/groovy/org/asciidoctor/maven/test/AsciidoctorMojoTest.groovy
+++ b/src/test/groovy/org/asciidoctor/maven/test/AsciidoctorMojoTest.groovy
@@ -4,7 +4,6 @@ import groovy.io.FileType
 import org.apache.commons.io.FileUtils
 import org.apache.maven.model.Resource
 import org.asciidoctor.maven.AsciidoctorMojo
-import org.asciidoctor.maven.io.AsciidoctorFileScanner
 import org.asciidoctor.maven.test.plexus.MockPlexusContainer
 import spock.lang.Specification
 
@@ -16,19 +15,8 @@ class AsciidoctorMojoTest extends Specification {
     static final String DEFAULT_SOURCE_DIRECTORY = 'target/test-classes/src/asciidoctor'
     static final String MULTIPLE_RESOURCES_OUTPUT = 'target/asciidoctor-output/multiple-resources'
 
-    /**
-     * Intercept Asciidoctor mojo constructor to mock and inject required
-     * plexus objects
-     */
     def setupSpec() {
-        MockPlexusContainer mockPlexusContainer = new MockPlexusContainer()
-        def oldConstructor = AsciidoctorMojo.constructors[0]
-
-        AsciidoctorMojo.metaClass.constructor = {
-            def mojo = oldConstructor.newInstance()
-            mockPlexusContainer.initializeContext(mojo)
-            return mojo
-        }
+        MockPlexusContainer.initializeMockContext(AsciidoctorMojo)
     }
 
     def "renders docbook"() {

--- a/src/test/groovy/org/asciidoctor/maven/test/AsciidoctorRefreshMojoTest.groovy
+++ b/src/test/groovy/org/asciidoctor/maven/test/AsciidoctorRefreshMojoTest.groovy
@@ -10,19 +10,8 @@ import java.util.concurrent.CountDownLatch
 
 class AsciidoctorRefreshMojoTest extends Specification {
 
-    /**
-     * Intercept Asciidoctor mojo constructor to mock and inject required
-     * plexus objects
-     */
     def setupSpec() {
-        MockPlexusContainer mockPlexusContainer = new MockPlexusContainer()
-        def oldConstructor = AsciidoctorRefreshMojo.constructors[0]
-
-        AsciidoctorRefreshMojo.metaClass.constructor = {
-            def mojo = oldConstructor.newInstance()
-            mockPlexusContainer.initializeContext(mojo)
-            return mojo
-        }
+        MockPlexusContainer.initializeMockContext(AsciidoctorRefreshMojo)
     }
 
     def "auto render when source updated"() {

--- a/src/test/groovy/org/asciidoctor/maven/test/AsciidoctorZipMojoTest.groovy
+++ b/src/test/groovy/org/asciidoctor/maven/test/AsciidoctorZipMojoTest.groovy
@@ -12,19 +12,8 @@ import java.util.zip.ZipFile
  */
 class AsciidoctorZipMojoTest extends Specification {
 
-    /**
-     * Intercept Asciidoctor mojo constructor to mock and inject required
-     * plexus objects
-     */
     def setupSpec() {
-        MockPlexusContainer mockPlexusContainer = new MockPlexusContainer()
-        def oldConstructor = AsciidoctorZipMojo.constructors[0]
-
-        AsciidoctorZipMojo.metaClass.constructor = {
-            def mojo = oldConstructor.newInstance()
-            mockPlexusContainer.initializeContext(mojo)
-            return mojo
-        }
+        MockPlexusContainer.initializeMockContext(AsciidoctorZipMojo)
     }
 
     def "zip it"() {

--- a/src/test/groovy/org/asciidoctor/maven/test/plexus/MockPlexusContainer.groovy
+++ b/src/test/groovy/org/asciidoctor/maven/test/plexus/MockPlexusContainer.groovy
@@ -23,7 +23,7 @@ class MockPlexusContainer {
         Log logger = new SystemStreamLog()
     }
 
-    void initializeContext(AsciidoctorMojo mojo) {
+    private void initializeMojoContext(AsciidoctorMojo mojo) {
 
         mojo.@project = [
                 getBasedir: {
@@ -45,7 +45,21 @@ class MockPlexusContainer {
         resourceFilter.enableLogging(logger)
         mojo.encoding = "UTF-8"
         mojo.@outputResourcesFiltering = resourceFilter
+    }
 
+    /**
+     * Intercept Asciidoctor mojo constructor to mock and inject required plexus objects.
+     */
+    static MockPlexusContainer initializeMockContext(Class<?> clazz) {
+        final MockPlexusContainer mockPlexusContainer = new MockPlexusContainer()
+        def oldConstructor = clazz.constructors[0]
+
+        clazz.metaClass.constructor = {
+            def mojo = oldConstructor.newInstance()
+            mockPlexusContainer.initializeMojoContext(mojo)
+            return mojo
+        }
+        mockPlexusContainer
     }
 
 }

--- a/src/test/java/org/asciidoctor/maven/test/processors/ManpageInlineMacroProcessor.java
+++ b/src/test/java/org/asciidoctor/maven/test/processors/ManpageInlineMacroProcessor.java
@@ -13,7 +13,7 @@ public class ManpageInlineMacroProcessor extends InlineMacroProcessor {
     }
 
     @Override
-    protected String process(AbstractBlock parent, String target, Map<String, Object> attributes) {
+    public String process(AbstractBlock parent, String target, Map<String, Object> attributes) {
 
         Map<String, Object> options = new HashMap<String, Object>();
         options.put("type", ":link");

--- a/src/test/resources/src/asciidoctor/errors/document-with-missing-include.adoc
+++ b/src/test/resources/src/asciidoctor/errors/document-with-missing-include.adoc
@@ -1,0 +1,25 @@
+= My Document
+
+include::unexistingdoc.adoc[]
+
+include::unexistingdoc.adoc[]
+
+include::https://raw.githubusercontent.com/asciidoctor/asciidoctor-maven-plugin/master/src/test/resources/src/asciidoctor/github-include.adoc[]
+
+include::unexistingdoc.adoc[]
+
+
+== Code example
+
+[source,java]
+----
+public class HelloWorld {
+
+    public static void main(String[] args) {
+        // Prints "Hello, World" to the terminal window.
+        System.out.println("Hello, World");
+    }
+
+}
+----
+<1> Missing callout reference?


### PR DESCRIPTION
Addresses: https://github.com/asciidoctor/asciidoctor-maven-plugin/issues/261, https://github.com/asciidoctor/asciidoctor-maven-plugin/issues/178

_Features are complete, but there's an issue with duplicated asciidoctor messages https://github.com/asciidoctor/asciidoctorj/issues/669._ Depending on suggestions we can merge or review the feature.

**Feature summary**
This PR adds a new configuration element as follows:
```xml
<logHandler>
	<outputToConsole>true</outputToConsole>
	<failIf>
		<severity>WARNING</severity>
		<containsText>super-important-document.adoc</containsText>
	</failIf>
</logHandler>
```
* `outputToConsole`: redirects asciidoctor messages to maven's logger. Messages are shown as Maven's INFO during renderitzation. Messages will appear twice as mentioned in issue https://github.com/asciidoctor/asciidoctorj/issues/669.
* `severity`: named so to align with AsciidoctorJ property. Will make the build fail if a message of this severity level is found. ~~It only matches the exact level, not same and above. I did this for simplicity but I am open to suggestions, implementation is trivial.~~ I finally decided to filter all messages above certain level to allow capturing all messages easily, also, feels more natural to understand.
* `containsText`: named so instead of `matchesText` because it just asserts that, a `contains`. I considered the option of allowing regex, but this made configuration more complex and less expressive for simple cases like a simple contains. Adding regex options could be done with another option or some custom syntax in the field.

Note that if both  `severity` and `containsText` are set, only messages that match both are captured.
Messages that match `severity` and/or `containsText` are shown as Maven ERROR (independently from `outputToConsole`), so that CIs can capture them as cause of build fail. Also, an initial error message showing the number of issues found is returned.

If someone wants to create a custom report like mentioned in https://github.com/asciidoctor/asciidoctor-maven-plugin/issues/261, you can register a custom LogHandler using the SPI interface (added integration test for that). However, this has some limitations with some formats that need to "close" and estructure (see https://github.com/asciidoctor/asciidoctor/issues/2832).

**Other notes**

* Filenames are formated to show relative path from project sourceDirectory. I considered that showing the absolute path as provided by AsciidoctorJ logger bloates the messages. Showing full path could be enabled with a new boolean option in the <logHandler> sections if requested.
* Since `severity` and `containsText`  are validated after the renderitzation the target document (html, pdf, etc.) can be found in the target directory. I don't see any reason to delete it.
* I know the code is not the best, but can be improved in the future with Java8 features.


**Other changes to code**
* Updated AsciidoctorJ to 1.5.67 and updated `InlineMacroProcessor` test extension to new especification
* Aligned JRuby with AsciidoctorJ: updated `jruby-complete` to 9.1.16.0: updated `maven-plugin-plugin` from 3.4 to 3.5 to fix issue after updating `jruby-complete`
* Refactored mocking of Plexus in tests.

I kept code as Java 7 compatible, but AsciidoctorJ is 1.8. I'd add that to docs and release notes when PR is agreed. I did not want to add more things to the mix.
