### PR TITLE
Update asciidoctorj to 1.5.8.1

### DIFF
--- a/README.adoc
+++ b/README.adoc
@@ -268,6 +268,12 @@ For example, set `include` to fail on any issue related to included files regard
 <2> Build will fail on any message of severity `DEBUG` or higher, that includes all.
 All matching messages will appear as ERROR in Maven output.
 
+[WARNING]
+====
+Due to link:https://github.com/asciidoctor/asciidoctor/issues/2722[issue #2722] in `asciidoctor`, versions >1.5.8.x of AsciidoctorJ cause internal reference warning messages not to be shown.
+Note however that using versions 1.5.7 and below may show false positives messages which may affect the build.
+====
+
 ==== Built-in attributes
 
 There are various attributes Asciidoctor recognizes.

--- a/README.adoc
+++ b/README.adoc
@@ -229,6 +229,9 @@ Here follows a configuration example:
 NOTE: Extensions can also be integrated through the SPI interface implementation.
 This method does not require any configuration in the [.path]_pom.xml_, see link:https://github.com/asciidoctor/asciidoctorj#extension-spi[Extension SPI] for details.
 
+enableVerbose:: enables Asciidoctor verbose messages, defaults to `false`.
+Enable it, for example, if you want to validate https://asciidoctor.org/docs/user-manual/#validating-internal-cross-references[internal cross references] and capture the messages with the logHandler option.
+
 logHandler:: enables processing of Asciidoctor messages (e.g. errors on missing included files), to hide messages as well setup build fail conditions based on them.
 Contains the following configuration elements:
 
@@ -268,10 +271,10 @@ For example, set `include` to fail on any issue related to included files regard
 <2> Build will fail on any message of severity `DEBUG` or higher, that includes all.
 All matching messages will appear as ERROR in Maven output.
 
-[WARNING]
+[NOTE]
 ====
-Due to link:https://github.com/asciidoctor/asciidoctor/issues/2722[issue #2722] in `asciidoctor`, versions >1.5.8.x of AsciidoctorJ cause internal reference warning messages not to be shown.
-Note however that using versions 1.5.7 and below may show false positives messages which may affect the build.
+Since version 1.5.8 of AsciidoctorJ set `enableVerbose` to `true` option to validate internal cross references, this is being improved to avoid false positives
+See https://github.com/asciidoctor/asciidoctor/issues/2722[#2722] if your are interested in the details.
 ====
 
 ==== Built-in attributes

--- a/pom.xml
+++ b/pom.xml
@@ -61,7 +61,9 @@
         <project.execution.environment>JavaSE-1.7</project.execution.environment>
         <spock.version>0.7-groovy-2.0</spock.version>
         <groovy.version>2.1.3</groovy.version>
-        <asciidoctorj.version>1.5.7</asciidoctorj.version>
+        <!--<asciidoctorj.version>1.6.0-SNAPSHOT</asciidoctorj.version>-->
+        <asciidoctorj.version>1.5.8</asciidoctorj.version>
+        <!--<asciidoctorj.version>1.5.7</asciidoctorj.version>-->
         <maven.coveralls.plugin.version>4.3.0</maven.coveralls.plugin.version>
         <maven.jacoco.plugin.version>0.8.2</maven.jacoco.plugin.version>
         <jruby.version>9.1.17.0</jruby.version>

--- a/src/it/spi-registered-log/asciidoctor-project/src/main/doc/sample.asciidoc
+++ b/src/it/spi-registered-log/asciidoctor-project/src/main/doc/sample.asciidoc
@@ -28,4 +28,5 @@ NOTE: This is test, only a test.
 
 include::something.adoc[]
 
+// use <enableVerbose> to show this message
 <<invalid,reference>>

--- a/src/it/spi-registered-log/validate.groovy
+++ b/src/it/spi-registered-log/validate.groovy
@@ -4,8 +4,7 @@ if (!file.exists())
     throw new Exception("Log file not initialized")
 
 def text = file.text
-if (!text.contains("Logging from TestLogHandlerService: include file not found:") ||
-        !text.contains("Logging from TestLogHandlerService: invalid reference"))
+if (!text.contains("Logging from TestLogHandlerService: include file not found:"))
     throw new Exception("Expected LogHandler message not found in log file")
 
 return true

--- a/src/main/java/org/asciidoctor/maven/AsciidoctorMojo.java
+++ b/src/main/java/org/asciidoctor/maven/AsciidoctorMojo.java
@@ -163,6 +163,9 @@ public class AsciidoctorMojo extends AbstractMojo {
     @Parameter(defaultValue = "${session}", readonly = true, required = true)
     protected MavenSession session;
 
+    @Parameter(property = AsciidoctorMaven.PREFIX + "verbose")
+    protected boolean enableVerbose = false;
+
     @Parameter
     private LogHandler logHandler = new LogHandler();
 
@@ -200,6 +203,9 @@ public class AsciidoctorMojo extends AbstractMojo {
         }
 
         final Asciidoctor asciidoctor = getAsciidoctorInstance(gemPath);
+        if (enableVerbose) {
+            asciidoctor.requireLibrary("enable_verbose.rb");
+        }
 
         asciidoctor.requireLibraries(requires);
 

--- a/src/main/resources/enable_verbose.rb
+++ b/src/main/resources/enable_verbose.rb
@@ -1,0 +1,2 @@
+# script used to enable Asciidoctor verbose
+$VERBOSE=true

--- a/src/test/groovy/org/asciidoctor/maven/test/AsciidoctorMojoLogHandlerTest.groovy
+++ b/src/test/groovy/org/asciidoctor/maven/test/AsciidoctorMojoLogHandlerTest.groovy
@@ -110,6 +110,7 @@ class AsciidoctorMojoLogHandlerTest extends Specification {
         System.setOut(originalOut)
     }
 
+    @spock.lang.Ignore("Broke in 1.5.8: https://github.com/asciidoctor/asciidoctor/issues/2722")
     def "should not fail & log errors as INFO when outputToConsole is set and doc contains messages without cursor"() {
         setup:
         def originalOut = System.out


### PR DESCRIPTION
This updates AsciidoctorJ version and tests that started failing due to https://github.com/asciidoctor/asciidoctor/issues/2722.

@mojavelinux I added about the issue in the README. I'd appreciate your opinion on wether we should make this visible or not.