### PR TITLE
Update TravisCI setting to new vm based builds

### DIFF
--- a/.travis.yml
+++ b/.travis.yml
@@ -1,5 +1,3 @@
-dist: trusty
-sudo: false
 language: java
 before_script:
   - export MAVEN_SKIP_RC=true

--- a/.travis.yml
+++ b/.travis.yml
@@ -1,3 +1,4 @@
+dist: trusty
 language: java
 before_script:
   - export MAVEN_SKIP_RC=true


### PR DESCRIPTION
As mentioned here: https://blog.travis-ci.com/2018-11-19-required-linux-infrastructure-migration

Travis is disabling docker model.
This PR just removes configurations that not necessary or working:

* removes `sudo: false`
* removes `dist: trusty`, which is not needed since trusty is already default