### PR TITLE
Use asciidoctor.convertFile() instead of asciidoctor.renderFile()

### DIFF
--- a/src/main/java/org/asciidoctor/maven/AsciidoctorHttpMojo.java
+++ b/src/main/java/org/asciidoctor/maven/AsciidoctorHttpMojo.java
@@ -48,7 +48,7 @@ public class AsciidoctorHttpMojo extends AsciidoctorRefreshMojo {
 
     @Override
     protected void renderFile(final Asciidoctor asciidoctorInstance, final Map<String, Object> options, final File f) {
-        asciidoctorInstance.renderFile(f, options);
+        asciidoctorInstance.convertFile(f, options);
 
         if (autoReloadInterval > 0 && backend.toLowerCase().startsWith("html")) {
             final String filename = f.getName();
@@ -82,7 +82,7 @@ public class AsciidoctorHttpMojo extends AsciidoctorRefreshMojo {
                 }
             }
         } else {
-            asciidoctorInstance.renderFile(f, options);
+            asciidoctorInstance.convertFile(f, options);
         }
 
         logRenderedFile(f);

--- a/src/main/java/org/asciidoctor/maven/AsciidoctorMojo.java
+++ b/src/main/java/org/asciidoctor/maven/AsciidoctorMojo.java
@@ -460,7 +460,7 @@ public class AsciidoctorMojo extends AbstractMojo {
     }
 
     protected void renderFile(Asciidoctor asciidoctor, Map<String, Object> options, File f) {
-        asciidoctor.renderFile(f, options);
+        asciidoctor.convertFile(f, options);
         logRenderedFile(f);
     }
 


### PR DESCRIPTION
The methods `Asciidoctor.render*()` are on the way of being deprecated (see asciidoctor/asciidoctorj#711)
Therefore this PR changes the calls to Asciidoctor to use the corresponding `convertFile()` method.