### PR TITLE
Inject maven properties in asciidoctor mojo

### DIFF
--- a/CHANGELOG.adoc
+++ b/CHANGELOG.adoc
@@ -13,6 +13,10 @@ For a detailed view of what has changed, refer to the {uri-repo}/commits/master[
 
 == Unreleased
 
+Bug Fixes::
+
+  * Remove Maven components from plugin descriptor (#450)
+
 Documentation::
 
   * Add reference to v2-migration-guide in README for better findability (#445)

--- a/src/main/java/org/asciidoctor/maven/AsciidoctorMojo.java
+++ b/src/main/java/org/asciidoctor/maven/AsciidoctorMojo.java
@@ -18,7 +18,6 @@ import org.apache.maven.model.Resource;
 import org.apache.maven.plugin.AbstractMojo;
 import org.apache.maven.plugin.MojoExecutionException;
 import org.apache.maven.plugin.MojoFailureException;
-import org.apache.maven.plugins.annotations.Component;
 import org.apache.maven.plugins.annotations.Mojo;
 import org.apache.maven.plugins.annotations.Parameter;
 import org.apache.maven.project.MavenProject;
@@ -42,6 +41,7 @@ import org.asciidoctor.maven.log.MemoryLogHandler;
 import org.jruby.Ruby;
 import org.sonatype.plexus.build.incremental.BuildContext;
 
+import javax.inject.Inject;
 import java.io.File;
 import java.io.IOException;
 import java.util.*;
@@ -147,23 +147,24 @@ public class AsciidoctorMojo extends AbstractMojo {
     @Parameter(property = AsciidoctorMaven.PREFIX + "sources")
     protected List<Resource> resources;
 
-    @Parameter(defaultValue = "${project}", readonly = true, required = true)
-    protected MavenProject project;
-
-    @Parameter(defaultValue = "${session}", readonly = true, required = true)
-    protected MavenSession session;
-
     @Parameter(property = AsciidoctorMaven.PREFIX + "verbose")
     protected boolean enableVerbose = false;
 
     @Parameter
     private LogHandler logHandler = new LogHandler();
 
-    @Component
+    @Inject
+    protected MavenProject project;
+
+    @Inject
+    protected MavenSession session;
+
+    @Inject
     protected MavenResourcesFiltering outputResourcesFiltering;
 
-    @Component
+    @Inject
     protected BuildContext buildContext;
+
 
     @Override
     public void execute() throws MojoExecutionException, MojoFailureException {


### PR DESCRIPTION
This PR automatically injects maven properties as attributes (replacing . by -).
This feature is already present in the site integration, so it makes sense to apply it here.

This PR contains:

* Implementation resing same code as site module
* Unit test
* IT test
* Updated README. We could remove a section to make things simpler now
