### PR TITLE
moves port configuration from refresh to http mojo

### DIFF
--- a/src/main/java/org/asciidoctor/maven/AsciidoctorHttpMojo.java
+++ b/src/main/java/org/asciidoctor/maven/AsciidoctorHttpMojo.java
@@ -31,6 +31,9 @@ public class AsciidoctorHttpMojo extends AsciidoctorRefreshMojo {
 
     public static final String PREFIX = AsciidoctorMaven.PREFIX + "http.";
 
+    @Parameter(property = PREFIX + "port")
+    protected int port = 2000;
+
     @Parameter(property = PREFIX + "home", defaultValue = "index")
     protected String home;
 

--- a/src/main/java/org/asciidoctor/maven/AsciidoctorRefreshMojo.java
+++ b/src/main/java/org/asciidoctor/maven/AsciidoctorRefreshMojo.java
@@ -38,9 +38,6 @@ public class AsciidoctorRefreshMojo extends AsciidoctorMojo {
 
     public static final String PREFIX = AsciidoctorMaven.PREFIX + "refresher.";
 
-    @Parameter(property = PREFIX + "port")
-    protected int port = 2000;
-
     @Parameter(property = PREFIX + "interval")
     protected int interval = 2000; // 2s
 


### PR DESCRIPTION
Small fix, this PR:
* Corrects http configuration which was in refresh mojo placing it in the http mojo.

Since both mojo's are still not public, not worth mentioning in changelog.