### PR TITLE
Refactor/asciidoctor mojo to allow dynamic resources processing logic

### DIFF
--- a/src/main/java/org/asciidoctor/maven/AsciidoctorRefreshMojo.java
+++ b/src/main/java/org/asciidoctor/maven/AsciidoctorRefreshMojo.java
@@ -25,6 +25,7 @@ import org.apache.maven.plugin.MojoFailureException;
 import org.apache.maven.plugin.logging.Log;
 import org.apache.maven.plugins.annotations.Mojo;
 import org.apache.maven.plugins.annotations.Parameter;
+import org.asciidoctor.maven.process.ResourcesProcessor;
 
 import java.io.File;
 import java.util.Collection;
@@ -37,6 +38,10 @@ import java.util.concurrent.TimeUnit;
 public class AsciidoctorRefreshMojo extends AsciidoctorMojo {
 
     public static final String PREFIX = AsciidoctorMaven.PREFIX + "refresher.";
+
+    private static final ResourcesProcessor EMPTY_RESOURCE_PROCESSOR =
+            (sourcesRootDirectory, outputRootDirectory, encoding, configuration) -> {
+            };
 
     @Parameter(property = PREFIX + "interval")
     protected int interval = 2000; // 2s
@@ -54,7 +59,7 @@ public class AsciidoctorRefreshMojo extends AsciidoctorMojo {
     protected void doWork() throws MojoFailureException, MojoExecutionException {
         long timeInMillis = timed(() -> {
             try {
-                processAllSources();
+                processAllSources(defaultResourcesProcessor);
             } catch (MojoExecutionException e) {
                 getLog().error(e);
             }
@@ -161,7 +166,7 @@ public class AsciidoctorRefreshMojo extends AsciidoctorMojo {
             log.info(String.format("Source file %s %s", file.getAbsolutePath(), actionName));
             long timeInMillis = timed(() -> {
                 try {
-                    mojo.processSources(Collections.singletonList(file));
+                    mojo.processSources(Collections.singletonList(file), EMPTY_RESOURCE_PROCESSOR);
                 } catch (MojoExecutionException e) {
                     log.error(e);
                 }

--- a/src/main/java/org/asciidoctor/maven/process/ResourcesProcessor.java
+++ b/src/main/java/org/asciidoctor/maven/process/ResourcesProcessor.java
@@ -1,0 +1,13 @@
+package org.asciidoctor.maven.process;
+
+import org.apache.maven.plugin.MojoExecutionException;
+import org.asciidoctor.maven.AsciidoctorMojo;
+
+import java.io.File;
+
+public interface ResourcesProcessor {
+
+    void process(File sourcesRootDirectory, File outputRootDirectory,
+                 String encoding, AsciidoctorMojo configuration) throws MojoExecutionException;
+
+}


### PR DESCRIPTION
**What kind of change does this PR introduce?** (check at least one)
<!-- Update "[ ]" to "[x]" to check a box -->

- [ ] Bugfix
- [ ] Feature
- [ ] Documentation
- [x] Refactor
- [ ] Build improvement
- [ ] Other (please describe)


**What is the goal of this pull request?**
Refactors to allow implementing "file by file" resource processing in refresh mojo.
Even when does not fix or add anything, I think it's worth keeping this in the git history.

**Are there any alternative ways to implement this?**
Yes. Eventually we want to better refactor the code to extract processing logic from AsciidoctorMojo.
Right now the code is kept clean but with minimal changes. One example is the use of the mojo as configuration holder which is not idea, but a beginning.

**Are there any implications of this pull request? Anything a user must know?**
No

**Is it related to an existing issue?**
<!-- If Yes, please add a line of the form: `Fixes #Issue` --> 
- [ ] Yes
- [x] No
Related with https://github.com/asciidoctor/asciidoctor-maven-plugin/issues/472 but not closes.

*Finally, please add a corresponding entry to CHANGELOG.adoc*
Since this is internal refactor I don't think is work mentioning explicitly in CHANGELOG.
Refactors will be mentioned as a general highlight in the release notes.