### PR TITLE
closes #366 Control when cursor in logger is null

### DIFF
--- a/src/it/spi-registered-log/asciidoctor-project/src/main/doc/sample.asciidoc
+++ b/src/it/spi-registered-log/asciidoctor-project/src/main/doc/sample.asciidoc
@@ -27,3 +27,5 @@ NOTE: This is test, only a test.
 == Missing include
 
 include::something.adoc[]
+
+<<invalid,reference>>

--- a/src/it/spi-registered-log/log-handler/src/main/java/org/asciidoctor/maven/test/TestLogHandlerService.java
+++ b/src/it/spi-registered-log/log-handler/src/main/java/org/asciidoctor/maven/test/TestLogHandlerService.java
@@ -43,8 +43,9 @@ public class TestLogHandlerService implements LogHandler {
     private void writeLine(String message) {
         try {
             logFile.write(message.getBytes());
+            logFile.write("\n".getBytes());
             logFile.flush();
-            logFile.close();
+            // logFile.close();
         } catch (IOException e) {
             e.printStackTrace();
         }

--- a/src/it/spi-registered-log/validate.groovy
+++ b/src/it/spi-registered-log/validate.groovy
@@ -3,7 +3,9 @@ final def file = new File(basedir, "custom_log.log")
 if (!file.exists())
     throw new Exception("Log file not initialized")
 
-if (!file.text.contains("Logging from TestLogHandlerService: include file not found:"))
+def text = file.text
+if (!text.contains("Logging from TestLogHandlerService: include file not found:") ||
+        !text.contains("Logging from TestLogHandlerService: invalid reference"))
     throw new Exception("Expected LogHandler message not found in log file")
 
 return true

--- a/src/main/java/org/asciidoctor/maven/log/LogRecordHelper.java
+++ b/src/main/java/org/asciidoctor/maven/log/LogRecordHelper.java
@@ -11,7 +11,9 @@ import java.io.IOException;
  */
 public class LogRecordHelper {
 
-    public static final String ASCIIDOCTOR_LOG_FORMAT = "asciidoctor: %s: %s: line %s: %s";
+    // includes replacers for cursor (file & line)
+    public static final String ASCIIDOCTOR_FULL_LOG_FORMAT = "asciidoctor: %s: %s: line %s: %s";
+    public static final String ASCIIDOCTOR_SIMPLE_LOG_FORMAT = "asciidoctor: %s: %s";
 
     /**
      * Formats the logRecord in a similar manner to original Asciidoctor.
@@ -22,7 +24,7 @@ public class LogRecordHelper {
      */
     public static String format(LogRecord logRecord) {
         final Cursor cursor = logRecord.getCursor();
-        return String.format(ASCIIDOCTOR_LOG_FORMAT, logRecord.getSeverity(), cursor.getFile(), cursor.getLineNumber(), logRecord.getMessage());
+        return String.format(ASCIIDOCTOR_FULL_LOG_FORMAT, logRecord.getSeverity(), cursor.getFile(), cursor.getLineNumber(), logRecord.getMessage());
     }
 
     /**
@@ -35,15 +37,21 @@ public class LogRecordHelper {
      */
     public static String format(LogRecord logRecord, File sourceDirectory) {
         final Cursor cursor = logRecord.getCursor();
-        String relativePath;
+        String relativePath = "";
         try {
-            relativePath = new File(cursor.getFile()).getCanonicalPath()
-                    .substring(sourceDirectory.getCanonicalPath().length() + 1);
+            if (cursor != null) {
+                relativePath = new File(cursor.getFile()).getCanonicalPath()
+                        .substring(sourceDirectory.getCanonicalPath().length() + 1);
+            }
         } catch (IOException e) {
             // use the absolute path as fail-safe
             relativePath = cursor.getFile();
         }
-        return String.format(ASCIIDOCTOR_LOG_FORMAT, logRecord.getSeverity(), relativePath, cursor.getLineNumber(), logRecord.getMessage());
+        return relativePath.length() > 0 ?
+                String.format(ASCIIDOCTOR_FULL_LOG_FORMAT, logRecord.getSeverity(), relativePath, cursor.getLineNumber(), logRecord.getMessage())
+                :
+                String.format(ASCIIDOCTOR_SIMPLE_LOG_FORMAT, logRecord.getSeverity(), logRecord.getMessage())
+                ;
     }
 
 }

--- a/src/test/resources/src/asciidoctor/errors/document-with-invalid-reference.adoc
+++ b/src/test/resources/src/asciidoctor/errors/document-with-invalid-reference.adoc
@@ -1,0 +1,7 @@
+= My Document
+
+== Code example
+
+Missing file reference to <<../path/some-file.adoc,the lost doc>>.
+
+Missing section reference to <<section-id,the lost doc>>.


### PR DESCRIPTION
Adds a null check to the cursor of logRecords.
In case the message does not have a cursor, it will print a message without it following Asciidoctor current format.

Example:
`[info] asciidoctor: WARN: invalid reference: section-id`
