### PR TITLE
Adds GitHub PR and issue templates

### DIFF
--- a/.github/ISSUE_TEMPLATE.md
+++ b/.github/ISSUE_TEMPLATE.md
@@ -1,0 +1,20 @@
+Thank you for taking your time to talk with us!
+
+**What is this issue about?**
+<!-- Update "[ ]" to "[x]" to check a box -->
+
+- [ ] Bug report
+- [ ] Feature request
+- [ ] Question
+
+
+**Description**
+
+
+<!-- In case of bug report, please fill out the following information. Is not mandatory, but will help finding the cause of the issue quicker. -->
+**Environment information**
+
+* asciidoctor-maven-plugin version: ___
+* asciidoctorj version: ___
+<!-- Open a terminal and run `mvn -v`. Note your home path may appear, edit if necessary. -->
+* Maven, Java and OS version: ___

--- a/.github/PULL_REQUEST_TEMPLATE.md
+++ b/.github/PULL_REQUEST_TEMPLATE.md
@@ -1,0 +1,28 @@
+Thank you for opening a pull request and contributing to asciidoctor-maven-plugin!
+
+**What kind of change does this PR introduce?** (check at least one)
+<!-- Update "[ ]" to "[x]" to check a box -->
+
+- [ ] Bugfix
+- [ ] Feature
+- [ ] Documentation
+- [ ] Refactor
+- [ ] Build improvement
+- [ ] Other (please describe)
+
+
+**What is the goal of this pull request?**
+
+
+**Are there any alternative ways to implement this?**
+
+
+**Are there any implications of this pull request? Anything a user must know?**
+
+
+**Is it related to an existing issue?**
+<!-- If Yes, please add a line of the form: `Fixes #Issue` --> 
+- [ ] Yes
+- [ ] No
+
+*Finally, please add a corresponding entry to CHANGELOG.adoc*

--- a/CHANGELOG.adoc
+++ b/CHANGELOG.adoc
@@ -28,6 +28,7 @@ Documentation::
 
   * Add reference to v2-migration-guide in README for better findability (#445)
   * Fix broken link to V2 migration guide (https://github.com/ge0ffrey[@ge0ffrey]) (#446)
+  * Add GitHub's PR and issue templates (#465)
 
 Build / Infrastructure::
 


### PR DESCRIPTION
This PR adds GitHub templates for PR and Issues.
I have based them on [asciidoctorj](https://github.com/asciidoctor/asciidoctorj/tree/master/.github) and [asciidoctor-intellij-plugin](https://github.com/asciidoctor/asciidoctor-intellij-plugin/tree/master/.github).

My approach have been to help people reporting more than mantainers. So I applied thess approaches:
* Simple structure
* Welcoming messages and texts
* Ask for minimal requirements
* Avoid "pedantic" remarks like requiring tests, docs or asking that the full builld completes. 