### PR TITLE
closes #265: removes deprecated templateDir option

### DIFF
--- a/README.adoc
+++ b/README.adoc
@@ -184,7 +184,6 @@ backend:: defaults to `html5`
 doctype:: defaults to `null` (which trigger's Asciidoctor's default of `article`)
 eruby:: defaults to erb, the version used in JRuby
 headerFooter:: defaults to `true`
-templateDir:: directory of Tilt-compatible templates to be used instead of the default built-in templates, disabled by default (`null`)
 templateDirs:: list of directories of Tilt-compatible templates to be used instead of the default built-in templates, empty by default
 +
 [NOTE]

--- a/README_zh-CN.adoc
+++ b/README_zh-CN.adoc
@@ -112,7 +112,6 @@ doctype:: 默认为 `null` （它将触发 Asciidoctor 的默认值 `article`）
 eruby:: 默认为 erb，被 JRuby 使用
 // eruby:: defaults to erb, the version used in JRuby
 headerFooter:: 默认为 `true`
-templateDir:: 默认不可用，默认值为 `null`
 templateEngine:: 默认不可用
 sourceHighlighter:: 启用语法高亮，设置语法高亮器（当前仅支持 `coderay` 和 `highlight.js`）
 attributes:: 包含传递给 Asciidoctor 的属性的 `Map<String,Object>`，默认为 `null`

--- a/src/main/java/org/asciidoctor/maven/AsciidoctorMojo.java
+++ b/src/main/java/org/asciidoctor/maven/AsciidoctorMojo.java
@@ -112,9 +112,6 @@ public class AsciidoctorMojo extends AbstractMojo {
     @Parameter(property = AsciidoctorMaven.PREFIX + "headerFooter", required = false)
     protected boolean headerFooter = true;
 
-    @Parameter(property = AsciidoctorMaven.PREFIX + "templateDir", required = false)
-    protected File templateDir;
-
     @Parameter(property = AsciidoctorMaven.PREFIX + "templateDirs", required = false)
     protected List<File> templateDirs = new ArrayList<>();
 
@@ -533,9 +530,6 @@ public class AsciidoctorMojo extends AbstractMojo {
 
         if (templateEngine != null)
             optionsBuilder.templateEngine(templateEngine);
-
-        if (templateDir != null)
-            optionsBuilder.templateDir(templateDir);
 
         if (templateDirs != null)
             optionsBuilder.templateDirs(templateDirs.toArray(new File[]{}));

--- a/src/test/groovy/org/asciidoctor/maven/test/AsciidoctorMojoTest.groovy
+++ b/src/test/groovy/org/asciidoctor/maven/test/AsciidoctorMojoTest.groovy
@@ -79,35 +79,6 @@ class AsciidoctorMojoTest extends Specification {
             text.contains('<pre class="CodeRay highlight">')
     }
 
-    def "should convert a html with a single template"() {
-        setup:
-            final def templatesPath = 'target/test-classes/templates/'
-            File srcDir = new File(DEFAULT_SOURCE_DIRECTORY)
-            File outputDir = new File('target/asciidoctor-output')
-
-            if (!outputDir.exists())
-              outputDir.mkdir()
-        when:
-            AsciidoctorMojo mojo = new AsciidoctorMojo()
-            mojo.backend = 'html5'
-            mojo.sourceDirectory = srcDir
-            mojo.sourceDocumentName = 'sample.asciidoc'
-            mojo.resources = [new Resource(directory: '.', excludes: ['**/**'])]
-            mojo.outputDirectory = outputDir
-            mojo.templateDir = new File(templatesPath, 'set-1')
-
-            mojo.execute()
-        then:
-            outputDir.list().toList().isEmpty() == false
-            outputDir.list().toList().contains('sample.html')
-
-            File sampleOutput = new File('sample.html', outputDir)
-            sampleOutput.length() > 0
-            String text = sampleOutput.getText()
-            text.contains('custom-admonition-block')
-            !text.contains('custom-block-style')
-    }
-
     def "should convert a html with a custom templates"() {
         setup:
             final def templatesPath = 'target/test-classes/templates/'
@@ -124,36 +95,6 @@ class AsciidoctorMojoTest extends Specification {
             mojo.resources = [new Resource(directory: '.', excludes: ['**/**'])]
             mojo.outputDirectory = outputDir
             mojo.templateDirs = [new File(templatesPath, 'set-1'), new File(templatesPath, 'set-2')]
-
-            mojo.execute()
-        then:
-            outputDir.list().toList().isEmpty() == false
-            outputDir.list().toList().contains('sample.html')
-
-            File sampleOutput = new File('sample.html', outputDir)
-            sampleOutput.length() > 0
-            String text = sampleOutput.getText()
-            text.contains('custom-admonition-block')
-            text.contains('custom-block-style')
-    }
-
-    def "should convert a html merging templateDir & templateDirs"() {
-        setup:
-            final def templatesPath = 'target/test-classes/templates/'
-            File srcDir = new File(DEFAULT_SOURCE_DIRECTORY)
-            File outputDir = new File('target/asciidoctor-output')
-
-            if (!outputDir.exists())
-                outputDir.mkdir()
-        when:
-            AsciidoctorMojo mojo = new AsciidoctorMojo()
-            mojo.backend = 'html5'
-            mojo.sourceDirectory = srcDir
-            mojo.sourceDocumentName = 'sample.asciidoc'
-            mojo.resources = [new Resource(directory: '.', excludes: ['**/**'])]
-            mojo.outputDirectory = outputDir
-            mojo.templateDir = new File(templatesPath, 'set-1')
-            mojo.templateDirs = [new File(templatesPath, 'set-2')]
 
             mojo.execute()
         then:


### PR DESCRIPTION
This PR:
* Removes the deprecated option "templateDir". Uses should use "templateDirs" instead.
* Updates tests accordingly
* Updates READMEs accordingly
