### PR TITLE
removes unnecessary @Parameter configuration from ExtensionConfiguration, Synchronization and Resources

### DIFF
--- a/CHANGELOG.adoc
+++ b/CHANGELOG.adoc
@@ -20,6 +20,7 @@ Improvements::
 Bug Fixes::
 
   * Remove Maven components from plugin descriptor (#450)
+  * Remove unnecessary maven's @Parameter configuration from ExtensionConfiguration, Synchronization and Resources (#461)
 
 Documentation::
 

--- a/src/main/java/org/asciidoctor/maven/AsciidoctorMojo.java
+++ b/src/main/java/org/asciidoctor/maven/AsciidoctorMojo.java
@@ -134,17 +134,17 @@ public class AsciidoctorMojo extends AbstractMojo {
     @Parameter(property = AsciidoctorMaven.PREFIX + "catalogAssets")
     protected boolean catalogAssets = false;
 
-    @Parameter(property = AsciidoctorMaven.PREFIX + "synchronizations", required = false)
+    @Parameter
     protected List<Synchronization> synchronizations = new ArrayList<Synchronization>();
 
-    @Parameter(property = AsciidoctorMaven.PREFIX + "extensions")
+    @Parameter
     protected List<ExtensionConfiguration> extensions = new ArrayList<ExtensionConfiguration>();
 
     @Parameter(property = AsciidoctorMaven.PREFIX + "embedAssets")
     protected boolean embedAssets = false;
 
     // List of resources to copy to the output directory (e.g., images, css). By default everything is copied
-    @Parameter(property = AsciidoctorMaven.PREFIX + "sources")
+    @Parameter
     protected List<Resource> resources;
 
     @Parameter(property = AsciidoctorMaven.PREFIX + "verbose")

--- a/src/main/java/org/asciidoctor/maven/Synchronization.java
+++ b/src/main/java/org/asciidoctor/maven/Synchronization.java
@@ -13,14 +13,10 @@ package org.asciidoctor.maven;
 
 import java.io.File;
 
-import org.apache.maven.plugins.annotations.Parameter;
-
 public class Synchronization {
-    public static final String PREFIX = AsciidoctorMaven.PREFIX + "synchronization.";
-    @Parameter(property = PREFIX + "source")
+
     protected File source;
 
-    @Parameter(property = PREFIX + "target")
     protected File target;
 
     public Synchronization() {

--- a/src/main/java/org/asciidoctor/maven/extensions/ExtensionConfiguration.java
+++ b/src/main/java/org/asciidoctor/maven/extensions/ExtensionConfiguration.java
@@ -1,28 +1,21 @@
 package org.asciidoctor.maven.extensions;
 
-import org.apache.maven.plugins.annotations.Parameter;
-import org.asciidoctor.maven.AsciidoctorMaven;
-
 /**
- * Holds a processor's configuration parameters in the pom.xml
- * 
+ * Holds an extension's configuration parameters in the pom.xml
+ *
  * @author abelsromero
  */
 public class ExtensionConfiguration {
 
-    public static final String PREFIX = AsciidoctorMaven.PREFIX + "extension.";
-    
     /**
-     * Fully qualified name of the processor
+     * Fully qualified name of the extension
      */
-    @Parameter(property = PREFIX + "className", required = true)
     private String className;
 
     /**
      * Optional. Block name in case of setting a Block, BlockMacro or
      * InlineMacro processor
      */
-    @Parameter(property = PREFIX + "blockName")
     private String blockName;
 
     public ExtensionConfiguration() {


### PR DESCRIPTION
As part of some clean up tasks, this PR:
* Removes unnecessary `org.apache.maven.plugins.annotations.Parameter` usages in ExtensionConfiguration, Synchronization and Resources, and in AsciidoctorMojo.
This is because properties in beans cannot be configured via terminal with _-D_. I'll do more search while the PR is open, but could not find any official doc so far and tests where unsuccessful. Note that List of String or File can be assigned passing a comma separated list like `mvn -Dasciidoctor.requires=onegem,anothergem`