### PR TITLE
upgrade jruby security vulnerabilities

### DIFF
--- a/pom.xml
+++ b/pom.xml
@@ -64,7 +64,7 @@
         <spock.version>0.7-groovy-2.0</spock.version>
         <groovy.version>2.1.3</groovy.version>
         <asciidoctorj.version>2.3.0</asciidoctorj.version>
-        <jruby.version>9.2.11.1</jruby.version>
+        <jruby.version>9.2.12.0</jruby.version>
         <maven.coveralls.plugin.version>4.3.0</maven.coveralls.plugin.version>
         <maven.jacoco.plugin.version>0.8.2</maven.jacoco.plugin.version>
         <maven.plugin.plugin.version>3.5</maven.plugin.plugin.version>


### PR DESCRIPTION
-jruby 9.2.11.1 uses ruby 2.5.0 which has multiple security vulnerabilities tied to it.  This upgrades jruby to latest 9.2.12.0 