### PR TITLE
Feature/auto refresh files individually

### DIFF
--- a/src/main/java/org/asciidoctor/maven/AsciidoctorMojo.java
+++ b/src/main/java/org/asciidoctor/maven/AsciidoctorMojo.java
@@ -497,7 +497,7 @@ public class AsciidoctorMojo extends AbstractMojo {
 
 
     /**
-     * Creates an AttributesBuilder instance with the options defined in the configuration.
+     * Creates an AttributesBuilder instance with the attributes defined in the configuration.
      *
      * @param configuration AsciidoctorMojo containing conversion configuration.
      * @return initialized attributesBuilder.

--- a/src/main/java/org/asciidoctor/maven/AsciidoctorMojo.java
+++ b/src/main/java/org/asciidoctor/maven/AsciidoctorMojo.java
@@ -162,17 +162,52 @@ public class AsciidoctorMojo extends AbstractMojo {
 
     @Override
     public void execute() throws MojoExecutionException, MojoFailureException {
+        processAllSources();
+    }
+
+    /**
+     * Converts all found AsciiDoc sources according to mojo rules.
+     *
+     * @throws MojoExecutionException If requirements are not met
+     */
+    public void processAllSources() throws MojoExecutionException {
+        processSources(null);
+    }
+
+    /**
+     * Converts a collection of AsciiDoc sources.
+     *
+     * @param sourceFiles Collection of source files to convert.
+     * @throws MojoExecutionException If requirements are not met
+     */
+    public void processSources(List<File> sourceFiles) throws MojoExecutionException {
         if (skip) {
             getLog().info("AsciiDoc processing is skipped.");
             return;
         }
 
         if (sourceDirectory == null) {
-            throw new MojoExecutionException("Required parameter 'asciidoctor.sourceDirectory' not set.");
+            throw new MojoExecutionException("Required parameter 'asciidoctor.alternateSourceDir' not set.");
         }
 
-        if (!initSourceDirectory()) return;
-        ensureOutputExists();
+        Optional<File> sourceDirectoryCandidate = findSourceDirectory(sourceDirectory, project.getBasedir());
+        if (!sourceDirectoryCandidate.isPresent()) {
+            getLog().info("No sourceDirectory found. Skipping processing");
+            return;
+        }
+
+        if (sourceFiles == null) {
+            sourceFiles = calculateSourceFiles(sourceDirectoryCandidate.get());
+        }
+        if (sourceFiles.isEmpty()) {
+            getLog().info("No sources found. Skipping processing");
+            return;
+        }
+
+        if (!ensureOutputExists()) {
+            getLog().error("Can't create " + outputDirectory.getPath());
+            return;
+        }
 
         // Validate resources to avoid errors later on
         if (resources != null) {
@@ -187,16 +222,7 @@ public class AsciidoctorMojo extends AbstractMojo {
         if (enableVerbose) {
             asciidoctor.requireLibrary("enable_verbose.rb");
         }
-
         asciidoctor.requireLibraries(requires);
-
-        final OptionsBuilder optionsBuilder = OptionsBuilder.options();
-        setOptionsOnBuilder(optionsBuilder);
-
-        final AttributesBuilder attributesBuilder = AttributesBuilder.attributes();
-        setAttributesOnBuilder(attributesBuilder);
-
-        optionsBuilder.attributes(attributesBuilder);
 
         ExtensionRegistry extensionRegistry = new AsciidoctorJExtensionRegistry(asciidoctor);
         for (ExtensionConfiguration extension : extensions) {
@@ -207,34 +233,33 @@ public class AsciidoctorMojo extends AbstractMojo {
             }
         }
 
-        // Copy output resources
-        prepareResources();
-        copyResources();
+        AttributesBuilder attributesBuilder = createAttributesBuilder(this, project);
+        OptionsBuilder optionsBuilder = createOptionsBuilder(this, attributesBuilder);
 
-        // Prepare sources
-        final List<File> sourceFiles = calculateSourceFiles();
+        // Copy output resources
+        final File sourceDir = sourceDirectoryCandidate.get();
+        prepareResources(sourceDir);
+        copyResources();
 
         // register LogHandler to capture asciidoctor messages
         final Boolean outputToConsole = logHandler.getOutputToConsole() == null ? Boolean.TRUE : logHandler.getOutputToConsole();
-        final MemoryLogHandler memoryLogHandler = new MemoryLogHandler(outputToConsole, sourceDirectory,
-                logRecord -> getLog().info(LogRecordHelper.format(logRecord, sourceDirectory)));
-        if (!sourceFiles.isEmpty()) {
-            asciidoctor.registerLogHandler(memoryLogHandler);
-            // disable default console output of AsciidoctorJ
-            Logger.getLogger("asciidoctor").setUseParentHandlers(false);
-        }
+        final MemoryLogHandler memoryLogHandler = new MemoryLogHandler(outputToConsole, sourceDir,
+                logRecord -> getLog().info(LogRecordHelper.format(logRecord, sourceDir)));
+        asciidoctor.registerLogHandler(memoryLogHandler);
+        // disable default console output of AsciidoctorJ
+        Logger.getLogger("asciidoctor").setUseParentHandlers(false);
 
-        final Set<File> uniqueDirs = new HashSet<>();
+        final Set<File> uniquePaths = new HashSet<>();
         for (final File source : sourceFiles) {
-            final File destinationPath = setDestinationPaths(optionsBuilder, source);
-            if (!uniqueDirs.add(destinationPath))
+            final File destinationPath = setDestinationPaths(source, optionsBuilder, sourceDir);
+            if (!uniquePaths.add(destinationPath))
                 getLog().warn("Duplicated destination found: overwriting file: " + destinationPath.getAbsolutePath());
 
             convertFile(asciidoctor, optionsBuilder.asMap(), source);
 
             try {
                 // process log messages according to mojo configuration
-                new LogRecordsProcessors(logHandler, sourceDirectory, errorMessage -> getLog().error(errorMessage))
+                new LogRecordsProcessors(logHandler, sourceDir, errorMessage -> getLog().error(errorMessage))
                         .processLogRecords(memoryLogHandler);
             } catch (Exception exception) {
                 throw new MojoExecutionException(exception.getMessage());
@@ -242,8 +267,8 @@ public class AsciidoctorMojo extends AbstractMojo {
         }
     }
 
-    private boolean initSourceDirectory() {
-        Optional<File> sourceDirCandidate = new SourceDirectoryFinder(sourceDirectory, project.getBasedir(),
+    private Optional<File> findSourceDirectory(File initialSourceDirectory, File baseDir) {
+        Optional<File> sourceDirCandidate = new SourceDirectoryFinder(initialSourceDirectory, baseDir,
                 candidate -> {
                     String candidateName = candidate.toString();
                     if (isRelativePath(candidateName)) candidateName = candidateName.substring(2);
@@ -251,13 +276,7 @@ public class AsciidoctorMojo extends AbstractMojo {
                 })
                 .find();
 
-        if (sourceDirCandidate.isPresent()) {
-            this.sourceDirectory = sourceDirCandidate.get();
-        } else {
-            getLog().info("No sourceDirectory found. Skipping processing");
-            return false;
-        }
-        return true;
+        return sourceDirCandidate;
     }
 
     private boolean isRelativePath(String candidateName) {
@@ -269,13 +288,13 @@ public class AsciidoctorMojo extends AbstractMojo {
      * underscore).
      * By default everything in the sources directories is copied.
      */
-    private void prepareResources() {
+    private void prepareResources(File sourceDirectory) {
         if (resources == null || resources.isEmpty()) {
-            resources = new ArrayList<Resource>();
+            resources = new ArrayList<>();
             // we don't want to copy files considered sources
             Resource resource = new Resource();
             resource.setDirectory(sourceDirectory.getAbsolutePath());
-            resource.setExcludes(new ArrayList<String>());
+            resource.setExcludes(new ArrayList<>());
             // exclude sourceDocumentName if defined
             if (sourceDocumentName != null && sourceDocumentName.isEmpty()) {
                 resource.getExcludes().add(sourceDocumentName);
@@ -287,9 +306,9 @@ public class AsciidoctorMojo extends AbstractMojo {
         // All resources must exclude AsciiDoc documents and folders beginning with underscore
         for (Resource resource : resources) {
             if (resource.getExcludes() == null || resource.getExcludes().isEmpty()) {
-                resource.setExcludes(new ArrayList<String>());
+                resource.setExcludes(new ArrayList<>());
             }
-            List<String> excludes = new ArrayList<String>();
+            List<String> excludes = new ArrayList<>();
             for (String value : AsciidoctorFileScanner.IGNORED_FOLDERS_AND_FILES) {
                 excludes.add(value);
             }
@@ -313,7 +332,7 @@ public class AsciidoctorMojo extends AbstractMojo {
             // Right now it's not used at all, but could be used to apply resource filters/replacements
             MavenResourcesExecution resourcesExecution =
                     new MavenResourcesExecution(resources, outputDirectory, project, encoding,
-                            Collections.<String>emptyList(), Collections.<String>emptyList(), session);
+                            Collections.emptyList(), Collections.emptyList(), session);
             resourcesExecution.setIncludeEmptyDirs(true);
             resourcesExecution.setAddDefaultExcludes(true);
             outputResourcesFiltering.filterResources(resourcesExecution);
@@ -325,11 +344,12 @@ public class AsciidoctorMojo extends AbstractMojo {
     /**
      * Updates optionsBuilder object's baseDir and destination(s) accordingly to the options.
      *
-     * @param optionsBuilder AsciidoctorJ options to be updated.
-     * @param sourceFile     AsciiDoc source file to process.
+     * @param sourceFile      AsciiDoc source file to process.
+     * @param optionsBuilder  Asciidoctor options to be updated.
+     * @param sourceDirectory Source directory configured (`sourceFile` may include relative path).
      * @return the final destination file path.
      */
-    private File setDestinationPaths(OptionsBuilder optionsBuilder, final File sourceFile) throws MojoExecutionException {
+    private File setDestinationPaths(final File sourceFile, final OptionsBuilder optionsBuilder, final File sourceDirectory) throws MojoExecutionException {
         try {
             if (baseDir != null) {
                 optionsBuilder.baseDir(baseDir);
@@ -349,7 +369,7 @@ public class AsciidoctorMojo extends AbstractMojo {
                 optionsBuilder.toDir(outputDirectory).destinationDir(outputDirectory);
             }
             if (outputFile != null) {
-                //allow overriding the output file name
+                // allow overriding the output file name
                 optionsBuilder.toFile(outputFile);
             }
             // return destination file path
@@ -406,14 +426,15 @@ public class AsciidoctorMojo extends AbstractMojo {
         return asciidoctor;
     }
 
-    protected List<File> calculateSourceFiles() {
+    protected List<File> calculateSourceFiles(File sourceDirectory) {
         if (sourceDocumentName != null)
             return Arrays.asList(new File(sourceDirectory, sourceDocumentName));
 
         // Both DirectoryWalkers filter out internal sources and path (_ prefix)
+        final String sourceDirectoryAbsolutePath = sourceDirectory.getAbsolutePath();
         final DirectoryWalker directoryWalker = sourceDocumentExtensions.isEmpty()
-                ? new AsciiDocDirectoryWalker(sourceDirectory.getAbsolutePath())
-                : new CustomExtensionDirectoryWalker(sourceDirectory.getAbsolutePath(), sourceDocumentExtensions);
+                ? new AsciiDocDirectoryWalker(sourceDirectoryAbsolutePath)
+                : new CustomExtensionDirectoryWalker(sourceDirectoryAbsolutePath, sourceDocumentExtensions);
 
         return directoryWalker.scan();
     }
@@ -427,61 +448,78 @@ public class AsciidoctorMojo extends AbstractMojo {
         getLog().info("Converted " + f.getAbsolutePath());
     }
 
-    protected void ensureOutputExists() {
+    protected boolean ensureOutputExists() {
         if (!outputDirectory.exists()) {
-            if (!outputDirectory.mkdirs()) {
-                getLog().error("Can't create " + outputDirectory.getPath());
-            }
+            return outputDirectory.mkdirs();
         }
+        return true;
     }
 
     /**
-     * Updates and OptionsBuilder instance with the options defined in the configuration.
+     * Creates an OptionsBuilder instance with the options defined in the configuration.
      *
-     * @param optionsBuilder AsciidoctorJ options to be updated.
+     * @param configuration     AsciidoctorMojo containing conversion configuration.
+     * @param attributesBuilder
+     * @return initialized optionsBuilder.
      */
-    protected void setOptionsOnBuilder(OptionsBuilder optionsBuilder) {
-        optionsBuilder
-                .backend(backend)
+    protected OptionsBuilder createOptionsBuilder(AsciidoctorMojo configuration, AttributesBuilder attributesBuilder) {
+
+        final OptionsBuilder optionsBuilder = OptionsBuilder.options()
+                .backend(configuration.getBackend())
                 .safe(SafeMode.UNSAFE)
-                .headerFooter(headerFooter)
-                .eruby(eruby)
+                .headerFooter(configuration.isHeaderFooter())
+                .eruby(configuration.getEruby())
                 .mkDirs(true);
 
-        // Following options are only set when the value is different than the default
-        if (sourcemap)
-            optionsBuilder.option("sourcemap", true);
+        if (configuration.isSourcemap())
+            optionsBuilder.option(Options.SOURCEMAP, true);
 
-        if (catalogAssets)
-            optionsBuilder.option("catalog_assets", true);
+        if (configuration.isCatalogAssets())
+            optionsBuilder.option(Options.CATALOG_ASSETS, true);
 
-        if (!templateCache)
-            optionsBuilder.option("template_cache", false);
+        if (!configuration.isTemplateCache())
+            optionsBuilder.option(Options.TEMPLATE_CACHE, false);
 
-        if (doctype != null)
+        if (configuration.getDoctype() != null)
             optionsBuilder.docType(doctype);
 
-        if (templateEngine != null)
+        if (configuration.getTemplateEngine() != null)
             optionsBuilder.templateEngine(templateEngine);
 
-        if (templateDirs != null)
+        if (!configuration.getTemplateDirs().isEmpty())
             optionsBuilder.templateDirs(templateDirs.toArray(new File[]{}));
+
+        if (!attributesBuilder.asMap().isEmpty())
+            optionsBuilder.attributes(attributesBuilder);
+
+        return optionsBuilder;
     }
 
-    protected void setAttributesOnBuilder(AttributesBuilder attributesBuilder) {
-        if (embedAssets) {
+
+    /**
+     * Creates an AttributesBuilder instance with the options defined in the configuration.
+     *
+     * @param configuration AsciidoctorMojo containing conversion configuration.
+     * @return initialized attributesBuilder.
+     */
+    protected AttributesBuilder createAttributesBuilder(AsciidoctorMojo configuration, MavenProject maven) {
+
+        final AttributesBuilder attributesBuilder = AttributesBuilder.attributes();
+
+        if (configuration.isEmbedAssets()) {
             attributesBuilder.linkCss(false);
             attributesBuilder.dataUri(true);
         }
 
-        AsciidoctorHelper.addMavenProperties(project, attributesBuilder);
-        AsciidoctorHelper.addAttributes(attributes, attributesBuilder);
+        AsciidoctorHelper.addMavenProperties(maven, attributesBuilder);
+        AsciidoctorHelper.addAttributes(configuration.getAttributes(), attributesBuilder);
 
-        if (!attributesChain.isEmpty()) {
+        if (!configuration.getAttributesChain().isEmpty()) {
             getLog().info("Attributes: " + attributesChain);
             attributesBuilder.arguments(attributesChain);
         }
 
+        return attributesBuilder;
     }
 
     public File getSourceDirectory() {
@@ -651,4 +689,35 @@ public class AsciidoctorMojo extends AbstractMojo {
         this.resources = resources;
     }
 
+    public boolean isEnableVerbose() {
+        return enableVerbose;
+    }
+
+    public List<String> getRequires() {
+        return requires;
+    }
+
+    public void setEnableVerbose(boolean enableVerbose) {
+        this.enableVerbose = enableVerbose;
+    }
+
+    public boolean isSourcemap() {
+        return sourcemap;
+    }
+
+    public boolean isCatalogAssets() {
+        return catalogAssets;
+    }
+
+    public boolean isTemplateCache() {
+        return templateCache;
+    }
+
+    public List<File> getTemplateDirs() {
+        return templateDirs;
+    }
+
+    public String getAttributesChain() {
+        return attributesChain;
+    }
 }

--- a/src/main/java/org/asciidoctor/maven/AsciidoctorRefreshMojo.java
+++ b/src/main/java/org/asciidoctor/maven/AsciidoctorRefreshMojo.java
@@ -12,8 +12,10 @@
 
 package org.asciidoctor.maven;
 
-import org.apache.commons.io.FileUtils;
-import org.apache.commons.io.filefilter.*;
+import org.apache.commons.io.filefilter.FileFilterUtils;
+import org.apache.commons.io.filefilter.IOFileFilter;
+import org.apache.commons.io.filefilter.NameFileFilter;
+import org.apache.commons.io.filefilter.RegexFileFilter;
 import org.apache.commons.io.monitor.FileAlterationListener;
 import org.apache.commons.io.monitor.FileAlterationListenerAdaptor;
 import org.apache.commons.io.monitor.FileAlterationMonitor;
@@ -23,15 +25,13 @@ import org.apache.maven.plugin.MojoFailureException;
 import org.apache.maven.plugin.logging.Log;
 import org.apache.maven.plugins.annotations.Mojo;
 import org.apache.maven.plugins.annotations.Parameter;
-import org.asciidoctor.Asciidoctor;
 
 import java.io.File;
 import java.util.Collection;
 import java.util.Collections;
 import java.util.Scanner;
 import java.util.StringJoiner;
-import java.util.concurrent.*;
-import java.util.concurrent.atomic.AtomicBoolean;
+import java.util.concurrent.TimeUnit;
 
 @Mojo(name = "auto-refresh")
 public class AsciidoctorRefreshMojo extends AsciidoctorMojo {
@@ -41,48 +41,30 @@ public class AsciidoctorRefreshMojo extends AsciidoctorMojo {
     @Parameter(property = PREFIX + "interval")
     protected int interval = 2000; // 2s
 
-    private Future<Asciidoctor> asciidoctor = null;
     private Collection<FileAlterationMonitor> monitors = null;
 
-    private final AtomicBoolean needsUpdate = new AtomicBoolean(false);
-    private ScheduledExecutorService updaterScheduler = null;
 
     @Override
     public void execute() throws MojoExecutionException, MojoFailureException {
-        // this is long because of JRuby startup
-        createAsciidoctor();
-
         startPolling();
-        startUpdater();
-
         doWork();
-
-        stopUpdater();
-        stopMonitor();
-    }
-
-    private void stopUpdater() {
-        if (updaterScheduler != null) {
-            updaterScheduler.shutdown();
-        }
-    }
-
-    private void startUpdater() {
-        updaterScheduler = Executors.newScheduledThreadPool(1);
-
-        // we prevent refreshing more often than all 200ms and we refresh at least once/s
-        // NOTE1: it is intended to avoid too much time space between file polling and re-converting
-        // NOTE2: if nothing to refresh it does nothing so all is fine
-        updaterScheduler.scheduleAtFixedRate(new Updater(needsUpdate, this), 0, Math.min(1000, Math.max(200, interval / 2)), TimeUnit.MILLISECONDS);
+        stopMonitors();
     }
 
     protected void doWork() throws MojoFailureException, MojoExecutionException {
-        getLog().info("Converted doc(s) in " + executeAndReturnDuration() + "ms");
+        long timeInMillis = timed(() -> {
+            try {
+                processAllSources();
+            } catch (MojoExecutionException e) {
+                getLog().error(e);
+            }
+        });
+        getLog().info("Converted document(s) in " + timeInMillis + "ms");
         doWait();
     }
 
-    protected void doWait() {
-        getLog().info("Type [exit|quit] to exit and [refresh] to force a manual re-conversion.");
+    protected void doWait() throws MojoExecutionException, MojoFailureException {
+        showWaitMessage();
 
         String line;
         final Scanner scanner = new Scanner(System.in);
@@ -93,14 +75,18 @@ public class AsciidoctorRefreshMojo extends AsciidoctorMojo {
             }
 
             if ("refresh".equalsIgnoreCase(line)) {
-                doExecute();
+                doWork();
             } else {
                 getLog().warn("'" + line + "' not understood, available commands are [quit, exit, refresh].");
             }
         }
     }
 
-    private void stopMonitor() throws MojoExecutionException {
+    private void showWaitMessage() {
+        getLog().info("Type [exit|quit] to exit and [refresh] to force a manual re-conversion.");
+    }
+
+    private void stopMonitors() throws MojoExecutionException {
         if (monitors != null) {
             for (final FileAlterationMonitor monitor : monitors) {
                 try {
@@ -112,36 +98,11 @@ public class AsciidoctorRefreshMojo extends AsciidoctorMojo {
         }
     }
 
-    protected synchronized void doExecute() {
-        if (!ensureOutputExists())
-            getLog().error("Can't create " + outputDirectory.getPath());
-
-        // delete only content files, resources are synchronized so normally up to date
-        for (final File f : FileUtils.listFiles(outputDirectory, new RegexFileFilter(ASCIIDOC_REG_EXP_EXTENSION), TrueFileFilter.INSTANCE)) {
-            FileUtils.deleteQuietly(f);
-        }
-
-        try {
-            getLog().info("Re-converted doc(s) in " + executeAndReturnDuration() + "ms");
-        } catch (final MojoExecutionException e) {
-            getLog().error(e);
-        } catch (final MojoFailureException e) {
-            getLog().error(e);
-        }
-    }
-
-    protected long executeAndReturnDuration() throws MojoExecutionException, MojoFailureException {
-        final long start = System.nanoTime();
-        super.execute();
-        final long end = System.nanoTime();
-        return TimeUnit.NANOSECONDS.toMillis(end - start);
-    }
-
     private void startPolling() throws MojoExecutionException {
 
         { // content monitor
             final FileAlterationObserver observer = new FileAlterationObserver(sourceDirectory, buildFileFilter());
-            final FileAlterationListener listener = new AtomicFlagFileAlterationListenerAdaptor(needsUpdate, getLog());
+            final FileAlterationListener listener = new AsciidoctorConverterFileAlterationListenerAdaptor(this, () -> showWaitMessage(), getLog());
             final FileAlterationMonitor monitor = new FileAlterationMonitor(interval);
 
             observer.addListener(listener);
@@ -174,89 +135,46 @@ public class AsciidoctorRefreshMojo extends AsciidoctorMojo {
         return new RegexFileFilter(ASCIIDOC_REG_EXP_EXTENSION);
     }
 
-    private void createAsciidoctor() {
-        final ExecutorService es = Executors.newSingleThreadExecutor();
-        asciidoctor = es.submit(() -> Asciidoctor.Factory.create());
-        es.shutdown();
-    }
-
-    private static class Updater implements Runnable {
-
-        private final AtomicBoolean run;
-        private final AsciidoctorRefreshMojo mojo;
-
-        private Updater(final AtomicBoolean run, final AsciidoctorRefreshMojo mojo) {
-            this.run = run;
-            this.mojo = mojo;
-        }
-
-        @Override
-        public void run() {
-            if (run.get()) {
-                run.set(false);
-                mojo.doExecute();
-            }
-        }
-    }
-
-    private static class AsciidoctorConverterFileAlterationListenerAdaptor extends FileAlterationListenerAdaptor {
+    private class AsciidoctorConverterFileAlterationListenerAdaptor extends FileAlterationListenerAdaptor {
 
         private final AsciidoctorMojo mojo;
-        private final AtomicBoolean needsUpdate;
+        private final Runnable postAction;
         private final Log log;
 
-        private AsciidoctorConverterFileAlterationListenerAdaptor(AsciidoctorMojo config, AtomicBoolean needsUpdate, Log log) {
+        private AsciidoctorConverterFileAlterationListenerAdaptor(AsciidoctorMojo config, Runnable postAction, Log log) {
             this.mojo = config;
-            this.needsUpdate = needsUpdate;
+            this.postAction = postAction;
             this.log = log;
         }
 
         @Override
         public void onFileCreate(final File file) {
-            log.info("File " + file.getAbsolutePath() + " created.");
-//            mojo.convert(s);
-            needsUpdate.set(true);
+            processFile(file, "created");
         }
 
         @Override
         public void onFileChange(final File file) {
-            log.info("File " + file.getAbsolutePath() + " updated.");
-            needsUpdate.set(true);
+            processFile(file, "updated");
         }
 
-        @Override
-        public void onFileDelete(final File file) {
-            log.info("File " + file.getAbsolutePath() + " deleted.");
-            needsUpdate.set(true);
+        private synchronized void processFile(File file, String actionName) {
+            log.info(String.format("Source file %s %s", file.getAbsolutePath(), actionName));
+            long timeInMillis = timed(() -> {
+                try {
+                    mojo.processSources(Collections.singletonList(file));
+                } catch (MojoExecutionException e) {
+                    log.error(e);
+                }
+            });
+            getLog().info("Converted document in " + timeInMillis + "ms");
+            postAction.run();
         }
     }
 
-    private static class AtomicFlagFileAlterationListenerAdaptor extends FileAlterationListenerAdaptor {
-
-        private final AtomicBoolean needsUpdate;
-        private final Log log;
-
-        private AtomicFlagFileAlterationListenerAdaptor(AtomicBoolean needsUpdate, Log log) {
-            this.needsUpdate = needsUpdate;
-            this.log = log;
-        }
-
-        @Override
-        public void onFileCreate(final File file) {
-            log.info("File " + file.getAbsolutePath() + " created.");
-            needsUpdate.set(true);
-        }
-
-        @Override
-        public void onFileChange(final File file) {
-            log.info("File " + file.getAbsolutePath() + " updated.");
-            needsUpdate.set(true);
-        }
-
-        @Override
-        public void onFileDelete(final File file) {
-            log.info("File " + file.getAbsolutePath() + " deleted.");
-            needsUpdate.set(true);
-        }
+    public long timed(Runnable runnable) {
+        final long start = System.nanoTime();
+        runnable.run();
+        final long end = System.nanoTime();
+        return TimeUnit.NANOSECONDS.toMillis(end - start);
     }
 }

--- a/src/test/groovy/org/asciidoctor/maven/test/AsciidoctorMojoTest.groovy
+++ b/src/test/groovy/org/asciidoctor/maven/test/AsciidoctorMojoTest.groovy
@@ -794,7 +794,6 @@ class AsciidoctorMojoTest extends Specification {
         }
     }
 
-
     /**
      * Tests the behaviour when:
      *  - simple paths are used
@@ -1087,20 +1086,40 @@ class AsciidoctorMojoTest extends Specification {
             System.setOut(new PrintStream(newOut))
 
             File outputDir = newOutputTestDirectory('multiple-resources-skip')
-            if (!outputDir.exists())
-                outputDir.mkdir()
         when:
             AsciidoctorMojo mojo = new AsciidoctorMojo()
             mojo.sourceDirectory = new File(UUID.randomUUID().toString())
             mojo.backend = 'html5'
             mojo.outputDirectory = outputDir
             mojo.execute()
-
         then:
             def output = newOut.toString()
             println output
             output.contains("sourceDirectory ${mojo.sourceDirectory} does not exist")
             output.contains("No sourceDirectory found. Skipping processing")
+            !outputDir.exists()
+        cleanup:
+            System.setOut(originalOut)
+    }
+
+    def "should skip processing when there are no sources"() {
+        setup:
+            def originalOut = System.out
+            def newOut = new ByteArrayOutputStream()
+            System.setOut(new PrintStream(newOut))
+
+            File srcDir = new File(DEFAULT_SOURCE_DIRECTORY, 'templates')
+            File outputDir = newOutputTestDirectory()
+        when:
+            AsciidoctorMojo mojo = new AsciidoctorMojo()
+            mojo.sourceDirectory = srcDir
+            mojo.backend = 'html5'
+            mojo.outputDirectory = outputDir
+            mojo.execute()
+        then:
+            def output = newOut.toString()
+            println output
+            output.contains("No sources found. Skipping processing")
             !outputDir.exists()
         cleanup:
             System.setOut(originalOut)

--- a/src/test/groovy/org/asciidoctor/maven/test/AsciidoctorRefreshMojoTest.groovy
+++ b/src/test/groovy/org/asciidoctor/maven/test/AsciidoctorRefreshMojoTest.groovy
@@ -1,5 +1,6 @@
 package org.asciidoctor.maven.test
 
+
 import org.asciidoctor.maven.AsciidoctorRefreshMojo
 import org.asciidoctor.maven.test.io.DoubleOuputStream
 import org.asciidoctor.maven.test.io.PrefilledInputStream
@@ -18,7 +19,7 @@ class AsciidoctorRefreshMojoTest extends Specification {
 
     def "auto convert when source updated"() {
         setup:
-            def srcDir = new File('target/test-classes/src/asciidoctor-refresh')
+            File srcDir = new File('target/test-classes/src/asciidoctor-refresh')
             srcDir.mkdirs()
             File outputDir = newOutputTestDirectory('refresh-mojo')
 
@@ -38,10 +39,12 @@ class AsciidoctorRefreshMojoTest extends Specification {
             if (content.exists())
                 content.delete()
 
-            content.withWriter{ it <<
-                '''= Document Title
-
-                This is test, only a test.'''.stripIndent() }
+            content.withWriter {
+                it <<
+                        '''= Document Title
+    
+                    This is test, only a test.'''.stripIndent()
+            }
 
             def target = new File(outputDir, content.name.replace('.asciidoc', '.html'))
 
@@ -49,37 +52,35 @@ class AsciidoctorRefreshMojoTest extends Specification {
             mojo.backend = 'html'
             mojo.sourceDirectory = srcDir
             mojo.outputDirectory = outputDir
-            def mojoThread = new Thread(new Runnable() {
-                @Override
-                void run() {
-                    mojo.execute()
-                    println 'end'
-                }
+            def mojoThread = new Thread({
+                mojo.execute()
+                println 'end'
             })
             mojoThread.start()
 
-            while (!new String(newOut.toByteArray()).contains('Converted')) {
-                Thread.sleep(200)
+            while (!new String(newOut.toByteArray()).contains('Converted document(s) in')) {
+                Thread.sleep(300)
             }
-
             assert target.text.contains('This is test, only a test')
 
         when:
-            content.withWriter{ it <<
-                '''= Document Title
-
-                Wow, this will be auto refreshed!'''.stripIndent() }
+            content.withWriter {
+                it <<
+                        '''= Document Title
+    
+                    Wow, this will be auto refreshed!'''.stripIndent()
+            }
 
         then:
-            while (!new String(newOut.toByteArray()).contains('Re-converted ')) {
-                Thread.sleep 500
+            while (!new String(newOut.toByteArray()).contains("Converted document in")) {
+                Thread.sleep(300)
             }
+
             assert target.text.contains('Wow, this will be auto refreshed')
 
         cleanup:
             System.setOut(originalOut)
             inputLatch.countDown()
             System.setIn(originalIn)
-
     }
 }

--- a/src/test/groovy/org/asciidoctor/maven/test/io/PrefilledInputStream.groovy
+++ b/src/test/groovy/org/asciidoctor/maven/test/io/PrefilledInputStream.groovy
@@ -3,6 +3,7 @@ package org.asciidoctor.maven.test.io
 import java.util.concurrent.CountDownLatch
 
 class PrefilledInputStream extends ByteArrayInputStream {
+
     final CountDownLatch latch
 
     PrefilledInputStream(final byte[] buf, final CountDownLatch latch) {
@@ -11,7 +12,7 @@ class PrefilledInputStream extends ByteArrayInputStream {
     }
 
     @Override
-    public synchronized int read(final byte[] b, final int off, final int len) {
+    synchronized int read(final byte[] b, final int off, final int len) {
         latch.await()
         return super.read(b, off, len)
     }


### PR DESCRIPTION
Related to #472

Make it so that auto-refresh mojo only converts modified or newly created files. This is far more efficient and more importantly, will offer for a much responsive experience for users.

This PR contains:
* Refactor of `AsciidoctorMojo` so all constructions logic can be applied to individual files. 
* Added message and skip logic when no sources are found. This is not treated as error and allows finishing sooner, so may help usign having problems with configurations.
* Modified messages in `RefreshMojo`:
    * "File ..." has been changed to "Source file ..." to better distinguish between AsciiDoc sources and resources.
    * "Re-converted" has been removed since the reuse of the AsciidoctorMojo already shows "Converted ..." message
    * "doc" has been replaced by "document"


PS: Still need to see how to deal with deleted files. That includes renaming a file, which is triggered as a creation + deletion.