### PR TITLE
fixes #467 - prevent files from being converted twice in http mojo

### DIFF
--- a/CHANGELOG.adoc
+++ b/CHANGELOG.adoc
@@ -23,6 +23,7 @@ Bug Fixes::
   * Remove unnecessary maven's @Parameter configuration from ExtensionConfiguration, Synchronization and Resources (#461)
   * Remove unused BuildContext from AsciidoctorMojo (#462)
   * Remove unnecessary required configuration from mojo parameters (#463)
+  * Prevent sources from being converted twice in http mojo (#469)
 
 Documentation::
 

--- a/src/main/java/org/asciidoctor/maven/AsciidoctorHttpMojo.java
+++ b/src/main/java/org/asciidoctor/maven/AsciidoctorHttpMojo.java
@@ -28,6 +28,7 @@ import java.util.Map;
 
 @Mojo(name = "http")
 public class AsciidoctorHttpMojo extends AsciidoctorRefreshMojo {
+
     public static final String PREFIX = AsciidoctorMaven.PREFIX + "http.";
 
     @Parameter(property = PREFIX + "home", defaultValue = "index")
@@ -49,6 +50,7 @@ public class AsciidoctorHttpMojo extends AsciidoctorRefreshMojo {
     @Override
     protected void convertFile(final Asciidoctor asciidoctorInstance, final Map<String, Object> options, final File f) {
         asciidoctorInstance.convertFile(f, options);
+        logConvertedFile(f);
 
         if (autoReloadInterval > 0 && backend.toLowerCase().startsWith("html")) {
             final String filename = f.getName();
@@ -81,11 +83,7 @@ public class AsciidoctorHttpMojo extends AsciidoctorRefreshMojo {
                     }
                 }
             }
-        } else {
-            asciidoctorInstance.convertFile(f, options);
         }
-
-        logConvertedFile(f);
     }
 
     private String addRefreshing(final String html) {

--- a/src/main/java/org/asciidoctor/maven/AsciidoctorRefreshMojo.java
+++ b/src/main/java/org/asciidoctor/maven/AsciidoctorRefreshMojo.java
@@ -35,7 +35,9 @@ import java.util.concurrent.atomic.AtomicBoolean;
 
 @Mojo(name = "auto-refresh")
 public class AsciidoctorRefreshMojo extends AsciidoctorMojo {
+
     public static final String PREFIX = AsciidoctorMaven.PREFIX + "refresher.";
+
     @Parameter(property = PREFIX + "port")
     protected int port = 2000;
 
@@ -72,7 +74,7 @@ public class AsciidoctorRefreshMojo extends AsciidoctorMojo {
         updaterScheduler = Executors.newScheduledThreadPool(1);
 
         // we prevent refreshing more often than all 200ms and we refresh at least once/s
-        // NOTE1: it is intended to avoid too much time space between file polling and re-convertin
+        // NOTE1: it is intended to avoid too much time space between file polling and re-converting
         // NOTE2: if nothing to refresh it does nothing so all is fine
         updaterScheduler.scheduleAtFixedRate(new Updater(needsUpdate, this), 0, Math.min(1000, Math.max(200, interval / 2)), TimeUnit.MILLISECONDS);
     }
@@ -138,7 +140,7 @@ public class AsciidoctorRefreshMojo extends AsciidoctorMojo {
     }
 
     private void startPolling() throws MojoExecutionException {
-        monitors = new ArrayList<FileAlterationMonitor>();
+        monitors = new ArrayList<>();
 
         { // content monitor
             final FileAlterationObserver observer;


### PR DESCRIPTION
This PR fixes an issue by ensuring source are converted 1 each.
Also includes a couple of minnor formatting changes.