### PR TITLE
remove attributeUndefined option in favour of direct atrtibute usage

### DIFF
--- a/src/main/java/org/asciidoctor/maven/AsciidoctorMojo.java
+++ b/src/main/java/org/asciidoctor/maven/AsciidoctorMojo.java
@@ -143,12 +143,6 @@ public class AsciidoctorMojo extends AbstractMojo {
     @Parameter(property = AsciidoctorMaven.PREFIX + "embedAssets")
     protected boolean embedAssets = false;
 
-    @Parameter(property = AsciidoctorMaven.PREFIX + "attributeMissing")
-    protected String attributeMissing = "skip";
-
-    @Parameter(property = AsciidoctorMaven.PREFIX + "attributeUndefined")
-    protected String attributeUndefined = "drop-line";
-
     // List of resources to copy to the output directory (e.g., images, css). By default everything is copied
     @Parameter(property = AsciidoctorMaven.PREFIX + "sources")
     protected List<Resource> resources;
@@ -528,12 +522,6 @@ public class AsciidoctorMojo extends AbstractMojo {
             attributesBuilder.dataUri(true);
         }
 
-        if ("drop".equals(attributeUndefined) || "drop-line".equals(attributeUndefined)) {
-            attributesBuilder.attributeUndefined(attributeUndefined);
-        } else {
-            throw new MojoExecutionException(attributeUndefined + " is not valid. Must be one of 'drop' or 'drop-line'");
-        }
-
         AsciidoctorHelper.addAttributes(attributes, attributesBuilder);
 
         if (!attributesChain.isEmpty()) {
@@ -660,22 +648,6 @@ public class AsciidoctorMojo extends AbstractMojo {
 
     public void setEmbedAssets(boolean embedAssets) {
         this.embedAssets = embedAssets;
-    }
-
-    public String getAttributeMissing() {
-        return attributeMissing;
-    }
-
-    public void setAttributeMissing(String attributeMissing) {
-        this.attributeMissing = attributeMissing;
-    }
-
-    public String getAttributeUndefined() {
-        return attributeUndefined;
-    }
-
-    public void setAttributeUndefined(String attributeUndefined) {
-        this.attributeUndefined = attributeUndefined;
     }
 
     public File getProjectDirectory() {

--- a/src/test/groovy/org/asciidoctor/maven/test/AsciidoctorMojoTest.groovy
+++ b/src/test/groovy/org/asciidoctor/maven/test/AsciidoctorMojoTest.groovy
@@ -407,7 +407,7 @@ class AsciidoctorMojoTest extends Specification {
             mojo.sourceDirectory = srcDir
             mojo.sourceDocumentName = 'attribute-undefined.adoc'
             mojo.backend = 'html'
-            mojo.attributeUndefined = 'drop'
+            mojo.attributes = ['attribute-undefined':'drop']
             mojo.execute()
         then:
             File sampleOutput = new File(outputDir, 'attribute-undefined.html')
@@ -429,7 +429,7 @@ class AsciidoctorMojoTest extends Specification {
             mojo.sourceDirectory = srcDir
             mojo.sourceDocumentName = 'attribute-undefined.adoc'
             mojo.backend = 'html'
-            mojo.attributeMissing = 'drop-line'
+            mojo.attributes = ['attribute-undefined':'drop-line']
             mojo.execute()
         then:
             File sampleOutput = new File(outputDir, 'attribute-undefined.html')


### PR DESCRIPTION
This is the last attribute that was still configurable as an option directly in the mojo.