### PR TITLE
closes #376: replaces use of word render by convert in README and code

### DIFF
--- a/README.adoc
+++ b/README.adoc
@@ -122,13 +122,13 @@ When a custom value is set, no other paths are checked.
 [NOTE]
 ====
 All paths and AsciiDoc documents that start with `pass:[_]` are considered _internal_ and are skipped.
-That is, AsciiDocs are not rendered and resources are not copied to target, but you can include them normally from other AsciiDocs. +
+That is, AsciiDocs are not converted and resources are not copied from them, but you can include them normally from other AsciiDocs. +
 This is useful to split your sources in sets of master documents and included parts.
 ====
 
-sourceDocumentName:: an override to process a single source file; defaults to all files in `$\{sourceDirectory}`
-sourceDocumentExtensions:: (named `extensions` in v1.5.3 and below) a `List<String>` of non-standard file extensions to render.
-Currently ad, adoc, and asciidoc will be rendered by default
+sourceDocumentName:: an override to process a single source file; defaults to all files in [.path]`$\{sourceDirectory}`.
+sourceDocumentExtensions:: (named `extensions` in v1.5.3 and below) a `List<String>` of non-standard file extensions to convert.
+Currently, _ad_, _adoc_, and _asciidoc_ will be converted by default
 resources:: list of resource files to copy to the output directory (e.g., images, css).
 The configuration follows the same patterns as the `maven-resources-plugin`.
 If not set, all resources inside `$\{sourceDirectory}` are copied.
@@ -162,13 +162,15 @@ When converting to HTML, images must be copied to the output location so that th
     ...
 </resources>
 ----
-outputDirectory:: relative paths are added to the project root path. Defaults to [.path]_${project.build.directory}/generated-docs_.
+outputDirectory:: locations where converted sources and copied resources will be places.
+Note that relative paths are added to the project root path.
+Defaults to [.path]_${project.build.directory}/generated-docs_.
 outputFile:: defaults to `null`, used to override the name of the generated output file, can be a relative or absolute path.
 Useful for backends that create a single file, e.g. the pdf backend.
 All output will be redirected to the same file, the same way as the `-o, --out-file=OUT_FILE` option from the `asciidoctor` CLI command.
 baseDir:: (not Maven's basedir) enables to set the root path for resources (e.g. included files), defaults to `$\{sourceDirectory}`
 skip:: set this to `true` to bypass generation, defaults to `false`
-preserveDirectories:: enables to specify whether the documents should be rendered in the same folder structure as in the source directory or not, defaults to `false`.
+preserveDirectories:: enables to specify whether the documents should be converted in the same folder structure as in the source directory or not, defaults to `false`.
 When `true`, instead of generating all output in a single folder, output files are generated in the same structure.
 See the following example
 +
@@ -188,16 +190,10 @@ backend:: defaults to `html5`
 doctype:: defaults to `null` (which trigger's Asciidoctor's default of `article`)
 eruby:: defaults to erb, the version used in JRuby
 headerFooter:: defaults to `true`
-templateDirs:: list of directories of Tilt-compatible templates to be used instead of the default built-in templates, empty by default
-+
-[NOTE]
-====
-Order is not relevant for templateDir and templateDirs.
-Values set in both properties are merged together into a single final list.
-====
+templateDirs:: list of directories of compatible templates to be used instead of the default built-in templates, empty by default.
 templateEngine:: template engine to use for the custom converter templates, disabled by default (`null`)
 templateCache:: enables the built-in cache used by the template converter when reading the source of template files.
-Only relevant if the `:template_dir` option is specified, defaults to `true`
+Only relevant if the `:template_dirs` option is specified, defaults to `true`.
 sourcemap:: adds file and line number information to each parsed block (`lineno` and `source_location` attributes), defaults to `false`
 catalogAssets:: tells the parser to capture images and links in the reference table available via the `references` property on the document AST object (experimental), defaults to `false`
 attributes:: a `Map<String,Object>` of Asciidoctor attributes to pass for conversion, defaults to `null`
@@ -209,14 +205,14 @@ attributes:: a `Map<String,Object>` of Asciidoctor attributes to pass for conver
     <source-highlighter>coderay</source-highlighter>
 </attributes>
 ----
-embedAssets:: Embedd the CSS file, etc into the output, defaults to `false`
+embedAssets:: embeds the CSS file and images into the output, defaults to `false`
 gemPaths:: enables to specify the location to one or more gem installation directories (same as GEM_PATH environment var), `empty` by default
 requires:: a `List<String>` to specify additional Ruby libraries not packaged in AsciidoctorJ, `empty` by default
-extensions:: `List` of extensions to include during the conversion process (see link:https://github.com/asciidoctor/asciidoctorj/blob/master/README.adoc#extension-api[AsciidoctorJ's Extension API] for information about the available options).
+extensions:: `List` of extensions to include during the conversion process (see link:https://github.com/asciidoctor/asciidoctorj/blob/master/docs/integrator-guide.adoc#automatically-loading-extensions[AsciidoctorJ's Extension API] for information about the available options).
 For each extension, the implementation class must be specified in the `className` parameter, the `blockName` is only required when configuring a _BlockProcessor_, _BlockMacroProcessor_ or _InlineMacroProcessor_.
-Here follows a configuration example:
 +
 [source,xml]
+.extensions configuration example
 ----
 <plugin>
     ...
@@ -245,7 +241,7 @@ Here follows a configuration example:
     </dependencies>
 </plugin>
 ----
-<1> Note that processors must be included in the plugin's execution classpath, not in the project's.
+<1> Extensions must be included in the plugin's execution classpath, not in the project's.
 
 NOTE: Extensions can also be integrated through the SPI interface implementation.
 This method does not require any configuration in the [.path]_pom.xml_, see link:https://github.com/asciidoctor/asciidoctorj#extension-spi[Extension SPI] for details.
@@ -254,11 +250,11 @@ enableVerbose:: enables Asciidoctor verbose messages, defaults to `false`.
 Enable it, for example, if you want to validate https://asciidoctor.org/docs/user-manual/#validating-internal-cross-references[internal cross references] and capture the messages with the logHandler option.
 
 [[logHandler-configuration]]
-logHandler:: enables processing of Asciidoctor messages (e.g. errors on missing included files), to hide messages as well setup build fail conditions based on them.
-Contains the following configuration elements:
+logHandler:: enables processing options for Asciidoctor messages (e.g. errors on missing included files), to either hide messages or setup build fail conditions based on them.
+Options are:
 
 * `outputToConsole`: `Boolean`, defaults to `true`.
-Redirects all Asciidoctor messages to Maven's console logger as INFO during renderization.
+Redirects all Asciidoctor messages to Maven's console logger as INFO during conversion.
 * `failIf`: build fail conditions, disabled by default.
 Allows setting one or many conditions that when met, abort the Maven build with `BUILD FAILURE` status.
 +
@@ -383,7 +379,6 @@ For example, the following configuration could be modified with the command opti
 ----
 <configuration>
     <backend>html5</backend>
-    <sourceHighlighter>coderay</sourceHighlighter>
     <attributes>
         <toc>left</toc>
     </attributes>
@@ -394,7 +389,7 @@ For example, the following configuration could be modified with the command opti
 
  mvn generate-resources -Dasciidoctor.attributes="toc=right source-highlighter=highlight.js imagesdir=my_images"
 
-Note that in the second case we need to use quotes due to the spaces, and that `source-highlighter` is the asciidoctor attribute name used to update the configuration.
+Note that in the second case we need to use quotes due to the spaces.
 
 === Multiple outputs for the same file
 
@@ -410,22 +405,22 @@ An example of this setup is below:
     <artifactId>asciidoctor-maven-plugin</artifactId>
     <version>{release-version}</version>
     <executions>
-        <execution>
+        <execution> <!--.-->
             <id>output-html</id>
             <phase>generate-resources</phase>
             <goals>
                 <goal>process-asciidoc</goal>
             </goals>
             <configuration>
-                <sourceHighlighter>coderay</sourceHighlighter>
                 <backend>html</backend>
                 <attributes>
                     <toc/>
                     <linkcss>false</linkcss>
+                    <source-highlighter>coderay</source-highlighter>
                 </attributes>
             </configuration>
         </execution>
-        <execution>
+        <execution> <!--.-->
             <id>output-docbook</id>
             <phase>generate-resources</phase>
             <goals>
@@ -437,15 +432,16 @@ An example of this setup is below:
             </configuration>
         </execution>
     </executions>
-    <configuration>
+    <configuration>  <!--.-->
         <sourceDirectory>src/main/asciidoc</sourceDirectory>
         <headerFooter>true</headerFooter>
     </configuration>
 </plugin>
 ----
-
-Any configuration specified outside the executions section is inherited by each execution.
-This allows an easier way of defining common configuration options.
+<.> First execution, converts documents to HTML.
+<.> Second execution, converts documents to DocBook.
+<.> Any configuration outside the executions section is inherited by each execution.
+This allows an easier way to share common configuration options.
 
 == Maven Site Integration
 
@@ -479,8 +475,8 @@ IMPORTANT: Maven v3.2.1 or above required, and since asciidoctor-maven-plugin v1
 The Asciidoctor Doxia module follows the maven-site-plugin conventions for file location, and delegates all resource management to it.
 
 First, all of your AsciiDoc-based files should be placed in [.path]_src/site/asciidoc_ with an extension of `.adoc`.
-These files will be rendered into the [.path]_target/site_ directory.
-For example, the file [.path]_src/site/asciidoc/usage.adoc_ will be rendered into [.path]_target/site/usage.html_.
+These files will be converted into the [.path]_target/site_ directory.
+For example, the file [.path]_src/site/asciidoc/usage.adoc_ will be converted into [.path]_target/site/usage.html_.
 
 Then, all resources (images, css, etc.) should be placed in [.path]_src/site/resources_.
 These will be automatically copied into [.path]_target/site_.
@@ -574,7 +570,7 @@ templatesDirs (also template_dirs)::
 Built-in templates are supported by specifying one or more template directories.
 This feature enables you to provide custom templates for converting any node in the tree (e.g., document, section, listing, etc).
 Custom templates can be extremely helpful when trying to customize the appearance of your site.
-Note that each one should be enclosed in a `<dir>` element.
+Each path to add should be enclosed in a `<dir>` element.
 
 requires::
 Same as the plugin's `requires`. +

--- a/src/main/java/org/asciidoctor/maven/AsciidoctorHttpMojo.java
+++ b/src/main/java/org/asciidoctor/maven/AsciidoctorHttpMojo.java
@@ -47,7 +47,7 @@ public class AsciidoctorHttpMojo extends AsciidoctorRefreshMojo {
     }
 
     @Override
-    protected void renderFile(final Asciidoctor asciidoctorInstance, final Map<String, Object> options, final File f) {
+    protected void convertFile(final Asciidoctor asciidoctorInstance, final Map<String, Object> options, final File f) {
         asciidoctorInstance.convertFile(f, options);
 
         if (autoReloadInterval > 0 && backend.toLowerCase().startsWith("html")) {
@@ -60,7 +60,7 @@ public class AsciidoctorHttpMojo extends AsciidoctorRefreshMojo {
                 { // read
                     FileInputStream fis = null;
                     try {
-                        fis = new FileInputStream(out); // java asciidoctor render() doesn't work ATM so read the rendered file instead of doing it in memory
+                        fis = new FileInputStream(out); // java asciidoctor render() doesn't work ATM so read the converted file instead of doing it in memory
                         content = IO.slurp(fis);
                     } catch (final Exception e) {
                         getLog().error(e);
@@ -69,7 +69,7 @@ public class AsciidoctorHttpMojo extends AsciidoctorRefreshMojo {
                     }
                 }
 
-                if (content != null) { // render + write
+                if (content != null) { // convert + write
                     FileOutputStream fos = null;
                     try {
                         fos = new FileOutputStream(out);
@@ -85,7 +85,7 @@ public class AsciidoctorHttpMojo extends AsciidoctorRefreshMojo {
             asciidoctorInstance.convertFile(f, options);
         }
 
-        logRenderedFile(f);
+        logConvertedFile(f);
     }
 
     private String addRefreshing(final String html) {

--- a/src/main/java/org/asciidoctor/maven/AsciidoctorMojo.java
+++ b/src/main/java/org/asciidoctor/maven/AsciidoctorMojo.java
@@ -45,14 +45,13 @@ import org.sonatype.plexus.build.incremental.BuildContext;
 import java.io.File;
 import java.io.IOException;
 import java.util.*;
-import java.util.function.Consumer;
 import java.util.logging.Logger;
 
 import static org.asciidoctor.maven.SourceDirectoryFinder.DEFAULT_SOURCE_DIR;
 
 
 /**
- * Basic maven plugin goal to render AsciiDoc files using Asciidoctor, a ruby port.
+ * Basic maven plugin goal to convert AsciiDoc files using Asciidoctor, a ruby port.
  */
 @Mojo(name = "process-asciidoc", threadSafe = true)
 public class AsciidoctorMojo extends AbstractMojo {
@@ -247,7 +246,7 @@ public class AsciidoctorMojo extends AbstractMojo {
             if (!dirs.add(destinationPath))
                 getLog().warn("Duplicated destination found: overwriting file: " + destinationPath.getAbsolutePath());
 
-            renderFile(asciidoctor, optionsBuilder.asMap(), source);
+            convertFile(asciidoctor, optionsBuilder.asMap(), source);
 
             try {
                 // process log messages according to mojo configuration
@@ -460,13 +459,13 @@ public class AsciidoctorMojo extends AbstractMojo {
         }
     }
 
-    protected void renderFile(Asciidoctor asciidoctor, Map<String, Object> options, File f) {
+    protected void convertFile(Asciidoctor asciidoctor, Map<String, Object> options, File f) {
         asciidoctor.convertFile(f, options);
-        logRenderedFile(f);
+        logConvertedFile(f);
     }
 
-    protected void logRenderedFile(File f) {
-        getLog().info("Rendered " + f.getAbsolutePath());
+    protected void logConvertedFile(File f) {
+        getLog().info("Converted " + f.getAbsolutePath());
     }
 
     protected void synchronize(final Synchronization synchronization) {

--- a/src/main/java/org/asciidoctor/maven/AsciidoctorRefreshMojo.java
+++ b/src/main/java/org/asciidoctor/maven/AsciidoctorRefreshMojo.java
@@ -77,18 +77,18 @@ public class AsciidoctorRefreshMojo extends AsciidoctorMojo {
         updaterScheduler = Executors.newScheduledThreadPool(1);
 
         // we prevent refreshing more often than all 200ms and we refresh at least once/s
-        // NOTE1: it is intended to avoid too much time space between file polling and re-rendering
+        // NOTE1: it is intended to avoid too much time space between file polling and re-convertin
         // NOTE2: if nothing to refresh it does nothing so all is fine
         updaterScheduler.scheduleAtFixedRate(new Updater(needsUpdate, this), 0, Math.min(1000, Math.max(200, interval / 2)), TimeUnit.MILLISECONDS);
     }
 
     protected void doWork() throws MojoFailureException, MojoExecutionException {
-        getLog().info("Rendered doc in " + executeAndReturnDuration() + "ms");
+        getLog().info("Converted doc in " + executeAndReturnDuration() + "ms");
         doWait();
     }
 
     protected void doWait() {
-        getLog().info("Type [exit|quit] to exit and [refresh] to force a manual re-rendering.");
+        getLog().info("Type [exit|quit] to exit and [refresh] to force a manual re-conversion.");
 
         String line;
         final Scanner scanner = new Scanner(System.in);
@@ -127,7 +127,7 @@ public class AsciidoctorRefreshMojo extends AsciidoctorMojo {
         }
 
         try {
-            getLog().info("Re-rendered doc in " + executeAndReturnDuration() + "ms");
+            getLog().info("Re-converted doc in " + executeAndReturnDuration() + "ms");
         } catch (final MojoExecutionException e) {
             getLog().error(e);
         } catch (final MojoFailureException e) {

--- a/src/main/java/org/asciidoctor/maven/log/AsciidoctorConversionException.java
+++ b/src/main/java/org/asciidoctor/maven/log/AsciidoctorConversionException.java
@@ -2,11 +2,11 @@ package org.asciidoctor.maven.log;
 
 import org.asciidoctor.log.LogRecord;
 
-public class AsciidoctorConvertionException extends Exception {
+public class AsciidoctorConversionException extends Exception {
 
     private final LogRecord logRecord;
 
-    public AsciidoctorConvertionException(String message, LogRecord logRecord) {
+    public AsciidoctorConversionException(String message, LogRecord logRecord) {
         super(message);
         this.logRecord = logRecord;
     }

--- a/src/main/java/org/asciidoctor/maven/log/LogRecordsProcessors.java
+++ b/src/main/java/org/asciidoctor/maven/log/LogRecordsProcessors.java
@@ -41,7 +41,7 @@ public class LogRecordsProcessors {
                 for (LogRecord record : records) {
                     errorMessageConsumer.accept(LogRecordHelper.format(record, sourceDirectory));
                 }
-                throw new Exception(String.format("Found %s issue(s) of severity %s or higher during rendering", records.size(), severity));
+                throw new Exception(String.format("Found %s issue(s) of severity %s or higher during conversion", records.size(), severity));
             }
         } else if (logHandler.isContainsTextNotBlank()) {
             final String textToSearch = logHandler.getFailIf().getContainsText();

--- a/src/test/groovy/org/asciidoctor/maven/test/AsciidoctorHttpMojoTest.groovy
+++ b/src/test/groovy/org/asciidoctor/maven/test/AsciidoctorHttpMojoTest.groovy
@@ -15,7 +15,7 @@ class AsciidoctorHttpMojoTest extends Specification {
         MockPlexusContainer.initializeMockContext(AsciidoctorHttpMojo)
     }
 
-    def "http front should let access rendered files"() {
+    def "http front should let access converted files"() {
         setup:
             def srcDir = new File('target/test-classes/src/asciidoctor-http')
             def outputDir = new File('target/asciidoctor-http-output')

--- a/src/test/groovy/org/asciidoctor/maven/test/AsciidoctorMojoExtensionsTest.groovy
+++ b/src/test/groovy/org/asciidoctor/maven/test/AsciidoctorMojoExtensionsTest.groovy
@@ -75,7 +75,7 @@ class AsciidoctorMojoExtensionsTest extends Specification {
             ]
             mojo.execute()
         then:
-            // since v 1.5.4 resources are copied before rendering, so some files remain
+            // since v 1.5.4 resources are copied before conversion, so some files remain
             outputDir.list().size() > 0
             thrown(RuntimeException)
     }
@@ -119,7 +119,7 @@ class AsciidoctorMojoExtensionsTest extends Specification {
             'UriIncludeProcessor'   |'IncludeProcessor'       || "UriIncludeProcessor(IncludeProcessor) initialized"          || 'Processing UriIncludeProcessor'
     }
 
-    def "successfully renders html with a preprocessor"() {
+    def "successfully converts html with a preprocessor"() {
         setup:
             File srcDir = new File(SRC_DIR)
             File outputDir = new File("${OUTPUT_DIR}/preprocessor/${System.currentTimeMillis()}")
@@ -145,7 +145,7 @@ class AsciidoctorMojoExtensionsTest extends Specification {
             text.count(ChangeAttributeValuePreprocessor.AUTHOR_NAME) == 2
     }
 
-    def "successfully renders html with a blockprocessor"() {
+    def "successfully converts html with a blockprocessor"() {
         setup:
             File srcDir = new File(SRC_DIR)
             File outputDir = new File("${OUTPUT_DIR}/blockprocessor/${System.currentTimeMillis()}")
@@ -170,7 +170,7 @@ class AsciidoctorMojoExtensionsTest extends Specification {
             sampleOutput.getText().contains('The time is now. Get a move on.'.toUpperCase())
     }
     
-    def "successfully renders html and adds meta tag with a DocinfoProcessor"() {
+    def "successfully converts html and adds meta tag with a DocinfoProcessor"() {
         setup:
             File srcDir = new File(SRC_DIR)
             File outputDir = new File("${OUTPUT_DIR}/docinfoProcessor/${System.currentTimeMillis()}")
@@ -195,7 +195,7 @@ class AsciidoctorMojoExtensionsTest extends Specification {
             sampleOutput.text.contains("<meta name=\"author\" content=\"asciidoctor\">")
     }
 
-    def "successfully renders html and modifies output with a BlockMacroProcessor"() {
+    def "successfully converts html and modifies output with a BlockMacroProcessor"() {
         setup:
             File srcDir = new File(SRC_DIR)
             File outputDir = new File("${OUTPUT_DIR}/blockMacroProcessor/${System.currentTimeMillis()}")
@@ -220,7 +220,7 @@ class AsciidoctorMojoExtensionsTest extends Specification {
             sampleOutput.text.contains("<script src=\"https://gist.github.com/123456.js\"></script>")
     }
 
-    def "successfully renders html and modifies output with a InlineMacroProcessor"() {
+    def "successfully converts html and modifies output with a InlineMacroProcessor"() {
         setup:
             File srcDir = new File(SRC_DIR)
             File outputDir = new File("${OUTPUT_DIR}/inlineMacroProcessor/${System.currentTimeMillis()}")
@@ -245,7 +245,7 @@ class AsciidoctorMojoExtensionsTest extends Specification {
             sampleOutput.text.contains("<p>See <a href=\"gittutorial.html\">gittutorial</a> to get started.</p>")
     }
     
-    def "successfully renders html and modifies output with an IncludeProcessor"() {
+    def "successfully converts html and modifies output with an IncludeProcessor"() {
         setup:
             File srcDir = new File(SRC_DIR)
             File outputDir = new File("${OUTPUT_DIR}/includeProcessor/${System.currentTimeMillis()}")
@@ -303,7 +303,7 @@ class AsciidoctorMojoExtensionsTest extends Specification {
 
 
     // Adding a BlockMacroProcessor or BlockProcessor makes the conversion fail
-    def "successfully renders html with Preprocessor, DocinfoProcessor, InlineMacroProcessor and IncludeProcessor"() {
+    def "successfully converts html with Preprocessor, DocinfoProcessor, InlineMacroProcessor and IncludeProcessor"() {
         setup:
             File srcDir = new File(SRC_DIR)
             File outputDir = new File("${OUTPUT_DIR}/processors/${System.currentTimeMillis()}")
@@ -340,7 +340,7 @@ class AsciidoctorMojoExtensionsTest extends Specification {
             text.contains("source 'https://rubygems.org'")
     }
     
-    def "renders html when using all types of extensions"() {
+    def "converts html when using all types of extensions"() {
         setup:
             File srcDir = new File(SRC_DIR)
             File outputDir = new File("${OUTPUT_DIR}/processors/${System.currentTimeMillis()}")

--- a/src/test/groovy/org/asciidoctor/maven/test/AsciidoctorMojoLogHandlerTest.groovy
+++ b/src/test/groovy/org/asciidoctor/maven/test/AsciidoctorMojoLogHandlerTest.groovy
@@ -209,7 +209,7 @@ class AsciidoctorMojoLogHandlerTest extends Specification {
 
         then: 'issues with WARN and ERROR are returned'
         def e = thrown(MojoExecutionException)
-        e.message.contains('Found 4 issue(s) of severity WARN or higher during rendering')
+        e.message.contains('Found 4 issue(s) of severity WARN or higher during conversion')
     }
 
     def "should fail when logHandler failIf = ERROR"() {
@@ -233,7 +233,7 @@ class AsciidoctorMojoLogHandlerTest extends Specification {
 
         then:
         def e = thrown(MojoExecutionException)
-        e.message.contains('Found 3 issue(s) of severity ERROR or higher during rendering')
+        e.message.contains('Found 3 issue(s) of severity ERROR or higher during conversion')
     }
 
     def "should not fail if containsText does not match any message"() {

--- a/src/test/groovy/org/asciidoctor/maven/test/AsciidoctorMojoTest.groovy
+++ b/src/test/groovy/org/asciidoctor/maven/test/AsciidoctorMojoTest.groovy
@@ -22,7 +22,7 @@ class AsciidoctorMojoTest extends Specification {
         MockPlexusContainer.initializeMockContext(AsciidoctorMojo)
     }
 
-    def "renders docbook"() {
+    def "converts docbook"() {
         setup:
             File srcDir = new File(DEFAULT_SOURCE_DIRECTORY)
             File outputDir = new File('target/asciidoctor-output')
@@ -44,7 +44,7 @@ class AsciidoctorMojoTest extends Specification {
             sampleOutput.length() > 0
     }
 
-    def "renders html"() {
+    def "converts html"() {
         setup:
             File srcDir = new File(DEFAULT_SOURCE_DIRECTORY)
             File outputDir = new File('target/asciidoctor-output')
@@ -575,7 +575,7 @@ class AsciidoctorMojoTest extends Specification {
         text.contains('<img src="data:image/jpg;base64,/9j/4AAQSkZJRgABAQEASABIAAD/4gzESUNDX1BST0ZJTEUAAQEAAA')
     }
 
-    def 'code highlighting should be rendered when set in the document header'() {
+    def 'code highlighting should be converted when set in the document header'() {
         setup:
         File srcDir = new File('src/test/resources/src/asciidoctor')
         File outputDir = new File('target/asciidoctor-output-sourceHighlighting/header')
@@ -772,8 +772,8 @@ class AsciidoctorMojoTest extends Specification {
      *  - relativeBaseDir = true
      *
      *  Expected:
-     *   - all documents are rendered in the same folder structure found in the sourceDirectory
-     *   - all documents are correctly rendered with the import
+     *   - all documents are converted in the same folder structure found in the sourceDirectory
+     *   - all documents are correctly converted with the import
      */
     def 'should replicate source structure-standard paths'() {
         setup:
@@ -799,8 +799,8 @@ class AsciidoctorMojoTest extends Specification {
             }
             asciidocs.size() == 6
             // Checks that all imports are found in the respective baseDir
-            for (File renderedFile in asciidocs) {
-                assert renderedFile.text.contains('Unresolved directive') == false
+            for (File convertedFile in asciidocs) {
+                assert convertedFile.text.contains('Unresolved directive') == false
             }
         cleanup:
             // Avoids false positives in other tests
@@ -814,8 +814,8 @@ class AsciidoctorMojoTest extends Specification {
      *  - relativeBaseDir = true
      *
      *  Expected:
-     *   - all documents are rendered in the same folder structure found in the sourceDirectory
-     *   - all documents are correctly rendered with the import
+     *   - all documents are converted in the same folder structure found in the sourceDirectory
+     *   - all documents are correctly converted with the import
      */
     def 'should replicate source structure-complex paths'() {
         setup:
@@ -842,8 +842,8 @@ class AsciidoctorMojoTest extends Specification {
             }
             asciidocs.size() == 6
             // Checks that all imports are found in the respective baseDir
-            for (File renderedFile in asciidocs) {
-                assert renderedFile.text.contains('Unresolved directive') == false
+            for (File convertedFile in asciidocs) {
+                assert convertedFile.text.contains('Unresolved directive') == false
             }
         cleanup:
             // Avoid possible false positives in other tests
@@ -857,8 +857,8 @@ class AsciidoctorMojoTest extends Specification {
      *  - relativeBaseDir = false
      *
      *  Expected:
-     *   - all documents are rendered in the same outputDirectory. 1 document is overwritten
-     *   - all documents but 1 (in the root) are incorrectly rendered because they cannot find the imported file
+     *   - all documents are converted in the same outputDirectory. 1 document is overwritten
+     *   - all documents but 1 (in the root) are incorrectly converted because they cannot find the imported file
      */
     def 'should not replicate source structure-complex paths'() {
         setup:
@@ -879,9 +879,9 @@ class AsciidoctorMojoTest extends Specification {
 			asciidocs.length == 5
             // folders are copied anyway
             assertEqualsStructure(srcDir.listFiles(DIRECTORY_FILTER), outputDir.listFiles(DIRECTORY_FILTER))
-			for (File renderedFile in asciidocs) {
-				if (renderedFile.getName() != 'HelloWorld.html') {
-					assert renderedFile.text.contains('Unresolved directive')
+			for (File convertedFile in asciidocs) {
+				if (convertedFile.getName() != 'HelloWorld.html') {
+					assert convertedFile.text.contains('Unresolved directive')
 				}
 			}
         cleanup:
@@ -896,8 +896,8 @@ class AsciidoctorMojoTest extends Specification {
      *  - relativeBaseDir = false
      *
      *  Expected:
-     *   - all documents are rendered in the same folder structure found in the sourceDirectory
-     *   - all documents but 1 (in the root) are incorrectly rendered because they cannot find the imported file
+     *   - all documents are converted in the same folder structure found in the sourceDirectory
+     *   - all documents but 1 (in the root) are incorrectly converted because they cannot find the imported file
      */
     def 'should replicate source structure-no baseDir rewrite'() {
         setup:
@@ -924,9 +924,9 @@ class AsciidoctorMojoTest extends Specification {
             }
             asciidocs.size() == 6
             // Looks for import errors in all files but the one in the root folder
-            for (File renderedFile in asciidocs) {
-                if (renderedFile.getName() != 'HelloWorld.html') {
-                    assert renderedFile.text.contains('Unresolved directive')
+            for (File convertedFile in asciidocs) {
+                if (convertedFile.getName() != 'HelloWorld.html') {
+                    assert convertedFile.text.contains('Unresolved directive')
                 }
             }
 
@@ -941,7 +941,7 @@ class AsciidoctorMojoTest extends Specification {
      *  - preserveDirectories = false
      *  - relativeBaseDir = true
      *
-     *  Expected: all documents are correctly rendered in the same folder
+     *  Expected: all documents are correctly converted in the same folder
      */
     def 'should not replicate source structure-baseDir rewrite'() {
         setup:
@@ -960,13 +960,13 @@ class AsciidoctorMojoTest extends Specification {
 
         then:
             assertEqualsStructure(srcDir.listFiles(DIRECTORY_FILTER), outputDir.listFiles(DIRECTORY_FILTER))
-			// all files are rendered in the outputDirectory
+			// all files are converted in the outputDirectory
             def asciidocs = outputDir.listFiles({File f -> f.getName().endsWith('html')} as FileFilter)
 			// 1 file is missing because 2 share the same name and 1 is overwritten in outputDirectory
             asciidocs.length == 5
             // Checks that all imports are found correctly because baseDir is adapted for each file
-            for (File renderedFile in asciidocs) {
-                assert renderedFile.text.contains('Unresolved directive') == false
+            for (File converted in asciidocs) {
+                assert converted.text.contains('Unresolved directive') == false
             }
 
         cleanup:
@@ -1093,7 +1093,7 @@ class AsciidoctorMojoTest extends Specification {
             mojo.backend = 'html5'
             mojo.outputDirectory = outputDir
             mojo.execute()
-        then: 'only rendered (html) files are found in the target directory'
+        then: 'only converts (html) files are found in the target directory'
             def allFiles = outputDir.listFiles({File f -> f.isFile()} as FileFilter)
             def htmlFiles = FileUtils.listFiles(outputDir, ['html'] as String[], true)
             allFiles.size() == htmlFiles.size()
@@ -1101,7 +1101,7 @@ class AsciidoctorMojoTest extends Specification {
 
     }
 
-    def "should only render a single file and not copy any resource"() {
+    def "should only convert a single file and not copy any resource"() {
         setup:
             File outputDir = new File("$MULTIPLE_RESOURCES_OUTPUT/file-pattern/${System.currentTimeMillis()}")
 
@@ -1150,7 +1150,7 @@ class AsciidoctorMojoTest extends Specification {
             mojo.execute()
         then:
             def files = outputDir.listFiles({File f -> f.isFile()} as FileFilter)
-            // includes 2 rendered AsciiDoc documents and 3 resources
+            // includes 2 converted AsciiDoc documents and 3 resources
             files.size() == 5
             // from 'issue-78' directory
             // resource files obtained using the include
@@ -1165,7 +1165,7 @@ class AsciidoctorMojoTest extends Specification {
             FileUtils.listFiles(outputDir, ["jpg"] as String[], true).size() == 0
     }
 
-    def "should render GitHub README alone"() {
+    def "should convert GitHub README alone"() {
         setup:
             File outputDir = new File("$MULTIPLE_RESOURCES_OUTPUT/readme/${System.currentTimeMillis()}")
 
@@ -1184,7 +1184,7 @@ class AsciidoctorMojoTest extends Specification {
             mojo.execute()
         then:
             def files = outputDir.listFiles({File f -> f.isFile()} as FileFilter)
-            // includes only 1 rendered AsciiDoc document
+            // includes only 1 converted AsciiDoc document
             files.size() == 1
             files.first().text.contains('Asciidoctor Maven Plugin')
     }
@@ -1231,7 +1231,7 @@ class AsciidoctorMojoTest extends Specification {
             mojo.execute()
         then:
             def files = outputDir.listFiles({File f -> f.isFile()} as FileFilter)
-            // includes only 1 rendered AsciiDoc document
+            // includes only 1 converted AsciiDoc document
             files.size() == 1
             files.first().text.contains('Asciidoctor Maven Plugin')
     }
@@ -1257,7 +1257,7 @@ class AsciidoctorMojoTest extends Specification {
         then:
             def files = outputDir.listFiles({File f -> f.isFile()} as FileFilter)
             FileUtils.listFiles(outputDir, ['ext'] as String[], true).isEmpty()
-            // includes only 1 rendered AsciiDoc document
+            // includes only 1 converted AsciiDoc document
             def file = new File(outputDir, 'sample.html')
             file.text.contains('Asciidoctor default stylesheet')
     }
@@ -1288,7 +1288,7 @@ class AsciidoctorMojoTest extends Specification {
                 if (it.getName() ==~ /.+html/) asciidocs << it
             }
             asciidocs.size() == 5
-            newOut.toString().count("Rendered") == 6
+            newOut.toString().count("Converte") == 6
             newOut.toString().count("Duplicated destination found") == 1
         cleanup:
             System.setOut(originalOut)
@@ -1321,7 +1321,7 @@ class AsciidoctorMojoTest extends Specification {
                 if (it.getName() ==~ /.+html/) asciidocs << it
             }
             asciidocs.size() == 1
-            newOut.toString().count("Rendered") == 6
+            newOut.toString().count("Converte") == 6
             newOut.toString().count("Duplicated destination found") == 5
         cleanup:
             System.setOut(originalOut)
@@ -1356,7 +1356,7 @@ class AsciidoctorMojoTest extends Specification {
                 if (it.getName() ==~ /.+html/) asciidocs << it
             }
             asciidocs.size() == 5
-            newOut.toString().count("Rendered") == 6
+            newOut.toString().count("Converte") == 6
             newOut.toString().count("Duplicated destination found") == 1
         cleanup:
             System.setOut(originalOut)

--- a/src/test/groovy/org/asciidoctor/maven/test/AsciidoctorRefreshMojoTest.groovy
+++ b/src/test/groovy/org/asciidoctor/maven/test/AsciidoctorRefreshMojoTest.groovy
@@ -14,7 +14,7 @@ class AsciidoctorRefreshMojoTest extends Specification {
         MockPlexusContainer.initializeMockContext(AsciidoctorRefreshMojo)
     }
 
-    def "auto render when source updated"() {
+    def "auto convert when source updated"() {
         setup:
             def srcDir = new File('target/test-classes/src/asciidoctor-refresh')
             def outputDir = new File('target/asciidoctor-refresh-output')
@@ -57,7 +57,7 @@ class AsciidoctorRefreshMojoTest extends Specification {
             })
             mojoThread.start()
 
-            while (!new String(newOut.toByteArray()).contains('Rendered')) {
+            while (!new String(newOut.toByteArray()).contains('Converted')) {
                 Thread.sleep(200)
             }
 
@@ -70,7 +70,7 @@ class AsciidoctorRefreshMojoTest extends Specification {
                 Wow, this will be auto refreshed!'''.stripIndent() }
 
         then:
-            while (!new String(newOut.toByteArray()).contains('Re-rendered ')) {
+            while (!new String(newOut.toByteArray()).contains('Re-converted ')) {
                 Thread.sleep 500
             }
             assert target.text.contains('Wow, this will be auto refreshed')

--- a/src/test/groovy/org/asciidoctor/maven/test/site/AsciidoctorDoxiaParserTest.groovy
+++ b/src/test/groovy/org/asciidoctor/maven/test/site/AsciidoctorDoxiaParserTest.groovy
@@ -10,7 +10,7 @@ class AsciidoctorDoxiaParserTest extends Specification {
 
     public static final String TEST_DOCS_PATH = 'src/test/resources/src/asciidoctor'
 
-    def "should render html without any configuration"() {
+    def "should convert html without any configuration"() {
         given:
         final File srcAsciidoc = new File("$TEST_DOCS_PATH/sample.asciidoc")
         final Sink sink = createSinkMock()
@@ -31,7 +31,7 @@ class AsciidoctorDoxiaParserTest extends Specification {
         outputText.contains '<div class="title">Note</div>'
     }
 
-    def "should render html with an attribute"() {
+    def "should convert html with an attribute"() {
         given:
         final File srcAsciidoc = new File("$TEST_DOCS_PATH/sample.asciidoc")
         Reader reader = new FileReader(srcAsciidoc)
@@ -56,7 +56,7 @@ class AsciidoctorDoxiaParserTest extends Specification {
         outputText.contains '<i class="fa icon-note" title="Note"></i>'
     }
 
-    def "should render html with baseDir option"() {
+    def "should convert html with baseDir option"() {
         given:
         final File srcAsciidoc = new File("$TEST_DOCS_PATH/main-document.adoc")
         final Sink sink = createSinkMock()
@@ -78,7 +78,7 @@ class AsciidoctorDoxiaParserTest extends Specification {
         outputText.contains 'println "HelloWorld from Groovy on ${new Date()}"'
     }
 
-    def "should render html with relative baseDir option"() {
+    def "should convert html with relative baseDir option"() {
         given:
         final File srcAsciidoc = new File("$TEST_DOCS_PATH/main-document.adoc")
         final Sink sink = createSinkMock()
@@ -100,7 +100,7 @@ class AsciidoctorDoxiaParserTest extends Specification {
         outputText.contains 'println "HelloWorld from Groovy on ${new Date()}"'
     }
 
-    def "should render html with templateDir option"() {
+    def "should convert html with templateDir option"() {
         given:
         final File srcAsciidoc = new File("$TEST_DOCS_PATH/sample.asciidoc")
         final Sink sink = createSinkMock()
@@ -124,7 +124,7 @@ class AsciidoctorDoxiaParserTest extends Specification {
         outputText.contains '<p class="custom-template ">'
     }
 
-    def "should render html with attributes and baseDir option"() {
+    def "should convert html with attributes and baseDir option"() {
         given:
         final File srcAsciidoc = new File("$TEST_DOCS_PATH/main-document.adoc")
         final Sink sink = createSinkMock()
@@ -226,7 +226,7 @@ class AsciidoctorDoxiaParserTest extends Specification {
 
         then: 'issues with WARN and ERROR are returned'
         def e = thrown(org.apache.maven.doxia.parser.ParseException)
-        e.message.contains('Found 4 issue(s) of severity WARN or higher during rendering')
+        e.message.contains('Found 4 issue(s) of severity WARN or higher during conversion')
     }
 
     private javax.inject.Provider<MavenProject> createMavenProjectMock(final String configuration = null) {

--- a/src/test/java/org/asciidoctor/maven/test/processors/RequireCheckerTreeprocessor.java
+++ b/src/test/java/org/asciidoctor/maven/test/processors/RequireCheckerTreeprocessor.java
@@ -11,7 +11,7 @@ public class RequireCheckerTreeprocessor extends Treeprocessor {
   @Override
   public Document process(Document document) {
     assertEquals("constant", JRubyRuntimeContext.get(document).evalScriptlet("defined? ::DateTime").toString());
-    // Leave a trace in the rendered document so that the test can check that I was called
+    // Leave a trace in the converted document so that the test can check that I was called
     document.getBlocks().add(createBlock(document, "paragraph", RequireCheckerTreeprocessor.class.getSimpleName() + " was here"));
     return document;
   }

--- a/src/test/resources/src/asciidoctor/relative-path-treatment/_this_is_ignored/ignored.adoc
+++ b/src/test/resources/src/asciidoctor/relative-path-treatment/_this_is_ignored/ignored.adoc
@@ -2,7 +2,7 @@
 :icons:
 
 == Summary
-This document won't get rendered by default because it is inside a hidden folder. +
-Hidden folders begin with udnersore `_`.
+This document won't get converted by default because it is inside a hidden folder. +
+Hidden folders begin with underscore `_`.
 
 TIP: How cool is this?

--- a/src/test/resources/src/asciidoctor/relative-path-treatment/level-1-1/level-2-2/_this_is_ignored/ignored.adoc
+++ b/src/test/resources/src/asciidoctor/relative-path-treatment/level-1-1/level-2-2/_this_is_ignored/ignored.adoc
@@ -2,7 +2,7 @@
 :icons:
 
 == Summary
-This document won't get rendered by default because it is inside a hidden folder. +
-Hidden folders begin with udnersore `_`.
+This document won't get converted by default because it is inside a hidden folder. +
+Hidden folders begin with underscore `_`.
 
 TIP: How cool is this?


### PR DESCRIPTION
To align with Asciidoctor convenvtions and teminology replaces uses of the word "render" by "convert" in documentation and code.

Additionally include some minnor fixed to the README.