### PR TITLE
use comet branch name for remote include test instead of master

### DIFF
--- a/src/test/resources/src/asciidoctor/github-include.adoc
+++ b/src/test/resources/src/asciidoctor/github-include.adoc
@@ -11,7 +11,7 @@ This works using jRuby 9k or >= 1.7.22.
 
 [source,xml]
 ----
-include::https://raw.githubusercontent.com/cometd/cometd/master/pom.xml[]
+include::https://raw.githubusercontent.com/cometd/cometd/4.0.x/pom.xml[]
 ----
 
 


### PR DESCRIPTION
This PR fixes a test that started failing due a change in a remote file being used.
