### PR TITLE
Added openjdk9 and Java 10 to TravisCI

### DIFF
--- a/.travis.yml
+++ b/.travis.yml
@@ -4,8 +4,11 @@ language: java
 before_script:
   - export MAVEN_SKIP_RC=true
 jdk:
+  - oraclejdk10
   - oraclejdk9
   - oraclejdk8
+  - openjdk10
+  - openjdk9
   - openjdk8
   - openjdk7
 # skip installation step entirely

--- a/pom.xml
+++ b/pom.xml
@@ -63,7 +63,7 @@
         <groovy.version>2.1.3</groovy.version>
         <asciidoctorj.version>1.5.7</asciidoctorj.version>
         <maven.coveralls.plugin.version>4.3.0</maven.coveralls.plugin.version>
-        <maven.jacoco.plugin.version>0.7.9</maven.jacoco.plugin.version>
+        <maven.jacoco.plugin.version>0.8.2</maven.jacoco.plugin.version>
         <jruby.version>9.1.17.0</jruby.version>
         <maven.plugin.plugin.version>3.5</maven.plugin.plugin.version>
         <maven.project.version>3.0.5</maven.project.version>
@@ -343,7 +343,7 @@
               <plugin>
                 <groupId>org.apache.maven.plugins</groupId>
                 <artifactId>maven-surefire-plugin</artifactId>
-                <version>2.18.1</version>
+                <version>2.22.1</version>
               </plugin>
               <plugin>
                 <groupId>org.apache.maven.plugins</groupId>


### PR DESCRIPTION
`maven-surefire-plugin` has been updated also as a requeriment.

NOTE:
Java 11 fails during a test due to ssl changes, see below. I will deal with it in another PR.

```[ERROR] github files can be included(org.asciidoctor.maven.test.AsciidoctorMojoTest)  Time elapsed: 4.802 s  <<< ERROR!
org.asciidoctor.internal.AsciidoctorCoreException: org.jruby.exceptions.RaiseException: (LoadError) load error: jopenssl/load -- java.lang.StringIndexOutOfBoundsException: begin 0, end 3, length 2
	at org.asciidoctor.maven.test.AsciidoctorMojoTest.github files can be included(AsciidoctorMojoTest.groovy:990)
Caused by: org.jruby.exceptions.RaiseException: (LoadError) load error: jopenssl/load -- java.lang.StringIndexOutOfBoundsException: begin 0, end 3, length 2

```
