### PR TITLE
Support log handler configuration for site generation

### DIFF
--- a/README.adoc
+++ b/README.adoc
@@ -1,6 +1,7 @@
 = Asciidoctor Maven Plugin
 // Metadata
 :release-version: 1.5.8
+:maven-site-plugin-version: 3.9.0
 // Settings
 :idprefix:
 :idseparator: -
@@ -250,6 +251,7 @@ This method does not require any configuration in the [.path]_pom.xml_, see link
 enableVerbose:: enables Asciidoctor verbose messages, defaults to `false`.
 Enable it, for example, if you want to validate https://asciidoctor.org/docs/user-manual/#validating-internal-cross-references[internal cross references] and capture the messages with the logHandler option.
 
+[[logHandler-configuration]]
 logHandler:: enables processing of Asciidoctor messages (e.g. errors on missing included files), to hide messages as well setup build fail conditions based on them.
 Contains the following configuration elements:
 
@@ -459,7 +461,7 @@ IMPORTANT: Maven v3.2.1 or above required, and since asciidoctor-maven-plugin v1
         <plugin>
             <groupId>org.apache.maven.plugins</groupId>
             <artifactId>maven-site-plugin</artifactId>
-            <version>3.4</version>
+            <version>3.9.0</version>
             <dependencies>
                 <dependency><!-- add Asciidoctor Doxia Parser Module -->
                     <groupId>org.asciidoctor</groupId>
@@ -482,11 +484,12 @@ Then, all resources (images, css, etc.) should be placed in [.path]_src/site/res
 These will be automatically copied into [.path]_target/site_.
 
 Also note that AsciiDoc files are converted to embeddable HTML and inserted into the site's page layout.
-This disables certain features such as a the sidebar toc.
+This disables certain features such as the sidebar toc.
 
 Make sure you add a `menu` item for each page so you can access it from the site navigation:
 
 [source,xml]
+.site.xml
 -----
 <body>
     ...
@@ -507,13 +510,13 @@ This is necessary since the `<configuration>` element is used to configure more 
 +
 Here's an example that shows how to set options, attributes and ignore partial AsciiDoc files (i.e., files that begin with an underscore).
 +
-[source,xml]
+[source,xml,subs=attributes+]
 .Maven site integration with Asciidoctor configuration
 ----
 <plugin>
     <groupId>org.apache.maven.plugins</groupId>
     <artifactId>maven-site-plugin</artifactId>
-    <version>3.4</version>
+    <version>{maven-site-plugin-version}</version>
     <configuration>
         <asciidoc>
             <templateDirs>
@@ -535,7 +538,7 @@ Here's an example that shows how to set options, attributes and ignore partial A
         <dependency>
             <groupId>org.asciidoctor</groupId>
             <artifactId>asciidoctor-maven-plugin</artifactId>
-            <version>1.5.3</version>
+            <version>{release-version}</version>
         </dependency>
     </dependencies>
 </plugin>
@@ -558,26 +561,41 @@ There's currently no way (that we can tell) to configure this automatically.
 The supported ones are:
 
 baseDir::
-Sames as the plugin's `baseDir`.
+Same as the plugin's `baseDir`.
 Sets the root path for resources.
 Not set by default, AsciiDoc documents will be searched in [.path]_src/site/asciidoc_.
 External resources should be located in [.path]_src/site/resources_.
 +
 NOTE: Consider using maven-site-plugin's `siteDirectory` instead for better integration with the site functions (ie. resource copying).
 
-templatesDir (also template_dir)::
-Built-in template are supported by specifying a templates directory (i.e., `templatesDir`).
-This feature enables you to provide a custom template for converting any node in the tree (e.g., document, section, listing, etc).
-Custom templates can be extremely helpful when trying to customize the appearance of your site.
-
 templatesDirs (also template_dirs)::
-Allows to set multiple templates.
+Built-in templates are supported by specifying one or more template directories.
+This feature enables you to provide custom templates for converting any node in the tree (e.g., document, section, listing, etc).
+Custom templates can be extremely helpful when trying to customize the appearance of your site.
 Note that each one should be enclosed in a `<dir>` element.
 
 requires::
-Sames as the plugin's `requires`.
+Same as the plugin's `requires`. +
 Specifies additional Ruby libraries not packaged in AsciidoctorJ, `empty` by default.
 
+attributes::
+Similar to the plugin's `attributes`. +
+Allows defining a set of Asciidoctor attributes to be passed to the conversion. +
+In addition to those attributes found in this section, any maven property is also passed as attribute (replacing . by -).
++
+[source,xml]
+----
+<properties>
+  <my-site.version>2.3.0</my-site.version> <.>
+</properties>
+----
+<.> Will be passed as `my-site-version` to the converter
+
+logHandler::
+Sames as the plugin's `requires`. +
+Enables processing of Asciidoctor messages.
+For example to hide them, enable finer detail or fail the build on certain scenarios (e.g. missing included files).
+For conciseness the options are not reproduced here, please to see all options refer to the main plugin <<logHandler-configuration,logHandler>> configuration.
 
 // == Watching for changes
 
@@ -596,13 +614,12 @@ Specifies additional Ruby libraries not packaged in AsciidoctorJ, `empty` by def
 Developer setup for hacking on this project isn't very difficult.
 The requirements are very small:
 
-* Java
+* Java 8 or higher
 * Maven 3
 
 Everything else will be brought in by Maven.
 This is a typical Maven Java project, nothing special.
-You should be able to use IntelliJ, Eclipse, or Netbeans
-without any issue for hacking on the project.
+You should be able to use IntelliJ, Eclipse, or Netbeans without any issue for hacking on the project.
 
 == Building
 

--- a/README.adoc
+++ b/README.adoc
@@ -596,7 +596,9 @@ Sames as the plugin's `requires`. +
 Enables processing of Asciidoctor messages.
 For example to hide them, enable finer detail or fail the build on certain scenarios (e.g. missing included files).
 For conciseness the options are not reproduced here, please to see all options refer to the main plugin <<logHandler-configuration,logHandler>> configuration.
-
++
+IMPORTANT: Due to limitations in how Maven site integration works, it is not possible to provide the filename in the error message.
+We are aware this is not ideal and are tracking any development on the Maven side towards this goal (https://issues.apache.org/jira/browse/DOXIA-555[DOXIA-555]).
 // == Watching for changes
 
 // TODO

--- a/pom.xml
+++ b/pom.xml
@@ -161,6 +161,12 @@
             <version>3.16.1</version>
             <scope>test</scope>
         </dependency>
+        <dependency>
+            <groupId>org.mockito</groupId>
+            <artifactId>mockito-core</artifactId>
+            <version>3.3.0</version>
+            <scope>test</scope>
+        </dependency>
     </dependencies>
 
     <build>

--- a/pom.xml
+++ b/pom.xml
@@ -70,7 +70,7 @@
         <maven.compiler.plugin.version>3.7.0</maven.compiler.plugin.version>
         <maven.filtering.version>3.1.1</maven.filtering.version>
         <plexus.utils.version>3.0.23</plexus.utils.version>
-        <plexus.component.metadata.version>1.5.5</plexus.component.metadata.version>
+        <plexus.component.metadata.version>1.7</plexus.component.metadata.version>
         <netty.version>4.0.38.Final</netty.version>
         <commons.io.version>2.5</commons.io.version>
         <doxia.version>1.7</doxia.version>

--- a/pom.xml
+++ b/pom.xml
@@ -73,7 +73,7 @@
         <plexus.component.metadata.version>1.7</plexus.component.metadata.version>
         <netty.version>4.0.38.Final</netty.version>
         <commons.io.version>2.5</commons.io.version>
-        <doxia.version>1.7</doxia.version>
+        <doxia.version>1.8</doxia.version>
         <gmaven.version>1.5</gmaven.version>
     </properties>
 

--- a/pom.xml
+++ b/pom.xml
@@ -130,6 +130,11 @@
             <version>${asciidoctorj.version}</version>
         </dependency>
         <dependency>
+            <groupId>org.apache.commons</groupId>
+            <artifactId>commons-lang3</artifactId>
+            <version>3.8.1</version>
+        </dependency>
+        <dependency>
             <groupId>org.spockframework</groupId>
             <artifactId>spock-core</artifactId>
             <version>${spock.version}</version>

--- a/src/main/java/org/asciidoctor/maven/log/AsciidoctorConvertionException.java
+++ b/src/main/java/org/asciidoctor/maven/log/AsciidoctorConvertionException.java
@@ -1,0 +1,13 @@
+package org.asciidoctor.maven.log;
+
+import org.asciidoctor.log.LogRecord;
+
+public class AsciidoctorConvertionException extends Exception {
+
+    private final LogRecord logRecord;
+
+    public AsciidoctorConvertionException(String message, LogRecord logRecord) {
+        super(message);
+        this.logRecord = logRecord;
+    }
+}

--- a/src/main/java/org/asciidoctor/maven/log/LogHandler.java
+++ b/src/main/java/org/asciidoctor/maven/log/LogHandler.java
@@ -1,6 +1,6 @@
 package org.asciidoctor.maven.log;
 
-import org.apache.commons.lang.StringUtils;
+import org.apache.commons.lang3.StringUtils;
 
 public class LogHandler {
 

--- a/src/main/java/org/asciidoctor/maven/log/LogRecordsProcessors.java
+++ b/src/main/java/org/asciidoctor/maven/log/LogRecordsProcessors.java
@@ -1,16 +1,28 @@
 package org.asciidoctor.maven.log;
 
-import org.apache.maven.plugin.MojoExecutionException;
 import org.asciidoctor.log.LogRecord;
 import org.asciidoctor.log.Severity;
 
 import java.io.File;
 import java.util.List;
+import java.util.function.Consumer;
 
-public class LogHandlerHelper {
+public class LogRecordsProcessors {
 
+    private final LogHandler logHandler;
+    private final File sourceDirectory;
 
-    public static void processLogRecords(LogHandler logHandler, File sourceDirectory, MemoryLogHandler memoryLogHandler) throws MojoExecutionException {
+    private final Consumer<String> errorMessageConsumer;
+
+    public LogRecordsProcessors(LogHandler logHandler,
+                                File sourceDirectory,
+                                Consumer<String> errorMessageConsumer) {
+        this.logHandler = logHandler;
+        this.sourceDirectory = sourceDirectory;
+        this.errorMessageConsumer = errorMessageConsumer;
+    }
+
+    public void processLogRecords(MemoryLogHandler memoryLogHandler) throws Exception {
         if (logHandler.isSeveritySet() && logHandler.isContainsTextNotBlank()) {
             final Severity severity = logHandler.getFailIf().getSeverity();
             final String textToSearch = logHandler.getFailIf().getContainsText();
@@ -18,27 +30,27 @@ public class LogHandlerHelper {
             final List<LogRecord> records = memoryLogHandler.filter(severity, textToSearch);
             if (records.size() > 0) {
                 for (LogRecord record : records) {
-                    getLog().error(LogRecordHelper.format(record, sourceDirectory));
+                    errorMessageConsumer.accept(LogRecordHelper.format(record, sourceDirectory));
                 }
-                throw new MojoExecutionException(String.format("Found %s issue(s) matching severity %s or higher and text '%s'", records.size(), severity, textToSearch));
+                throw new Exception(String.format("Found %s issue(s) matching severity %s or higher and text '%s'", records.size(), severity, textToSearch));
             }
         } else if (logHandler.isSeveritySet()) {
             final Severity severity = logHandler.getFailIf().getSeverity();
             final List<LogRecord> records = memoryLogHandler.filter(severity);
             if (records.size() > 0) {
                 for (LogRecord record : records) {
-                    getLog().error(LogRecordHelper.format(record, sourceDirectory));
+                    errorMessageConsumer.accept(LogRecordHelper.format(record, sourceDirectory));
                 }
-                throw new MojoExecutionException(String.format("Found %s issue(s) of severity %s or higher during rendering", records.size(), severity));
+                throw new Exception(String.format("Found %s issue(s) of severity %s or higher during rendering", records.size(), severity));
             }
         } else if (logHandler.isContainsTextNotBlank()) {
             final String textToSearch = logHandler.getFailIf().getContainsText();
             final List<LogRecord> records = memoryLogHandler.filter(textToSearch);
             if (records.size() > 0) {
                 for (LogRecord record : records) {
-                    getLog().error(LogRecordHelper.format(record, sourceDirectory));
+                    errorMessageConsumer.accept(LogRecordHelper.format(record, sourceDirectory));
                 }
-                throw new MojoExecutionException(String.format("Found %s issue(s) containing '%s'", records.size(), textToSearch));
+                throw new Exception(String.format("Found %s issue(s) containing '%s'", records.size(), textToSearch));
             }
         }
     }

--- a/src/main/java/org/asciidoctor/maven/log/LogRecordsProcessors.java
+++ b/src/main/java/org/asciidoctor/maven/log/LogRecordsProcessors.java
@@ -1,0 +1,46 @@
+package org.asciidoctor.maven.log;
+
+import org.apache.maven.plugin.MojoExecutionException;
+import org.asciidoctor.log.LogRecord;
+import org.asciidoctor.log.Severity;
+
+import java.io.File;
+import java.util.List;
+
+public class LogHandlerHelper {
+
+
+    public static void processLogRecords(LogHandler logHandler, File sourceDirectory, MemoryLogHandler memoryLogHandler) throws MojoExecutionException {
+        if (logHandler.isSeveritySet() && logHandler.isContainsTextNotBlank()) {
+            final Severity severity = logHandler.getFailIf().getSeverity();
+            final String textToSearch = logHandler.getFailIf().getContainsText();
+
+            final List<LogRecord> records = memoryLogHandler.filter(severity, textToSearch);
+            if (records.size() > 0) {
+                for (LogRecord record : records) {
+                    getLog().error(LogRecordHelper.format(record, sourceDirectory));
+                }
+                throw new MojoExecutionException(String.format("Found %s issue(s) matching severity %s or higher and text '%s'", records.size(), severity, textToSearch));
+            }
+        } else if (logHandler.isSeveritySet()) {
+            final Severity severity = logHandler.getFailIf().getSeverity();
+            final List<LogRecord> records = memoryLogHandler.filter(severity);
+            if (records.size() > 0) {
+                for (LogRecord record : records) {
+                    getLog().error(LogRecordHelper.format(record, sourceDirectory));
+                }
+                throw new MojoExecutionException(String.format("Found %s issue(s) of severity %s or higher during rendering", records.size(), severity));
+            }
+        } else if (logHandler.isContainsTextNotBlank()) {
+            final String textToSearch = logHandler.getFailIf().getContainsText();
+            final List<LogRecord> records = memoryLogHandler.filter(textToSearch);
+            if (records.size() > 0) {
+                for (LogRecord record : records) {
+                    getLog().error(LogRecordHelper.format(record, sourceDirectory));
+                }
+                throw new MojoExecutionException(String.format("Found %s issue(s) containing '%s'", records.size(), textToSearch));
+            }
+        }
+    }
+
+}

--- a/src/main/java/org/asciidoctor/maven/log/MemoryLogHandler.java
+++ b/src/main/java/org/asciidoctor/maven/log/MemoryLogHandler.java
@@ -1,6 +1,5 @@
 package org.asciidoctor.maven.log;
 
-import org.apache.maven.plugin.logging.Log;
 import org.asciidoctor.log.LogHandler;
 import org.asciidoctor.log.LogRecord;
 import org.asciidoctor.log.Severity;
@@ -8,6 +7,7 @@ import org.asciidoctor.log.Severity;
 import java.io.File;
 import java.util.ArrayList;
 import java.util.List;
+import java.util.function.Consumer;
 
 
 /**
@@ -19,19 +19,19 @@ public class MemoryLogHandler implements LogHandler {
 
     private final Boolean outputToConsole;
     private final File sourceDirectory;
-    private final Log log;
+    private final Consumer<LogRecord> recordConsumer;
 
-    public MemoryLogHandler(Boolean outputToConsole, File sourceDirectory, Log log) {
+    public MemoryLogHandler(Boolean outputToConsole, File sourceDirectory, Consumer<LogRecord> recordConsumer) {
         this.outputToConsole = outputToConsole == null ? Boolean.FALSE : outputToConsole;
         this.sourceDirectory = sourceDirectory;
-        this.log = log;
+        this.recordConsumer = recordConsumer;
     }
 
     @Override
     public void log(LogRecord logRecord) {
         records.add(logRecord);
         if (outputToConsole)
-            log.info(LogRecordHelper.format(logRecord, sourceDirectory));
+            recordConsumer.accept(logRecord);
     }
 
     public void clear() {

--- a/src/main/java/org/asciidoctor/maven/site/AsciidoctorDoxiaParser.java
+++ b/src/main/java/org/asciidoctor/maven/site/AsciidoctorDoxiaParser.java
@@ -73,9 +73,9 @@ public class AsciidoctorDoxiaParser extends XhtmlParser {
             return;
         }
 
-        MavenProject project = mavenProjectProvider.get();
-        Xpp3Dom siteConfig = getSiteConfig(project);
-        File siteDirectory = resolveSiteDirectory(project, siteConfig);
+        final MavenProject project = mavenProjectProvider.get();
+        final Xpp3Dom siteConfig = getSiteConfig(project);
+        final File siteDirectory = resolveSiteDirectory(project, siteConfig);
 
         SiteConversionConfiguration conversionConfig = new SiteConversionConfigurationParser(project)
                 .processAsciiDocConfig(siteConfig, defaultOptions(siteDirectory), defaultAttributes());
@@ -109,7 +109,8 @@ public class AsciidoctorDoxiaParser extends XhtmlParser {
     }
 
     private LogHandler getLogHandlerConfig(Xpp3Dom siteConfig) {
-        return new SiteLogHandlerDeserializer().deserialize(siteConfig == null ? null : siteConfig.getChild("asciidoc"));
+        Xpp3Dom asciidoc = siteConfig == null ? null : siteConfig.getChild("asciidoc");
+        return new SiteLogHandlerDeserializer().deserialize(asciidoc);
     }
 
     protected Xpp3Dom getSiteConfig(MavenProject project) {

--- a/src/main/java/org/asciidoctor/maven/site/AsciidoctorDoxiaParser.java
+++ b/src/main/java/org/asciidoctor/maven/site/AsciidoctorDoxiaParser.java
@@ -24,6 +24,7 @@ import org.asciidoctor.*;
 import org.codehaus.plexus.component.annotations.Component;
 import org.codehaus.plexus.util.IOUtil;
 import org.codehaus.plexus.util.xml.Xpp3Dom;
+import org.codehaus.plexus.util.xml.Xpp3DomBuilder;
 
 import javax.inject.Inject;
 import javax.inject.Provider;

--- a/src/main/java/org/asciidoctor/maven/site/SiteConversionConfiguration.java
+++ b/src/main/java/org/asciidoctor/maven/site/SiteConversionConfiguration.java
@@ -1,0 +1,25 @@
+package org.asciidoctor.maven.site;
+
+import org.asciidoctor.Options;
+
+import java.util.List;
+
+public class SiteConversionConfiguration {
+
+    private final Options options;
+    private final List<String> requires;
+
+    SiteConversionConfiguration(Options options, List<String> requires) {
+        this.options = options;
+        this.requires = requires;
+    }
+
+    public Options getOptions() {
+        return options;
+    }
+
+    public List<String> getRequires() {
+        return requires;
+    }
+
+}

--- a/src/main/java/org/asciidoctor/maven/site/SiteConversionConfigurationParser.java
+++ b/src/main/java/org/asciidoctor/maven/site/SiteConversionConfigurationParser.java
@@ -1,6 +1,6 @@
 package org.asciidoctor.maven.site;
 
-import org.apache.commons.lang.StringUtils;
+import org.apache.commons.lang3.StringUtils;
 import org.apache.maven.project.MavenProject;
 import org.asciidoctor.AttributesBuilder;
 import org.asciidoctor.OptionsBuilder;
@@ -12,7 +12,7 @@ import java.util.*;
 import java.util.stream.Collectors;
 import java.util.stream.Stream;
 
-import static org.apache.commons.lang.StringUtils.isNotBlank;
+import static org.apache.commons.lang3.StringUtils.isNotBlank;
 
 public class SiteConversionConfigurationParser {
 

--- a/src/main/java/org/asciidoctor/maven/site/SiteConversionConfigurationParser.java
+++ b/src/main/java/org/asciidoctor/maven/site/SiteConversionConfigurationParser.java
@@ -1,0 +1,104 @@
+package org.asciidoctor.maven.site;
+
+import org.apache.commons.lang.StringUtils;
+import org.apache.maven.project.MavenProject;
+import org.asciidoctor.AttributesBuilder;
+import org.asciidoctor.OptionsBuilder;
+import org.asciidoctor.maven.AsciidoctorHelper;
+import org.codehaus.plexus.util.xml.Xpp3Dom;
+
+import java.io.File;
+import java.util.*;
+import java.util.stream.Collectors;
+import java.util.stream.Stream;
+
+import static org.apache.commons.lang.StringUtils.isNotBlank;
+
+public class SiteConversionConfigurationParser {
+
+    private final MavenProject project;
+
+    SiteConversionConfigurationParser(MavenProject project) {
+        this.project = project;
+    }
+
+    SiteConversionConfiguration processAsciiDocConfig(Xpp3Dom siteConfig,
+                                                      OptionsBuilder presetOptions,
+                                                      AttributesBuilder presetAttributes) {
+
+        if (siteConfig == null) {
+            OptionsBuilder options = presetOptions.attributes(presetAttributes);
+            return new SiteConversionConfiguration(options.get(), Collections.emptyList());
+        }
+
+        final Xpp3Dom asciidocConfig = siteConfig.getChild("asciidoc");
+        if (asciidocConfig == null) {
+            OptionsBuilder options = presetOptions.attributes(presetAttributes);
+            return new SiteConversionConfiguration(options.get(), Collections.emptyList());
+        }
+
+        if (project.getProperties() != null) {
+            for (Map.Entry<Object, Object> entry : project.getProperties().entrySet()) {
+                presetAttributes.attribute(((String) entry.getKey()).replaceAll("\\.", "-"), entry.getValue());
+            }
+        }
+
+        final List<String> gemsToRequire = new ArrayList<>();
+        for (Xpp3Dom asciidocOpt : asciidocConfig.getChildren()) {
+            String optName = asciidocOpt.getName();
+
+            if ("requires".equals(optName)) {
+                Xpp3Dom[] requires = asciidocOpt.getChildren("require");
+                if (requires.length > 0) {
+                    for (Xpp3Dom requireNode : requires) {
+                        if (requireNode.getValue().contains(",")) {
+                            // <requires>time, base64</requires>
+                            Stream.of(requireNode.getValue().split(","))
+                                    .map(String::trim)
+                                    .filter(StringUtils::isNotBlank)
+                                    .forEach(value -> gemsToRequire.add(value));
+                        } else {
+                            // <requires>
+                            //     <require>time</require>
+                            // </requires>
+                            String value = requireNode.getValue();
+                            if (value.trim().length() > 0)
+                                gemsToRequire.add(value.trim());
+                        }
+                    }
+                }
+            } else if ("attributes".equals(optName)) {
+                for (Xpp3Dom asciidocAttr : asciidocOpt.getChildren()) {
+                    AsciidoctorHelper.addAttribute(asciidocAttr.getName(), asciidocAttr.getValue(), presetAttributes);
+                }
+            } else if ("templateDir".equals(optName) || "template_dir".equals(optName)) {
+                presetOptions.templateDir(resolveProjectDir(project, asciidocOpt.getValue()));
+            } else if ("templateDirs".equals(optName) || "template_dirs".equals(optName)) {
+                List<File> dirs = Arrays.stream(asciidocOpt.getChildren("dir"))
+                        .filter(node -> isNotBlank(node.getValue()))
+                        .map(node -> resolveProjectDir(project, node.getValue()))
+                        .collect(Collectors.toList());
+                presetOptions.templateDirs(dirs.toArray(new File[dirs.size()]));
+            } else if ("baseDir".equals(optName)) {
+                presetOptions.baseDir(resolveProjectDir(project, asciidocOpt.getValue()));
+            } else {
+                presetOptions.option(optName.replaceAll("(?<!_)([A-Z])", "_$1").toLowerCase(), asciidocOpt.getValue());
+            }
+        }
+
+        return new
+
+                SiteConversionConfiguration(presetOptions.attributes(presetAttributes).
+
+                get(), gemsToRequire);
+    }
+
+    private File resolveProjectDir(MavenProject project, String path) {
+        File filePath = new File(path);
+        if (!filePath.isAbsolute()) {
+            filePath = new File(project.getBasedir(), filePath.toString());
+        }
+        return filePath;
+    }
+
+}

--- a/src/main/java/org/asciidoctor/maven/site/SiteConversionConfigurationParser.java
+++ b/src/main/java/org/asciidoctor/maven/site/SiteConversionConfigurationParser.java
@@ -71,8 +71,6 @@ public class SiteConversionConfigurationParser {
                 for (Xpp3Dom asciidocAttr : asciidocOpt.getChildren()) {
                     AsciidoctorHelper.addAttribute(asciidocAttr.getName(), asciidocAttr.getValue(), presetAttributes);
                 }
-            } else if ("templateDir".equals(optName) || "template_dir".equals(optName)) {
-                presetOptions.templateDir(resolveProjectDir(project, asciidocOpt.getValue()));
             } else if ("templateDirs".equals(optName) || "template_dirs".equals(optName)) {
                 List<File> dirs = Arrays.stream(asciidocOpt.getChildren("dir"))
                         .filter(node -> isNotBlank(node.getValue()))
@@ -86,11 +84,7 @@ public class SiteConversionConfigurationParser {
             }
         }
 
-        return new
-
-                SiteConversionConfiguration(presetOptions.attributes(presetAttributes).
-
-                get(), gemsToRequire);
+        return new SiteConversionConfiguration(presetOptions.attributes(presetAttributes).get(), gemsToRequire);
     }
 
     private File resolveProjectDir(MavenProject project, String path) {

--- a/src/main/java/org/asciidoctor/maven/site/SiteLogHandlerDeserializer.java
+++ b/src/main/java/org/asciidoctor/maven/site/SiteLogHandlerDeserializer.java
@@ -9,14 +9,20 @@ import java.util.Optional;
 
 public class SiteLogHandlerDeserializer {
 
-    public LogHandler deserialize(Xpp3Dom node) {
+    public static final String NODE_NAME = "logHandler";
+
+    public LogHandler deserialize(Xpp3Dom configNode) {
         final LogHandler logHandler = defaultLogHandler();
-        if (node == null || !node.getName().equals("logHandler"))
+        if (configNode == null)
             return logHandler;
 
-        logHandler.setOutputToConsole(deserializeOutputToConsole(node));
+        final Xpp3Dom logHandlerNode = configNode.getChild("logHandler");
+        if (logHandlerNode == null || !logHandlerNode.getName().equals(NODE_NAME))
+            return logHandler;
 
-        deserializeFailIf(node.getChild("failIf"))
+        logHandler.setOutputToConsole(deserializeOutputToConsole(logHandlerNode));
+
+        deserializeFailIf(logHandlerNode.getChild("failIf"))
                 .ifPresent(logHandler::setFailIf);
 
         return logHandler;

--- a/src/main/java/org/asciidoctor/maven/site/SiteLogHandlerDeserializer.java
+++ b/src/main/java/org/asciidoctor/maven/site/SiteLogHandlerDeserializer.java
@@ -1,0 +1,78 @@
+package org.asciidoctor.maven.site;
+
+import org.asciidoctor.log.Severity;
+import org.asciidoctor.maven.log.FailIf;
+import org.asciidoctor.maven.log.LogHandler;
+import org.codehaus.plexus.util.xml.Xpp3Dom;
+
+import java.util.Optional;
+
+public class SiteLogHandlerDeserializer {
+
+    public LogHandler deserialize(Xpp3Dom node) {
+        final LogHandler logHandler = defaultLogHandler();
+        if (node == null || !node.getName().equals("logHandler"))
+            return logHandler;
+
+        logHandler.setOutputToConsole(deserializeOutputToConsole(node));
+
+        deserializeFailIf(node.getChild("failIf"))
+                .ifPresent(logHandler::setFailIf);
+
+        return logHandler;
+    }
+
+    private Boolean deserializeOutputToConsole(Xpp3Dom node) {
+        return getBoolean(node, "outputToConsole");
+    }
+
+    private Optional<FailIf> deserializeFailIf(Xpp3Dom node) {
+        if (node == null)
+            return Optional.empty();
+
+        Xpp3Dom severity = node.getChild("severity");
+        FailIf failIf = null;
+        if (severity != null) {
+            String sanitizedSeverity = sanitizeString(severity);
+            if (sanitizedSeverity.length() > 0) {
+                Severity severityEnumValue = Severity.valueOf(sanitizedSeverity);
+                failIf = new FailIf();
+                failIf.setSeverity(severityEnumValue);
+            }
+        }
+
+        Xpp3Dom containsText = node.getChild("containsText");
+        if (containsText != null) {
+            String sanitizedContainsText = sanitizeString(containsText);
+            if (sanitizedContainsText.length() > 0) {
+                failIf = failIf == null ? new FailIf() : failIf;
+                failIf.setContainsText(sanitizedContainsText);
+            }
+        }
+        return Optional.ofNullable(failIf);
+    }
+
+    private String sanitizeString(Xpp3Dom severity) {
+        String value = severity.getValue();
+        return value == null ? "" : value.trim();
+    }
+
+    private LogHandler defaultLogHandler() {
+        LogHandler logHandler = new LogHandler();
+        logHandler.setOutputToConsole(Boolean.TRUE);
+        return logHandler;
+    }
+
+    private Boolean getBoolean(Xpp3Dom node, String name) {
+        final Xpp3Dom child = node.getChild(name);
+        if (child == null) {
+            return Boolean.TRUE;
+        } else {
+            if (child.getValue() == null) {
+                return Boolean.TRUE;
+            }
+            return Boolean.valueOf(child.getValue());
+        }
+    }
+
+}

--- a/src/test/java/org/asciidoctor/maven/log/LogRecordHelperTest.java
+++ b/src/test/java/org/asciidoctor/maven/log/LogRecordHelperTest.java
@@ -1,0 +1,120 @@
+package org.asciidoctor.maven.log;
+
+import org.asciidoctor.ast.Cursor;
+import org.asciidoctor.log.LogRecord;
+import org.asciidoctor.log.Severity;
+import org.junit.Test;
+import org.mockito.Mockito;
+
+import java.io.File;
+import java.io.IOException;
+
+import static org.assertj.core.api.Assertions.assertThat;
+
+public class LogRecordHelperTest {
+
+    @Test
+    public void should_apply_full_format_logRecord_with_all_data() {
+        // given
+        final Cursor cursor = new TestCursor(new File("file.adoc").getAbsolutePath(), 3, "path", "dir");
+        final LogRecord logRecord = new LogRecord(Severity.INFO, cursor, "a message");
+        final File sourceDir = getParentFile();
+        // when
+        String formattedLogRecord = LogRecordHelper.format(logRecord, sourceDir);
+        // then
+        assertThat(normalizePath(formattedLogRecord)).isEqualTo("asciidoctor: INFO: asciidoctor-maven-plugin/file.adoc: line 3: a message");
+    }
+
+    @Test
+    public void should_apply_simple_format_when_cursor_is_null() {
+        // given
+        final LogRecord logRecord = new LogRecord(Severity.INFO, null, "a message");
+        // when
+        String formattedLogRecord = LogRecordHelper.format(logRecord, null);
+        // then
+        assertThat(normalizePath(formattedLogRecord)).isEqualTo("asciidoctor: INFO: a message");
+    }
+
+    @Test
+    public void should_apply_simple_format_when_cursor_is_empty() {
+        // given
+        final Cursor cursor = new TestCursor(null, 0, null, null);
+        final LogRecord logRecord = new LogRecord(Severity.INFO, cursor, "a message");
+        // when
+        String formattedLogRecord = LogRecordHelper.format(logRecord, null);
+        // then
+        assertThat(normalizePath(formattedLogRecord)).isEqualTo("asciidoctor: INFO: a message");
+    }
+
+    @Test
+    public void should_format_full_logRecord_with_file_absolute_path_when_sourceDir_is_not_valid() throws IOException {
+        // given
+        final Cursor cursor = new TestCursor(new File("file.adoc").getAbsolutePath(), 3, "path", "dir");
+        final LogRecord logRecord = new LogRecord(Severity.INFO, cursor, "a message");
+        final File sourceDir = Mockito.mock(File.class);
+        Mockito.when(sourceDir.getCanonicalPath()).thenThrow(new IOException());
+
+        // when
+        String formattedLogRecord = LogRecordHelper.format(logRecord, sourceDir);
+        // then
+        assertThat(normalizePath(formattedLogRecord)).matches("asciidoctor: INFO: .*/asciidoctor-maven-plugin/file.adoc: line 3: a message");
+    }
+
+    @Test
+    public void should_format_logRecords_with_empty_lineNumber_absolute_path_when_sourceDir_is_not_valid2() throws IOException {
+        // given
+        final Cursor cursor = new TestCursor(new File("file.adoc").getAbsolutePath(), 0, "path", "dir");
+        final LogRecord logRecord = new LogRecord(Severity.INFO, cursor, "a message");
+        final File sourceDir = Mockito.mock(File.class);
+        Mockito.when(sourceDir.getCanonicalPath()).thenThrow(new IOException());
+
+        // when
+        String formattedLogRecord = LogRecordHelper.format(logRecord, sourceDir);
+        // then
+        assertThat(normalizePath(formattedLogRecord)).matches("asciidoctor: INFO: .*/asciidoctor-maven-plugin/file.adoc: a message");
+    }
+
+    private File getParentFile() {
+        return new File(".").getAbsoluteFile().getParentFile().getParentFile();
+    }
+
+    private String normalizePath(String formattedLogRecord) {
+        return formattedLogRecord.replaceAll("\\\\", "/");
+    }
+
+    class TestCursor implements Cursor {
+
+        private final int lineNumber;
+        private final String file;
+        private final String path;
+        private final String dir;
+
+        TestCursor(String file, int lineNumber, String path, String dir) {
+            this.file = file;
+            this.lineNumber = lineNumber;
+            this.path = path;
+            this.dir = dir;
+        }
+
+        @Override
+        public int getLineNumber() {
+            return lineNumber;
+        }
+
+        @Override
+        public String getPath() {
+            return path;
+        }
+
+        @Override
+        public String getDir() {
+            return dir;
+        }
+
+        @Override
+        public String getFile() {
+            return file;
+        }
+    }
+
+}

--- a/src/test/java/org/asciidoctor/maven/site/SiteConversionConfigurationParserTest.java
+++ b/src/test/java/org/asciidoctor/maven/site/SiteConversionConfigurationParserTest.java
@@ -1,0 +1,447 @@
+package org.asciidoctor.maven.site;
+
+import org.apache.maven.model.Model;
+import org.apache.maven.project.MavenProject;
+import org.asciidoctor.AttributesBuilder;
+import org.asciidoctor.OptionsBuilder;
+import org.codehaus.plexus.util.xml.Xpp3Dom;
+import org.junit.Test;
+
+import java.io.File;
+import java.util.AbstractMap;
+import java.util.Arrays;
+import java.util.HashMap;
+import java.util.Map;
+
+import static org.asciidoctor.Options.*;
+import static org.assertj.core.api.Assertions.assertThat;
+
+public class SiteConversionConfigurationParserTest {
+
+    @Test
+    public void should_return_default_configuration_when_site_xml_is_null() {
+        // given
+        final MavenProject project = fakeProject();
+        OptionsBuilder emptyOptions = OptionsBuilder.options();
+        AttributesBuilder emptyAttributes = AttributesBuilder.attributes();
+
+        // when
+        SiteConversionConfiguration configuration = new SiteConversionConfigurationParser(project)
+                .processAsciiDocConfig(null, emptyOptions, emptyAttributes);
+
+        // then
+        final Map<String, Object> optionsMap = configuration.getOptions().map();
+        assertThat(optionsMap).containsOnlyKeys(ATTRIBUTES);
+        assertThat((Map) optionsMap.get(ATTRIBUTES)).isEmpty();
+        assertThat(configuration.getRequires()).isEmpty();
+    }
+
+    @Test
+    public void should_return_default_configuration_when_asciidoc_xml_is_null() {
+        // given
+        final MavenProject project = fakeProject();
+        OptionsBuilder emptyOptions = OptionsBuilder.options();
+        AttributesBuilder emptyAttributes = AttributesBuilder.attributes();
+        Xpp3Dom siteConfig = Xpp3DoomBuilder.siteNode()
+                .build();
+        // when
+        SiteConversionConfiguration configuration = new SiteConversionConfigurationParser(project)
+                .processAsciiDocConfig(siteConfig, emptyOptions, emptyAttributes);
+
+        // then
+        final Map<String, Object> optionsMap = configuration.getOptions().map();
+        assertThat(optionsMap).containsOnlyKeys(ATTRIBUTES);
+        assertThat((Map) optionsMap.get(ATTRIBUTES)).isEmpty();
+        assertThat(configuration.getRequires()).isEmpty();
+    }
+
+    @Test
+    public void should_return_simple_single_requires() {
+        // given
+        final MavenProject project = fakeProject();
+        OptionsBuilder emptyOptions = OptionsBuilder.options();
+        AttributesBuilder emptyAttributes = AttributesBuilder.attributes();
+        Xpp3Dom siteConfig = Xpp3DoomBuilder.asciidocNode()
+                .addChild("requires")
+                .addChild("require", "gem")
+                .build();
+
+        // when
+        SiteConversionConfiguration configuration = new SiteConversionConfigurationParser(project)
+                .processAsciiDocConfig(siteConfig, emptyOptions, emptyAttributes);
+
+        // then
+        final Map<String, Object> optionsMap = configuration.getOptions().map();
+        assertThat(optionsMap).containsOnlyKeys(ATTRIBUTES);
+        assertThat((Map) optionsMap.get(ATTRIBUTES)).isEmpty();
+        assertThat(configuration.getRequires())
+                .containsExactly("gem");
+    }
+
+    @Test
+    public void should_return_multiple_requires() {
+        // given
+        final MavenProject project = fakeProject();
+        OptionsBuilder emptyOptions = OptionsBuilder.options();
+        AttributesBuilder emptyAttributes = AttributesBuilder.attributes();
+        Xpp3Dom siteConfig = Xpp3DoomBuilder.asciidocNode()
+                .addChild("requires")
+                .addChild("require", "gem_1", "gem_2", "gem_3")
+                .build();
+
+        // when
+        SiteConversionConfiguration configuration = new SiteConversionConfigurationParser(project)
+                .processAsciiDocConfig(siteConfig, emptyOptions, emptyAttributes);
+
+        // then
+        final Map<String, Object> optionsMap = configuration.getOptions().map();
+        assertThat(optionsMap).containsOnlyKeys(ATTRIBUTES);
+        assertThat((Map) optionsMap.get(ATTRIBUTES)).isEmpty();
+        assertThat(configuration.getRequires())
+                .containsExactlyInAnyOrder("gem_1", "gem_2", "gem_3");
+    }
+
+    @Test
+    public void should_return_multiple_requires_when_defined_in_single_element() {
+        // given
+        final MavenProject project = fakeProject();
+        OptionsBuilder emptyOptions = OptionsBuilder.options();
+        AttributesBuilder emptyAttributes = AttributesBuilder.attributes();
+        Xpp3Dom siteConfig = Xpp3DoomBuilder.asciidocNode()
+                .addChild("requires")
+                .addChild("require", "gem_1,gem_2, gem_3")
+                .build();
+
+        // when
+        SiteConversionConfiguration configuration = new SiteConversionConfigurationParser(project)
+                .processAsciiDocConfig(siteConfig, emptyOptions, emptyAttributes);
+
+        // then
+        final Map<String, Object> optionsMap = configuration.getOptions().map();
+        assertThat(optionsMap).containsOnlyKeys(ATTRIBUTES);
+        assertThat((Map) optionsMap.get(ATTRIBUTES)).isEmpty();
+        assertThat(configuration.getRequires())
+                .containsExactlyInAnyOrder("gem_1", "gem_2", "gem_3");
+    }
+
+    @Test
+    public void should_remove_empty_and_blank_requires() {
+        // given
+        final MavenProject project = fakeProject();
+        OptionsBuilder emptyOptions = OptionsBuilder.options();
+        AttributesBuilder emptyAttributes = AttributesBuilder.attributes();
+        Xpp3Dom siteConfig = Xpp3DoomBuilder.asciidocNode()
+                .addChild("requires")
+                .addChild("require", "gem_1,,gem_2", "", ",,", "gem_3")
+                .build();
+
+        // when
+        SiteConversionConfiguration configuration = new SiteConversionConfigurationParser(project)
+                .processAsciiDocConfig(siteConfig, emptyOptions, emptyAttributes);
+
+        // then
+        final Map<String, Object> optionsMap = configuration.getOptions().map();
+        assertThat(optionsMap).containsOnlyKeys(ATTRIBUTES);
+        assertThat((Map) optionsMap.get(ATTRIBUTES)).isEmpty();
+        assertThat(configuration.getRequires())
+                .containsExactlyInAnyOrder("gem_1", "gem_2", "gem_3");
+    }
+
+    @Test
+    public void should_return_attributes() {
+        // given
+        final MavenProject project = fakeProject();
+        OptionsBuilder emptyOptions = OptionsBuilder.options();
+        AttributesBuilder emptyAttributes = AttributesBuilder.attributes();
+        Xpp3Dom siteConfig = Xpp3DoomBuilder.asciidocNode()
+                .addChild("attributes")
+                .addChild("imagesdir", "./images")
+                .parent().addChild("source-highlighter", "coderay")
+                .parent().addChild("sectnums")
+                .parent().addChild("toc", null)
+                .build();
+
+        // when
+        SiteConversionConfiguration configuration = new SiteConversionConfigurationParser(project)
+                .processAsciiDocConfig(siteConfig, emptyOptions, emptyAttributes);
+
+        // then
+        Map attributes = (Map) configuration.getOptions()
+                .map()
+                .get(ATTRIBUTES);
+        assertThat(attributes).
+                containsExactlyInAnyOrderEntriesOf(map(
+                        entry("imagesdir", "./images"),
+                        entry("source-highlighter", "coderay"),
+                        entry("sectnums", ""),
+                        entry("toc", "")
+                ));
+    }
+
+    @Test
+    public void should_map_null_attributes_as_empty_string() {
+        // given
+        final MavenProject project = fakeProject();
+        OptionsBuilder emptyOptions = OptionsBuilder.options();
+        AttributesBuilder emptyAttributes = AttributesBuilder.attributes();
+        Xpp3Dom siteConfig = Xpp3DoomBuilder.asciidocNode()
+                .addChild("attributes")
+                .addChild("toc", null)
+                .build();
+
+        // when
+        SiteConversionConfiguration configuration = new SiteConversionConfigurationParser(project)
+                .processAsciiDocConfig(siteConfig, emptyOptions, emptyAttributes);
+
+        // then
+        Map attributes = (Map) configuration
+                .getOptions()
+                .map()
+                .get(ATTRIBUTES);
+        assertThat(attributes).
+                containsExactlyInAnyOrderEntriesOf(map(
+                        entry("toc", "")
+                ));
+    }
+
+    @Test
+    public void should_map_true_boolean_attribute_as_empty_string_value() {
+        // given
+        final MavenProject project = fakeProject();
+        OptionsBuilder emptyOptions = OptionsBuilder.options();
+        AttributesBuilder emptyAttributes = AttributesBuilder.attributes();
+        Xpp3Dom siteConfig = Xpp3DoomBuilder.asciidocNode()
+                .addChild("attributes")
+                .addChild("toc", "true")
+                .build();
+
+        // when
+        SiteConversionConfiguration configuration = new SiteConversionConfigurationParser(project)
+                .processAsciiDocConfig(siteConfig, emptyOptions, emptyAttributes);
+
+        // then
+        Map attributes = (Map) configuration
+                .getOptions()
+                .map()
+                .get(ATTRIBUTES);
+        assertThat(attributes).
+                containsExactlyInAnyOrderEntriesOf(map(
+                        entry("toc", "")
+                ));
+    }
+
+    @Test
+    public void should_map_false_boolean_attribute_as_null_value() {
+        // given
+        final MavenProject project = fakeProject();
+        OptionsBuilder emptyOptions = OptionsBuilder.options();
+        AttributesBuilder emptyAttributes = AttributesBuilder.attributes();
+        Xpp3Dom siteConfig = Xpp3DoomBuilder.asciidocNode()
+                .addChild("attributes")
+                .addChild("toc", "false")
+                .build();
+
+        // when
+        SiteConversionConfiguration configuration = new SiteConversionConfigurationParser(project)
+                .processAsciiDocConfig(siteConfig, emptyOptions, emptyAttributes);
+
+        // then
+        final Map<String, Object> optionsMap = configuration.getOptions().map();
+        assertThat(optionsMap)
+                .hasSize(1);
+        Map attributes = (Map) optionsMap.get(ATTRIBUTES);
+        assertThat(attributes).
+                containsExactlyInAnyOrderEntriesOf(map(
+                        entry("toc", null)
+                ));
+    }
+
+    @Test
+    public void should_return_template_dirs_when_defined_as_templateDirs_dir() {
+        // given
+        final MavenProject project = fakeProject();
+        OptionsBuilder emptyOptions = OptionsBuilder.options();
+        AttributesBuilder emptyAttributes = AttributesBuilder.attributes();
+        Xpp3Dom siteConfig = Xpp3DoomBuilder.asciidocNode()
+                .addChild("templateDirs")
+                .addChild("dir", "path")
+                .parent()
+                .addChild("dir", "path2")
+                .build();
+
+        // when
+        SiteConversionConfiguration configuration = new SiteConversionConfigurationParser(project)
+                .processAsciiDocConfig(siteConfig, emptyOptions, emptyAttributes);
+
+        // then
+        final Map<String, Object> optionsMap = configuration.getOptions().map();
+        assertThat(optionsMap).containsOnlyKeys(ATTRIBUTES, TEMPLATE_DIRS);
+        assertThat(optionsMap.get(TEMPLATE_DIRS))
+                .isEqualTo(Arrays.asList(
+                        new File("path").getAbsolutePath(),
+                        new File("path2").getAbsolutePath()
+                ));
+        assertThat((Map) optionsMap.get(ATTRIBUTES)).isEmpty();
+    }
+
+    @Test
+    public void should_return_template_dirs_when_defined_as_template_dirs_dir() {
+        // given
+        final MavenProject project = fakeProject();
+        OptionsBuilder emptyOptions = OptionsBuilder.options();
+        AttributesBuilder emptyAttributes = AttributesBuilder.attributes();
+        Xpp3Dom siteConfig = Xpp3DoomBuilder.asciidocNode()
+                .addChild("template_dirs")
+                .addChild("dir", "path")
+                .parent()
+                .addChild("dir", "path2")
+                .build();
+
+        // when
+        SiteConversionConfiguration configuration = new SiteConversionConfigurationParser(project)
+                .processAsciiDocConfig(siteConfig, emptyOptions, emptyAttributes);
+
+        // then
+        final Map<String, Object> optionsMap = configuration.getOptions().map();
+        assertThat(optionsMap).containsOnlyKeys(ATTRIBUTES, TEMPLATE_DIRS);
+        assertThat(optionsMap.get(TEMPLATE_DIRS))
+                .isEqualTo(Arrays.asList(
+                        new File("path").getAbsolutePath(),
+                        new File("path2").getAbsolutePath()
+                ));
+        assertThat((Map) optionsMap.get(ATTRIBUTES)).isEmpty();
+    }
+
+    @Test
+    public void should_not_return_empty_template_dirs() {
+        // given
+        final MavenProject project = fakeProject();
+        OptionsBuilder emptyOptions = OptionsBuilder.options();
+        AttributesBuilder emptyAttributes = AttributesBuilder.attributes();
+        Xpp3Dom siteConfig = Xpp3DoomBuilder.asciidocNode()
+                .addChild("template_dirs")
+                .addChild("dir", "")
+                .parent()
+                .addChild("dir", null)
+                .build();
+
+        // when
+        SiteConversionConfiguration configuration = new SiteConversionConfigurationParser(project)
+                .processAsciiDocConfig(siteConfig, emptyOptions, emptyAttributes);
+
+        // then
+        final Map<String, Object> optionsMap = configuration.getOptions().map();
+        assertThat(optionsMap).containsOnlyKeys(ATTRIBUTES);
+        assertThat((Map) optionsMap.get(ATTRIBUTES)).isEmpty();
+    }
+
+    @Test
+    public void should_return_baseDir_dirs_when_defined_as_template_dirs_dir() {
+        // given
+        final MavenProject project = fakeProject();
+        OptionsBuilder emptyOptions = OptionsBuilder.options();
+        AttributesBuilder emptyAttributes = AttributesBuilder.attributes();
+        Xpp3Dom siteConfig = Xpp3DoomBuilder.asciidocNode()
+                .addChild("baseDir", "path")
+                .build();
+
+        // when
+        SiteConversionConfiguration configuration = new SiteConversionConfigurationParser(project)
+                .processAsciiDocConfig(siteConfig, emptyOptions, emptyAttributes);
+
+        // then
+        final Map<String, Object> optionsMap = configuration.getOptions().map();
+
+        assertThat(optionsMap).containsOnlyKeys(ATTRIBUTES, BASEDIR);
+        assertThat(optionsMap.get(BASEDIR))
+                .isEqualTo(new File("path").getAbsolutePath());
+        assertThat((Map) optionsMap.get(ATTRIBUTES)).isEmpty();
+    }
+
+    @Test
+    public void should_return_any_configuration_inside_asciidoc_node_as_option() {
+        // given
+        final MavenProject project = fakeProject();
+        OptionsBuilder emptyOptions = OptionsBuilder.options();
+        AttributesBuilder emptyAttributes = AttributesBuilder.attributes();
+        Xpp3Dom siteConfig = Xpp3DoomBuilder.asciidocNode()
+                .addChild("option-1", "value-1")
+                .parent().addChild("option_2", "value-2")
+                .parent().addChild("_option-3", "value-3")
+                .parent().addChild("option-4_", "value-4")
+                .parent().addChild("option.5", "value-5")
+                .build();
+
+        // when
+        SiteConversionConfiguration configuration = new SiteConversionConfigurationParser(project)
+                .processAsciiDocConfig(siteConfig, emptyOptions, emptyAttributes);
+
+        // then
+        final Map<String, Object> optionsMap = configuration.getOptions().map();
+        assertThat(optionsMap)
+                .containsOnlyKeys(ATTRIBUTES, "option-1", "option_2", "_option-3", "option-4_", "option.5");
+        assertThat(optionsMap.get("option-1")).isEqualTo("value-1");
+        assertThat(optionsMap.get("option_2")).isEqualTo("value-2");
+        assertThat(optionsMap.get("_option-3")).isEqualTo("value-3");
+        assertThat(optionsMap.get("option-4_")).isEqualTo("value-4");
+        assertThat(optionsMap.get("option.5")).isEqualTo("value-5");
+        assertThat((Map) optionsMap.get(ATTRIBUTES)).isEmpty();
+    }
+
+    @Test
+    public void should_return_and_format_any_maven_project_property_as_attribute() {
+        // given
+        final Map<String, String> projectProperties = new HashMap<>();
+        projectProperties.put("mvn.property-test1", "value-1");
+        projectProperties.put("mvn-property.test2", "value_2");
+        final MavenProject project = fakeProject(projectProperties);
+        OptionsBuilder emptyOptions = OptionsBuilder.options();
+        AttributesBuilder emptyAttributes = AttributesBuilder.attributes();
+        Xpp3Dom siteConfig = Xpp3DoomBuilder.asciidocNode().build();
+
+        // when
+        SiteConversionConfiguration configuration = new SiteConversionConfigurationParser(project)
+                .processAsciiDocConfig(siteConfig, emptyOptions, emptyAttributes);
+
+        // then
+        final Map<String, Object> optionsMap = configuration.getOptions().map();
+        assertThat(optionsMap)
+                .containsOnlyKeys(ATTRIBUTES);
+        Map attributes = (Map) optionsMap.get(ATTRIBUTES);
+        assertThat(attributes).containsExactlyInAnyOrderEntriesOf(map(
+                entry("mvn-property-test1", "value-1"),
+                entry("mvn-property-test2", "value_2")
+        ));
+    }
+
+    private MavenProject fakeProject() {
+        return fakeProject(null);
+    }
+
+    private MavenProject fakeProject(Map<String, String> properties) {
+        MavenProject project;
+        if (properties != null) {
+            final Model model = new Model();
+            model.getProperties().putAll(properties);
+            project = new MavenProject(model);
+        } else {
+            project = new MavenProject();
+        }
+        project.setFile(new File(".").getAbsoluteFile());
+        return project;
+    }
+
+
+    private Map<String, Object> map(Map.Entry<String, Object>... entries) {
+        final Map<String, Object> map = new HashMap<>();
+        for (Map.Entry<String, Object> entry : entries) {
+            map.put(entry.getKey(), entry.getValue());
+        }
+        return map;
+    }
+
+    private AbstractMap.SimpleEntry<String, Object> entry(String key, Object value) {
+        return new AbstractMap.SimpleEntry<>(key, value);
+    }
+
+}

--- a/src/test/java/org/asciidoctor/maven/site/SiteLogHandlerDeserializerTest.java
+++ b/src/test/java/org/asciidoctor/maven/site/SiteLogHandlerDeserializerTest.java
@@ -1,0 +1,209 @@
+package org.asciidoctor.maven.site;
+
+import org.asciidoctor.log.Severity;
+import org.asciidoctor.maven.log.FailIf;
+import org.asciidoctor.maven.log.LogHandler;
+import org.codehaus.plexus.util.xml.Xpp3Dom;
+import org.junit.Test;
+
+import static org.assertj.core.api.Assertions.assertThat;
+import static org.assertj.core.api.Assertions.catchThrowable;
+
+public class SiteLogHandlerDeserializerTest {
+
+    @Test
+    public void should_deserialize_null_logHandler() {
+        // given
+        final Xpp3Dom logHandlerConfig = null;
+        // when
+        LogHandler logHandler = new SiteLogHandlerDeserializer()
+                .deserialize(logHandlerConfig);
+        // then
+        assertThat(logHandler)
+                .usingRecursiveComparison()
+                .isEqualTo(defaultLogHandler());
+    }
+
+    @Test
+    public void should_deserialize_empty_logHandler() {
+        // given
+        final Xpp3Dom logHandlerConfig = Xpp3DoomBuilder.asciidocNode()
+                .build();
+        // when
+        LogHandler logHandler = new SiteLogHandlerDeserializer()
+                .deserialize(logHandlerConfig);
+        // then
+        assertThat(logHandler)
+                .usingRecursiveComparison()
+                .isEqualTo(defaultLogHandler());
+    }
+
+    @Test
+    public void should_deserialize_valid_outputToConsole() {
+        // given
+        final Xpp3Dom logHandlerConfig = Xpp3DoomBuilder.logHandler()
+                .addChild("outputToConsole", "false")
+                .build();
+        // when
+        LogHandler logHandler = new SiteLogHandlerDeserializer()
+                .deserialize(logHandlerConfig);
+        // then
+        LogHandler expected = new LogHandler();
+        expected.setOutputToConsole(Boolean.FALSE);
+        assertThat(logHandler)
+                .usingRecursiveComparison()
+                .isEqualTo(expected);
+    }
+
+    @Test
+    public void should_deserialize_invalid_outputToConsole() {
+        // given
+        final Xpp3Dom logHandlerConfig = Xpp3DoomBuilder.logHandler()
+                .addChild("outputToConsole", "text")
+                .build();
+        // when
+        LogHandler logHandler = new SiteLogHandlerDeserializer()
+                .deserialize(logHandlerConfig);
+        // then: set false as default (same as Maven does for a normal Mojo)
+        LogHandler expected = new LogHandler();
+        expected.setOutputToConsole(Boolean.FALSE);
+        assertThat(logHandler)
+                .usingRecursiveComparison()
+                .isEqualTo(expected);
+    }
+
+    @Test
+    public void should_deserialize_empty_failIf() {
+        // given
+        final Xpp3Dom logHandlerConfig = Xpp3DoomBuilder.logHandler()
+                .addChild("failIf")
+                .build();
+        // when
+        LogHandler logHandler = new SiteLogHandlerDeserializer()
+                .deserialize(logHandlerConfig);
+        // then:
+        assertThat(logHandler)
+                .usingRecursiveComparison()
+                .isEqualTo(defaultLogHandler());
+    }
+
+    @Test
+    public void should_deserialize_failIf_with_valid_severity() {
+        // given
+        final Xpp3Dom logHandlerConfig = Xpp3DoomBuilder.logHandler()
+                .addChild("failIf")
+                .addChild("severity", "INFO")
+                .build();
+        // when
+        LogHandler logHandler = new SiteLogHandlerDeserializer()
+                .deserialize(logHandlerConfig);
+        // then:
+        LogHandler expected = defaultLogHandler();
+        FailIf failIf = new FailIf();
+        failIf.setSeverity(Severity.INFO);
+        expected.setFailIf(failIf);
+        assertThat(logHandler)
+                .usingRecursiveComparison()
+                .isEqualTo(expected);
+    }
+
+    @Test
+    public void should_deserialize_failIf_with_invalid_severity() {
+        // given
+        final Xpp3Dom logHandlerConfig = Xpp3DoomBuilder.logHandler()
+                .addChild("failIf")
+                .addChild("severity", "INVALID")
+                .build();
+        // when
+        Throwable throwable = catchThrowable(() -> new SiteLogHandlerDeserializer()
+                .deserialize(logHandlerConfig));
+        // then: mimic Maven Mojo behaviour
+        assertThat(throwable)
+                .isInstanceOf(IllegalArgumentException.class)
+                .hasMessage("No enum constant org.asciidoctor.log.Severity.INVALID");
+    }
+
+    @Test
+    public void should_deserialize_failIf_with_empty_severity() {
+        // given
+        final Xpp3Dom logHandlerConfig = Xpp3DoomBuilder.logHandler()
+                .addChild("failIf")
+                .addChild("severity")
+                .build();
+        // when
+        LogHandler logHandler = new SiteLogHandlerDeserializer()
+                .deserialize(logHandlerConfig);
+        // then:
+        assertThat(logHandler)
+                .usingRecursiveComparison()
+                .isEqualTo(defaultLogHandler());
+    }
+
+    @Test
+    public void should_deserialize_failIf_with_containsText() {
+        // given
+        final String textPattern = "some words";
+        final Xpp3Dom logHandlerConfig = Xpp3DoomBuilder.logHandler()
+                .addChild("failIf")
+                .addChild("containsText", textPattern)
+                .build();
+        // when
+        LogHandler logHandler = new SiteLogHandlerDeserializer()
+                .deserialize(logHandlerConfig);
+        // then:
+        LogHandler expected = defaultLogHandler();
+        FailIf failIf = new FailIf();
+        failIf.setContainsText(textPattern);
+        expected.setFailIf(failIf);
+        assertThat(logHandler)
+                .usingRecursiveComparison()
+                .isEqualTo(expected);
+    }
+
+    @Test
+    public void should_deserialize_failIf_empty_containsText() {
+        // given
+        final Xpp3Dom logHandlerConfig = Xpp3DoomBuilder.logHandler()
+                .addChild("failIf")
+                .addChild("containsText")
+                .build();
+        // when
+        LogHandler logHandler = new SiteLogHandlerDeserializer()
+                .deserialize(logHandlerConfig);
+        // then:
+        assertThat(logHandler)
+                .usingRecursiveComparison()
+                .isEqualTo(defaultLogHandler());
+    }
+
+    @Test
+    public void should_deserialize_failIf_with_severity_and_containsText() {
+
+        // given
+        final String textPattern = "some words";
+        final Xpp3Dom logHandlerConfig = Xpp3DoomBuilder.logHandler()
+                .addChild("failIf")
+                .addChild("containsText", textPattern)
+                .parent()
+                .addChild("severity", "FATAL")
+                .build();
+        // when
+        LogHandler logHandler = new SiteLogHandlerDeserializer()
+                .deserialize(logHandlerConfig);
+        // then:
+        LogHandler expected = defaultLogHandler();
+        FailIf failIf = new FailIf();
+        failIf.setContainsText(textPattern);
+        failIf.setSeverity(Severity.FATAL);
+        expected.setFailIf(failIf);
+        assertThat(logHandler)
+                .usingRecursiveComparison()
+                .isEqualTo(expected);
+    }
+
+    private LogHandler defaultLogHandler() {
+        LogHandler expected = new LogHandler();
+        expected.setOutputToConsole(Boolean.TRUE);
+        return expected;
+    }
+}

--- a/src/test/java/org/asciidoctor/maven/site/Xpp3DoomBuilder.java
+++ b/src/test/java/org/asciidoctor/maven/site/Xpp3DoomBuilder.java
@@ -1,0 +1,54 @@
+package org.asciidoctor.maven.site;
+
+import org.codehaus.plexus.util.xml.Xpp3Dom;
+
+public class Xpp3DoomBuilder {
+
+    private Xpp3Dom rootNode;
+    private Xpp3Dom currentNode;
+
+    private Xpp3DoomBuilder(String name) {
+        rootNode = currentNode = new Xpp3Dom(name);
+    }
+
+    public static Xpp3DoomBuilder siteNode() {
+        return new Xpp3DoomBuilder("site");
+    }
+
+    public static Xpp3DoomBuilder asciidocNode() {
+        return siteNode().addChild("asciidoc");
+    }
+
+    public Xpp3DoomBuilder addChild(String name) {
+        final Xpp3Dom newNode = new Xpp3Dom(name);
+        currentNode.addChild(newNode);
+        currentNode = newNode;
+        return this;
+    }
+
+    public Xpp3DoomBuilder addChild(String name, String... values) {
+        Xpp3Dom newNode = null;
+        if (values == null) {
+            newNode = new Xpp3Dom(name);
+            currentNode.addChild(newNode);
+        } else {
+            for (String value : values) {
+                newNode = new Xpp3Dom(name);
+                newNode.setValue(value);
+                currentNode.addChild(newNode);
+            }
+        }
+        currentNode = newNode;
+        return this;
+    }
+
+    public Xpp3DoomBuilder parent() {
+        currentNode = currentNode.getParent();
+        return this;
+    }
+
+    public Xpp3Dom build() {
+        return rootNode;
+    }
+
+}

--- a/src/test/java/org/asciidoctor/maven/site/Xpp3DoomBuilder.java
+++ b/src/test/java/org/asciidoctor/maven/site/Xpp3DoomBuilder.java
@@ -11,16 +11,16 @@ public class Xpp3DoomBuilder {
         rootNode = currentNode = new Xpp3Dom(name);
     }
 
-    public static Xpp3DoomBuilder logHandler() {
-        return new Xpp3DoomBuilder("logHandler");
-    }
-
     public static Xpp3DoomBuilder siteNode() {
         return new Xpp3DoomBuilder("site");
     }
 
     public static Xpp3DoomBuilder asciidocNode() {
         return siteNode().addChild("asciidoc");
+    }
+
+    public static Xpp3DoomBuilder logHandler() {
+        return new Xpp3DoomBuilder("asciidoc").addChild("logHandler");
     }
 
     public Xpp3DoomBuilder addChild(String name) {

--- a/src/test/java/org/asciidoctor/maven/site/Xpp3DoomBuilder.java
+++ b/src/test/java/org/asciidoctor/maven/site/Xpp3DoomBuilder.java
@@ -11,6 +11,10 @@ public class Xpp3DoomBuilder {
         rootNode = currentNode = new Xpp3Dom(name);
     }
 
+    public static Xpp3DoomBuilder logHandler() {
+        return new Xpp3DoomBuilder("logHandler");
+    }
+
     public static Xpp3DoomBuilder siteNode() {
         return new Xpp3DoomBuilder("site");
     }


### PR DESCRIPTION
Closes #400 

This PR adds the possibility to add "logHandler" options to abort a site generation based on certain conditions (e.g. some warning messages are detected).
This PR:
* Adds `SiteConversionConfigurationParser` and `SiteLogHandlerDeserializer` to help reading site configurations.
* Removes support for `templateDir`, users should use `templateDirs`.
* Refactors log processing logic into `LogRecordsProcessors` to be reused between Mojos and site module. As a note, it has some "nasty" code due to the fact that Doxia and Mojos use different logging interfaces and return different exceptions. I am happy with this for now. In deeper refactors this can be reviewed.
* Updates README with logHandler explanation and some additional reviews.

It also includes:
* Update of plexus.component.metadata plugin to v1.7 to support usage of Lambas.