### PR TITLE
fixes auto-refresh mojo not taking into account customized file extension

### DIFF
--- a/src/main/java/org/asciidoctor/maven/process/AsciidoctorHelper.java
+++ b/src/main/java/org/asciidoctor/maven/process/AsciidoctorHelper.java
@@ -10,7 +10,7 @@
  * limitations under the License.
  */
 
-package org.asciidoctor.maven;
+package org.asciidoctor.maven.process;
 
 import org.apache.maven.project.MavenProject;
 import org.asciidoctor.Attributes;

--- a/src/main/java/org/asciidoctor/maven/process/CustomExtensionDirectoryWalker.java
+++ b/src/main/java/org/asciidoctor/maven/process/CustomExtensionDirectoryWalker.java
@@ -1,0 +1,29 @@
+package org.asciidoctor.maven.process;
+
+import org.asciidoctor.jruby.AbstractDirectoryWalker;
+
+import java.io.File;
+import java.util.Collection;
+
+/**
+ * Directory walker that finds all files matching a collection of file extensions inside a folder and in all its subfolders.
+ * <p>
+ * It returns only the files which their extensions are: .asc, .asciidoc, .ad or .adoc.
+ *
+ * @author abelsromero
+ */
+public class CustomExtensionDirectoryWalker extends AbstractDirectoryWalker {
+
+    private final Collection<String> fileExtensions;
+
+    public CustomExtensionDirectoryWalker(final String absolutePath, final Collection<String> fileExtensions) {
+        super(absolutePath);
+        this.fileExtensions = fileExtensions;
+    }
+
+    @Override
+    protected boolean isAcceptedFile(final File filename) {
+        final String name = filename.getName();
+        return !name.startsWith("_") && fileExtensions.stream().anyMatch(extension -> name.endsWith(extension));
+    }
+}

--- a/src/main/java/org/asciidoctor/maven/process/SourceDirectoryFinder.java
+++ b/src/main/java/org/asciidoctor/maven/process/SourceDirectoryFinder.java
@@ -1,4 +1,4 @@
-package org.asciidoctor.maven;
+package org.asciidoctor.maven.process;
 
 import java.io.File;
 import java.util.Optional;

--- a/src/main/java/org/asciidoctor/maven/site/SiteConversionConfigurationParser.java
+++ b/src/main/java/org/asciidoctor/maven/site/SiteConversionConfigurationParser.java
@@ -4,7 +4,7 @@ import org.apache.commons.lang3.StringUtils;
 import org.apache.maven.project.MavenProject;
 import org.asciidoctor.AttributesBuilder;
 import org.asciidoctor.OptionsBuilder;
-import org.asciidoctor.maven.AsciidoctorHelper;
+import org.asciidoctor.maven.process.AsciidoctorHelper;
 import org.codehaus.plexus.util.xml.Xpp3Dom;
 
 import java.io.File;

--- a/src/test/groovy/org/asciidoctor/maven/test/AsciidoctorMojoTest.groovy
+++ b/src/test/groovy/org/asciidoctor/maven/test/AsciidoctorMojoTest.groovy
@@ -786,7 +786,7 @@ class AsciidoctorMojoTest extends Specification {
 
             File[] htmls =  actualFile.listFiles({File f -> f.getName() ==~ /.+html/} as FileFilter)
             if (htmls) {
-                File[] asciidocs =  expectedFile.listFiles({File f -> f.getName() ==~ ASCIIDOC_REG_EXP_EXTENSION} as FileFilter)
+                File[] asciidocs =  expectedFile.listFiles({File f -> f.getName() ==~ ASCIIDOC_REG_EXP_EXTENSION && !f.getName().startsWith('_')} as FileFilter)
                 assert htmls.length == asciidocs.length
             }
             File[] actualChildren =  actualFile.listFiles(DIRECTORY_FILTER)

--- a/src/test/java/org/asciidoctor/maven/SourceDirectoryFinderTest.java
+++ b/src/test/java/org/asciidoctor/maven/SourceDirectoryFinderTest.java
@@ -1,5 +1,6 @@
 package org.asciidoctor.maven;
 
+import org.asciidoctor.maven.process.SourceDirectoryFinder;
 import org.junit.Rule;
 import org.junit.Test;
 import org.junit.rules.TemporaryFolder;
@@ -10,7 +11,7 @@ import java.util.Optional;
 import java.util.concurrent.atomic.AtomicInteger;
 import java.util.function.Consumer;
 
-import static org.asciidoctor.maven.SourceDirectoryFinder.ORDERED_CANDIDATE_PATHS;
+import static org.asciidoctor.maven.process.SourceDirectoryFinder.ORDERED_CANDIDATE_PATHS;
 import static org.assertj.core.api.Assertions.assertThat;
 
 public class SourceDirectoryFinderTest {

--- a/src/test/java/org/asciidoctor/maven/process/CustomExtensionDirectoryWalkerTest.java
+++ b/src/test/java/org/asciidoctor/maven/process/CustomExtensionDirectoryWalkerTest.java
@@ -1,0 +1,65 @@
+package org.asciidoctor.maven.process;
+
+import org.junit.Test;
+
+import java.io.File;
+import java.util.Collections;
+import java.util.List;
+
+import static org.assertj.core.api.Assertions.assertThat;
+
+public class CustomExtensionDirectoryWalkerTest {
+
+    private static final String DEFAULT_SOURCE_DIRECTORY = "src/test/resources/src/asciidoctor";
+
+    @Test
+    public void should_init_CustomExtensionDirectoryWalker() {
+        // when
+        CustomExtensionDirectoryWalker walker = new CustomExtensionDirectoryWalker("", Collections.emptyList());
+        // then
+        assertThat(walker).isNotNull();
+    }
+
+    @Test
+    public void should_exclude_internal_sources() {
+        // given
+        final String rootDirectory = DEFAULT_SOURCE_DIRECTORY + "/relative-path-treatment";
+        final List<String> fileExtensions = Collections.singletonList("adoc");
+
+        // when
+        List<File> files = new CustomExtensionDirectoryWalker(rootDirectory, fileExtensions)
+                .scan();
+
+        // then
+        assertThat(files)
+                .isNotEmpty()
+                .allMatch(file -> !file.getName().startsWith("_"));
+    }
+
+    @Test
+    public void should_exclude_internal_directories() {
+        // given
+        final String rootDirectory = DEFAULT_SOURCE_DIRECTORY + "/relative-path-treatment";
+        final List<String> fileExtensions = Collections.singletonList("adoc");
+
+        // when
+        List<File> files = new CustomExtensionDirectoryWalker(rootDirectory, fileExtensions)
+                .scan();
+
+        // then
+        assertThat(files)
+                .isNotEmpty()
+                .allMatch(file -> !isContainedInInternalDirectory(file));
+    }
+
+    private boolean isContainedInInternalDirectory(File file) {
+        final String path = file.getPath();
+        int cursor = 0;
+        do {
+            cursor = path.indexOf(File.separator, cursor + 1);
+            if (path.charAt(cursor + 1) == '_')
+                return true;
+        } while (cursor != -1);
+        return false;
+    }
+}

--- a/src/test/resources/src/asciidoctor/relative-path-treatment/level-1-1/_internal-partial.adoc
+++ b/src/test/resources/src/asciidoctor/relative-path-treatment/level-1-1/_internal-partial.adoc
@@ -1,0 +1,8 @@
+:toc: left
+:icons:
+
+== Summary
+This document won't get converted by default because it considered "internal". +
+That is, is prefixed with underscore `_`.
+
+TIP: How cool is this?


### PR DESCRIPTION
Related to #472 
The original approach was to re-use logic from `AsciidoctorMojo`, however that was not efficient in that required creating multiple file monitors/listeners. Finally, I opted to apply custom logic that replicates under-the-hood the same logic to monitor sources, the only missing piece was taking into account custom file extensions.

In sum, this PR:
* Make `auto-refresh` mojo take `sourceDocumentExtensions` into consideration when filtering sources.
* Created `process` package to group classes used to assist in the conversion process of different mojos.
In future refactors if these become generic classes with no Maven dependencies may end up outside of the `maven` package. Maybe even sub-module? The case for a sub-module deppends more in how this affects mavenCentral deployments.

Derivated from the feature, additional changes applied are:
* Refactors in `AsciidoctorMojo` to make sources filtering easier to understand.
* Promoted internal `AsciidoctorMojo::CustomExtensionDirectoryWalker` class to public, and added unit tests for it.
* Fixed conversion message to day `doc(s)` instead of just `doc`
* Adds internal (aka. files with _ prefix) to `AsciidoctorMojo::ASCIIDOC_REG_EXP_EXTENSION` constant