### PR TITLE
simplify TravisCI for coveralls and Appveyor setup to Java8,11

### DIFF
--- a/.travis.yml
+++ b/.travis.yml
@@ -4,7 +4,6 @@ before_script:
   - export MAVEN_SKIP_RC=true
 jdk:
   - oraclejdk11
-  - openjdk8
 # skip installation step entirely
 install: true
 script:

--- a/CHANGELOG.adoc
+++ b/CHANGELOG.adoc
@@ -30,3 +30,5 @@ Build / Infrastructure::
 
   * Updated maven-release-plugin version (3.0.0-M1) and POM scm configuration to simplify release process
   * Adds GitHub Actions build for Linux, Windows, MacOS and Java 8, 11 (#452, #453)
+  * Simplify TravisCI and AppVeyor to run Java 8 and 11 only (#460)
+  * Upgrade Maven from v3.5.0 to 3.6.3 in AppVeyor (#460)

--- a/appveyor.yml
+++ b/appveyor.yml
@@ -2,11 +2,9 @@ version: '{build}'
 skip_tags: true
 clone_depth: 10
 environment:
-  MAVEN_VERSION: 3.5.0
+  MAVEN_VERSION: 3.6.3
   matrix:
     - JAVA_HOME: C:\Program Files\Java\jdk1.8.0
-    - JAVA_HOME: C:\Program Files\Java\jdk9
-    - JAVA_HOME: C:\Program Files\Java\jdk10
     - JAVA_HOME: C:\Program Files\Java\jdk11
 install:
   - ps: |


### PR DESCRIPTION
This PR simplifies CI configuration:

* Travis only runs for Java11 to enable easy integration of coveralls.io
* Appveyor is still kep but limited to java 8 and 11. Also upgraded maven version.