### PR TITLE
Add tip on how to show the asciidoctor version

### DIFF
--- a/README.adoc
+++ b/README.adoc
@@ -658,3 +658,10 @@ Automatically add version details to header and footer to all documents.
 </configuration>
 -----
 <1> Add `maven.build.timestamp.format` to the pom's properties section to set a custom date format.
+
+=== Show Asciidoctor version
+
+If you are not sure what version of the Asciidoctor converter is being used.
+You can obtain it using the version attribute like in the example blow.
+
+ Asciidoctor version: {asciidoctor-version}


### PR DESCRIPTION
This is a trick that has come up lately a few times and I think it is noteworthy enough to add it to the _Tips & Tricks_ section of the README