### PR TITLE
closes #417: removes attributeMissing option in favour of attributes configuration

### DIFF
--- a/README.adoc
+++ b/README.adoc
@@ -646,6 +646,27 @@ To run all tests at once just use `mvn clean verify -DskipTests -Prun-its`.
 
 == Tips & Tricks
 
+=== Fail on missing attributes
+
+Attributes whose value cannot be resolved are ignored by default and they don't show as error or warning.
+If you need to, this behaviour can be modified using the https://asciidoctor.org/docs/user-manual/#missing-attribute[missing-attribute] attribute.
+
+Combining it with logHandler option it is possible to report an error and abort a build in case of missing attributes.
+
+[source, xml]
+----
+<configuration>
+    <attributes>
+        <attribute-missing>warn</attribute-missing>
+    </attributes>
+    <logHandler>
+        <failIf>
+            <severity>WARN</severity>
+        </failIf>
+    </logHandler>
+</configuration>
+----
+
 === Generate your documentation in separate folders per version
 
 Use Maven `project.version` property to create dedicated custom output directories.

--- a/src/main/java/org/asciidoctor/maven/AsciidoctorMojo.java
+++ b/src/main/java/org/asciidoctor/maven/AsciidoctorMojo.java
@@ -531,12 +531,6 @@ public class AsciidoctorMojo extends AbstractMojo {
             attributesBuilder.dataUri(true);
         }
 
-        if ("skip".equals(attributeMissing) || "drop".equals(attributeMissing) || "drop-line".equals(attributeMissing)) {
-            attributesBuilder.attributeMissing(attributeMissing);
-        } else {
-            throw new MojoExecutionException(attributeMissing + " is not valid. Must be one of 'skip', 'drop' or 'drop-line'");
-        }
-
         if ("drop".equals(attributeUndefined) || "drop-line".equals(attributeUndefined)) {
             attributesBuilder.attributeUndefined(attributeUndefined);
         } else {

--- a/src/test/groovy/org/asciidoctor/maven/test/AsciidoctorMojoTest.groovy
+++ b/src/test/groovy/org/asciidoctor/maven/test/AsciidoctorMojoTest.groovy
@@ -342,7 +342,7 @@ class AsciidoctorMojoTest extends Specification {
             mojo.sourceDirectory = srcDir
             mojo.sourceDocumentName = 'attribute-missing.adoc'
             mojo.backend = 'html'
-            mojo.attributeMissing = 'skip'
+            mojo.attributes = ['attribute-missing':'skip']
             mojo.execute()
         then:
             File sampleOutput = new File(outputDir, 'attribute-missing.html')
@@ -363,7 +363,7 @@ class AsciidoctorMojoTest extends Specification {
             mojo.sourceDirectory = srcDir
             mojo.sourceDocumentName = 'attribute-missing.adoc'
             mojo.backend = 'html'
-            mojo.attributeMissing = 'drop'
+            mojo.attributes = ['attribute-missing':'drop']
             mojo.execute()
         then:
             File sampleOutput = new File(outputDir, 'attribute-missing.html')
@@ -385,7 +385,7 @@ class AsciidoctorMojoTest extends Specification {
             mojo.sourceDirectory = srcDir
             mojo.sourceDocumentName = 'attribute-missing.adoc'
             mojo.backend = 'html'
-            mojo.attributeMissing = 'drop-line'
+            mojo.attributes = ['attribute-missing':'drop-line']
             mojo.execute()
         then:
             File sampleOutput = new File(outputDir, 'attribute-missing.html')


### PR DESCRIPTION
This PR:
* Removes the attributeMissing option to be used in as a normal attribute. current solution had moreover the limitation of not being able to set "warn" as value. I updated the test, though one could argue these are not integration tests and should not be there.
* Also, added an exaplanation of how to combine the attribute with logHandler to fail a build on missing attibutes to "tips & tricks"