### PR TITLE
removes unused maven BuildContext in AsciidoctorMojo

### DIFF
--- a/CHANGELOG.adoc
+++ b/CHANGELOG.adoc
@@ -21,6 +21,7 @@ Bug Fixes::
 
   * Remove Maven components from plugin descriptor (#450)
   * Remove unnecessary maven's @Parameter configuration from ExtensionConfiguration, Synchronization and Resources (#461)
+  * Remove unused BuildContext from AsciidoctorMojo (#462)
 
 Documentation::
 

--- a/src/main/java/org/asciidoctor/maven/AsciidoctorMojo.java
+++ b/src/main/java/org/asciidoctor/maven/AsciidoctorMojo.java
@@ -162,9 +162,6 @@ public class AsciidoctorMojo extends AbstractMojo {
     @Inject
     protected MavenResourcesFiltering outputResourcesFiltering;
 
-    @Inject
-    protected BuildContext buildContext;
-
 
     @Override
     public void execute() throws MojoExecutionException, MojoFailureException {

--- a/src/test/groovy/org/asciidoctor/maven/test/plexus/MockPlexusContainer.groovy
+++ b/src/test/groovy/org/asciidoctor/maven/test/plexus/MockPlexusContainer.groovy
@@ -32,17 +32,16 @@ class MockPlexusContainer {
                 getProperties: properties as Properties
         ] as MavenProject
 
-        mojo.@buildContext = new DefaultBuildContext()
-
+        def buildContext = new DefaultBuildContext()
         def logger = new FakeMavenLogger() as org.codehaus.plexus.logging.Logger
 
         DefaultMavenFileFilter mavenFileFilter = new DefaultMavenFileFilter()
-        mavenFileFilter.@buildContext = mojo.@buildContext
+        mavenFileFilter.@buildContext = buildContext
         mavenFileFilter.enableLogging(logger)
 
         DefaultMavenResourcesFiltering resourceFilter = new DefaultMavenResourcesFiltering()
         resourceFilter.@mavenFileFilter = mavenFileFilter
-        resourceFilter.@buildContext = mojo.@buildContext
+        resourceFilter.@buildContext = buildContext
         resourceFilter.initialize()
         resourceFilter.enableLogging(logger)
         mojo.encoding = "UTF-8"


### PR DESCRIPTION
Part of cleanup tasks, this PR:
* Removes the unused `org.sonatype.plexus.build.incremental.BuildContext` from AsciidoctorMojo.