### PR TITLE
fix coveralls.io setup to run on GH actions

### DIFF
--- a/.github/workflows/build.yaml
+++ b/.github/workflows/build.yaml
@@ -33,6 +33,4 @@ jobs:
         run: mvn -B -V -Prun-its clean verify jacoco:report
       - name: Publish coverage reports
         if: matrix.os == 'ubuntu-latest' && matrix.java == '11' && github.base.ref == 'master'
-        env:
-          COVERALLS_REPO_TOKEN: ${{ secrets.COVERALLS_REPO_TOKEN }}
         run: mvn coveralls:report -DrepoToken=${COVERALLS_REPO_TOKEN}

--- a/.github/workflows/build.yaml
+++ b/.github/workflows/build.yaml
@@ -15,12 +15,9 @@ jobs:
       max-parallel: 2
       matrix:
         java:
-          - 8
           - 11
         os:
           - ubuntu-latest
-          - windows-latest
-          - macos-latest
     runs-on: ${{ matrix.os }}
     steps:
       - uses: actions/checkout@v1
@@ -32,5 +29,5 @@ jobs:
       - name: Build
         run: mvn -B -V -Prun-its clean verify jacoco:report
       - name: Publish coverage reports
-        if: matrix.os == 'ubuntu-latest' && matrix.java == '11' && github.base.ref == 'master'
+        if: matrix.os == 'ubuntu-latest' && matrix.java == '11'
         run: mvn coveralls:report -DrepoToken=${COVERALLS_REPO_TOKEN}

--- a/.github/workflows/build.yaml
+++ b/.github/workflows/build.yaml
@@ -30,4 +30,9 @@ jobs:
         with:
           java-version: ${{ matrix.java }}
       - name: Build
-        run: mvn -B -V -Prun-its clean verify
+        run: mvn -B -V -Prun-its clean verify jacoco:report
+      - name: Publish coverage reports
+        if: matrix.os == 'ubuntu-latest' && matrix.java == '11' && github.base.ref == 'master'
+        env:
+          COVERALLS_REPO_TOKEN: ${{ secrets.COVERALLS_REPO_TOKEN }}
+        run: mvn coveralls:report -DrepoToken=${COVERALLS_REPO_TOKEN}

--- a/.github/workflows/build.yaml
+++ b/.github/workflows/build.yaml
@@ -15,9 +15,12 @@ jobs:
       max-parallel: 2
       matrix:
         java:
+          - 8
           - 11
         os:
           - ubuntu-latest
+          - windows-latest
+          - macos-latest
     runs-on: ${{ matrix.os }}
     steps:
       - uses: actions/checkout@v1
@@ -26,8 +29,11 @@ jobs:
       - uses: actions/setup-java@v1
         with:
           java-version: ${{ matrix.java }}
+      - name: Cache dependencies
+        uses: actions/cache@v1
+        with:
+          path: ~/.m2/repository
+          key: ${{ runner.os }}-mvn-cache-${{ hashFiles('**/pom.xml') }}
+          restore-keys: ${{ runner.os }}-mvn-cache-
       - name: Build
-        run: mvn -B -V -Prun-its clean verify jacoco:report
-      - name: Publish coverage reports
-        if: matrix.os == 'ubuntu-latest' && matrix.java == '11'
-        run: mvn coveralls:report -DrepoToken=${COVERALLS_REPO_TOKEN}
+        run: mvn -B -V -Prun-its clean verify

--- a/pom.xml
+++ b/pom.xml
@@ -256,6 +256,18 @@
                 <groupId>org.eluder.coveralls</groupId>
                 <artifactId>coveralls-maven-plugin</artifactId>
                 <version>${maven.coveralls.plugin.version}</version>
+                <dependencies>
+                    <dependency>
+                        <groupId>jakarta.xml.bind</groupId>
+                        <artifactId>jakarta.xml.bind-api</artifactId>
+                        <version>2.3.3</version>
+                    </dependency>
+                    <dependency>
+                        <groupId>org.glassfish.jaxb</groupId>
+                        <artifactId>jaxb-runtime</artifactId>
+                        <version>2.3.3</version>
+                    </dependency>
+                </dependencies>
             </plugin>
             <plugin>
                 <groupId>org.jacoco</groupId>


### PR DESCRIPTION
This PR:
* Fixes configuration to push coverall.io resuls from GH Actions build pipeline. Thanks to @mojavelinux for setting up the repo.
This is restricted to only the linux, Java11 build for no special reason other than this is the more similar to production environments.
* Applies fix to `coveralls-maven-plugin` to run on Java11.