### PR TITLE
Sets current version to 1.5.7.1 in README

### DIFF
--- a/README.adoc
+++ b/README.adoc
@@ -1,6 +1,6 @@
 = Asciidoctor Maven Plugin
 // Metadata
-:release-version: 1.5.6
+:release-version: 1.5.7.1
 // Settings
 :idprefix:
 :idseparator: -
@@ -54,6 +54,8 @@ ifeval::['{tag}' == 'master']
 ====
 You're viewing the documentation for the upcoming release.
 If you're looking for the documentation for an older release, please refer to one of the following tags: +
+{uri-repo}/tree/asciidoctor-maven-plugin-1.5.6#readme[1.5.6]
+&hybull;
 {uri-repo}/tree/asciidoctor-maven-plugin-1.5.5#readme[1.5.5]
 &hybull;
 {uri-repo}/tree/asciidoctor-maven-plugin-1.5.3#readme[1.5.3]


### PR DESCRIPTION
This PR updated the README to the current version:

* Sets  `release-version` attribute to 1.5.7.1
* Adds link to README in branch 1.5.6