### PR TITLE
removes unnecessary required configuration from mojo parameters

### DIFF
--- a/CHANGELOG.adoc
+++ b/CHANGELOG.adoc
@@ -22,6 +22,7 @@ Bug Fixes::
   * Remove Maven components from plugin descriptor (#450)
   * Remove unnecessary maven's @Parameter configuration from ExtensionConfiguration, Synchronization and Resources (#461)
   * Remove unused BuildContext from AsciidoctorMojo (#462)
+  * Remove unnecessary required configuration from mojo parameters (#463)
 
 Documentation::
 

--- a/src/it/convert-with-minimal-configuration/invoker.properties
+++ b/src/it/convert-with-minimal-configuration/invoker.properties
@@ -1,0 +1,1 @@
+invoker.goals=clean asciidoctor:process-asciidoc

--- a/src/it/convert-with-minimal-configuration/pom.xml
+++ b/src/it/convert-with-minimal-configuration/pom.xml
@@ -1,0 +1,25 @@
+<project xmlns="http://maven.apache.org/POM/4.0.0" xmlns:xsi="http://www.w3.org/2001/XMLSchema-instance"
+	xsi:schemaLocation="http://maven.apache.org/POM/4.0.0 http://maven.apache.org/maven-v4_0_0.xsd">
+	<modelVersion>4.0.0</modelVersion>
+
+	<groupId>org.asciidoctor</groupId>
+	<artifactId>test</artifactId>
+	<version>1.0-SNAPSHOT</version>
+
+	<name>Converts Asciidoctor Article to Html</name>
+	<description>Runs asciidoctor-maven-plugin:process-asciidoc</description>
+
+	<properties>
+		<project.build.sourceEncoding>UTF-8</project.build.sourceEncoding>
+	</properties>
+
+	<build>
+		<plugins>
+			<plugin>
+				<groupId>org.asciidoctor</groupId>
+				<artifactId>asciidoctor-maven-plugin</artifactId>
+				<version>@project.version@</version>
+			</plugin>
+		</plugins>
+	</build>
+</project>

--- a/src/it/convert-with-minimal-configuration/src/docs/asciidoc/sample.asciidoc
+++ b/src/it/convert-with-minimal-configuration/src/docs/asciidoc/sample.asciidoc
@@ -1,0 +1,25 @@
+Document Title
+==============
+Doc Writer <thedoc@asciidoctor.org>
+:idprefix: id_
+
+Preamble paragraph.
+
+NOTE: This is test, only a test.
+
+== Section A
+
+*Section A* paragraph.
+
+=== Section A Subsection
+
+*Section A* 'subsection' paragraph.
+
+== Section B
+
+*Section B* paragraph.
+
+.Section B list
+* Item 1
+* Item 2
+* Item 3

--- a/src/it/convert-with-minimal-configuration/validate.groovy
+++ b/src/it/convert-with-minimal-configuration/validate.groovy
@@ -1,0 +1,11 @@
+File outputDir = new File(basedir, 'target/generated-docs');
+
+def expectedFiles = ['sample.html']
+
+for (String expectedFile : expectedFiles) {
+    File file = new File(outputDir, expectedFile)
+    if (!file.isFile())
+        throw new Exception("Missing file $file")
+}
+
+return true

--- a/src/main/java/org/asciidoctor/maven/AsciidoctorHttpMojo.java
+++ b/src/main/java/org/asciidoctor/maven/AsciidoctorHttpMojo.java
@@ -12,11 +12,6 @@
 
 package org.asciidoctor.maven;
 
-import java.io.File;
-import java.io.FileInputStream;
-import java.io.FileOutputStream;
-import java.util.Map;
-
 import org.apache.commons.io.IOUtils;
 import org.apache.maven.plugin.MojoExecutionException;
 import org.apache.maven.plugin.MojoFailureException;
@@ -26,14 +21,19 @@ import org.asciidoctor.Asciidoctor;
 import org.asciidoctor.maven.http.AsciidoctorHttpServer;
 import org.asciidoctor.maven.io.IO;
 
+import java.io.File;
+import java.io.FileInputStream;
+import java.io.FileOutputStream;
+import java.util.Map;
+
 @Mojo(name = "http")
 public class AsciidoctorHttpMojo extends AsciidoctorRefreshMojo {
     public static final String PREFIX = AsciidoctorMaven.PREFIX + "http.";
 
-    @Parameter(property = PREFIX + "home", required = false, defaultValue = "index")
+    @Parameter(property = PREFIX + "home", defaultValue = "index")
     protected String home;
 
-    @Parameter(property = PREFIX + "reload-interval", required = false, defaultValue = "0")
+    @Parameter(property = PREFIX + "reload-interval", defaultValue = "0")
     protected int autoReloadInterval;
 
     @Override

--- a/src/main/java/org/asciidoctor/maven/AsciidoctorMojo.java
+++ b/src/main/java/org/asciidoctor/maven/AsciidoctorMojo.java
@@ -62,71 +62,71 @@ public class AsciidoctorMojo extends AbstractMojo {
     @Parameter(defaultValue = "${project.build.sourceEncoding}")
     protected String encoding;
 
-    @Parameter(property = AsciidoctorMaven.PREFIX + "sourceDirectory", defaultValue = "${basedir}/" + DEFAULT_SOURCE_DIR, required = true)
+    @Parameter(property = AsciidoctorMaven.PREFIX + "sourceDirectory", defaultValue = "${basedir}/" + DEFAULT_SOURCE_DIR)
     protected File sourceDirectory;
 
-    @Parameter(property = AsciidoctorMaven.PREFIX + "outputDirectory", defaultValue = "${project.build.directory}/generated-docs", required = true)
+    @Parameter(property = AsciidoctorMaven.PREFIX + "outputDirectory", defaultValue = "${project.build.directory}/generated-docs")
     protected File outputDirectory;
 
-    @Parameter(property = AsciidoctorMaven.PREFIX + "outputFile", required = false)
+    @Parameter(property = AsciidoctorMaven.PREFIX + "outputFile")
     protected File outputFile;
 
-    @Parameter(property = AsciidoctorMaven.PREFIX + "preserveDirectories", defaultValue = "false", required = false)
+    @Parameter(property = AsciidoctorMaven.PREFIX + "preserveDirectories", defaultValue = "false")
     protected boolean preserveDirectories = false;
 
-    @Parameter(property = AsciidoctorMaven.PREFIX + "relativeBaseDir", defaultValue = "false", required = false)
+    @Parameter(property = AsciidoctorMaven.PREFIX + "relativeBaseDir", defaultValue = "false")
     protected boolean relativeBaseDir = false;
 
-    @Parameter(property = AsciidoctorMaven.PREFIX + "projectDirectory", defaultValue = "${basedir}", required = false, readonly = false)
+    @Parameter(property = AsciidoctorMaven.PREFIX + "projectDirectory", defaultValue = "${basedir}")
     protected File projectDirectory;
 
-    @Parameter(property = AsciidoctorMaven.PREFIX + "rootDir", defaultValue = "${basedir}", required = false, readonly = false)
+    @Parameter(property = AsciidoctorMaven.PREFIX + "rootDir", defaultValue = "${basedir}")
     protected File rootDir;
 
-    @Parameter(property = AsciidoctorMaven.PREFIX + "baseDir", required = false)
+    @Parameter(property = AsciidoctorMaven.PREFIX + "baseDir")
     protected File baseDir;
 
-    @Parameter(property = AsciidoctorMaven.PREFIX + "skip", required = false)
+    @Parameter(property = AsciidoctorMaven.PREFIX + "skip")
     protected boolean skip = false;
 
-    @Parameter(property = AsciidoctorMaven.PREFIX + "gemPath", defaultValue = "", required = false)
-    protected String gemPath = "";
+    @Parameter(property = AsciidoctorMaven.PREFIX + "gemPath")
+    protected String gemPath;
 
     @Parameter(property = AsciidoctorMaven.PREFIX + "requires")
-    protected List<String> requires = new ArrayList<String>();
+    protected List<String> requires = new ArrayList<>();
 
-    @Parameter(required = false)
-    protected Map<String, Object> attributes = new HashMap<String, Object>();
+    @Parameter
+    protected Map<String, Object> attributes = new HashMap<>();
 
-    @Parameter(property = AsciidoctorMaven.PREFIX + Options.ATTRIBUTES, required = false)
+    @Parameter(property = AsciidoctorMaven.PREFIX + Options.ATTRIBUTES)
     protected String attributesChain = "";
 
-    @Parameter(property = AsciidoctorMaven.PREFIX + Options.BACKEND, defaultValue = "html5", required = true)
+    @Parameter(property = AsciidoctorMaven.PREFIX + Options.BACKEND, defaultValue = "html5")
     protected String backend = "";
 
-    @Parameter(property = AsciidoctorMaven.PREFIX + Options.DOCTYPE, required = false)
+    @Parameter(property = AsciidoctorMaven.PREFIX + Options.DOCTYPE)
     protected String doctype;
 
-    @Parameter(property = AsciidoctorMaven.PREFIX + Options.ERUBY, required = false)
+    @Parameter(property = AsciidoctorMaven.PREFIX + Options.ERUBY)
     protected String eruby = "";
 
-    @Parameter(property = AsciidoctorMaven.PREFIX + "headerFooter", required = false)
+    @Parameter(property = AsciidoctorMaven.PREFIX + "headerFooter")
     protected boolean headerFooter = true;
 
-    @Parameter(property = AsciidoctorMaven.PREFIX + "templateDirs", required = false)
+    @Parameter(property = AsciidoctorMaven.PREFIX + "templateDirs")
     protected List<File> templateDirs = new ArrayList<>();
 
-    @Parameter(property = AsciidoctorMaven.PREFIX + "templateEngine", required = false)
+    @Parameter(property = AsciidoctorMaven.PREFIX + "templateEngine")
     protected String templateEngine;
 
     @Parameter(property = AsciidoctorMaven.PREFIX + "templateCache")
     protected boolean templateCache = true;
 
-    @Parameter(property = AsciidoctorMaven.PREFIX + "sourceDocumentName", required = false)
+    @Parameter(property = AsciidoctorMaven.PREFIX + "sourceDocumentName")
     protected String sourceDocumentName;
 
     @Parameter(property = AsciidoctorMaven.PREFIX + "sourceDocumentExtensions")
-    protected List<String> sourceDocumentExtensions = new ArrayList<String>();
+    protected List<String> sourceDocumentExtensions = new ArrayList<>();
 
     @Parameter(property = AsciidoctorMaven.PREFIX + "sourcemap")
     protected boolean sourcemap = false;
@@ -135,10 +135,10 @@ public class AsciidoctorMojo extends AbstractMojo {
     protected boolean catalogAssets = false;
 
     @Parameter
-    protected List<Synchronization> synchronizations = new ArrayList<Synchronization>();
+    protected List<Synchronization> synchronizations = new ArrayList<>();
 
     @Parameter
-    protected List<ExtensionConfiguration> extensions = new ArrayList<ExtensionConfiguration>();
+    protected List<ExtensionConfiguration> extensions = new ArrayList<>();
 
     @Parameter(property = AsciidoctorMaven.PREFIX + "embedAssets")
     protected boolean embedAssets = false;

--- a/src/main/java/org/asciidoctor/maven/AsciidoctorRefreshMojo.java
+++ b/src/main/java/org/asciidoctor/maven/AsciidoctorRefreshMojo.java
@@ -12,18 +12,6 @@
 
 package org.asciidoctor.maven;
 
-import java.io.File;
-import java.util.ArrayList;
-import java.util.Collection;
-import java.util.Scanner;
-import java.util.concurrent.Callable;
-import java.util.concurrent.ExecutorService;
-import java.util.concurrent.Executors;
-import java.util.concurrent.Future;
-import java.util.concurrent.ScheduledExecutorService;
-import java.util.concurrent.TimeUnit;
-import java.util.concurrent.atomic.AtomicBoolean;
-
 import org.apache.commons.io.FileUtils;
 import org.apache.commons.io.filefilter.NameFileFilter;
 import org.apache.commons.io.filefilter.RegexFileFilter;
@@ -38,13 +26,20 @@ import org.apache.maven.plugins.annotations.Mojo;
 import org.apache.maven.plugins.annotations.Parameter;
 import org.asciidoctor.Asciidoctor;
 
+import java.io.File;
+import java.util.ArrayList;
+import java.util.Collection;
+import java.util.Scanner;
+import java.util.concurrent.*;
+import java.util.concurrent.atomic.AtomicBoolean;
+
 @Mojo(name = "auto-refresh")
 public class AsciidoctorRefreshMojo extends AsciidoctorMojo {
     public static final String PREFIX = AsciidoctorMaven.PREFIX + "refresher.";
-    @Parameter(property = PREFIX + "port", required = false)
+    @Parameter(property = PREFIX + "port")
     protected int port = 2000;
 
-    @Parameter(property = PREFIX + "interval", required = false)
+    @Parameter(property = PREFIX + "interval")
     protected int interval = 2000; // 2s
 
     private Future<Asciidoctor> asciidoctor = null;


### PR DESCRIPTION
Part of clean up tasks, this PR:

* Removes unnecessary `required = false` from mojo parameters, since this is the default value.
* Removes incorrect `required = true` from `sourceDirectory` and `outputDirectory`. This was incorrect since these parameters have default values. Added an IT test to assert this behauviour.