### PR TITLE
avoids docInfo files from being copied in refresh mojo

### DIFF
--- a/CHANGELOG.adoc
+++ b/CHANGELOG.adoc
@@ -18,6 +18,7 @@ Improvements::
   * Inject Maven properties as attributes in `process-asciidoc` mojo (#459)
   * Make `auto-refresh` (and `http` by inheritance) only convert modified and created sources (#474)
   * Make `auto-refresh` only copy modified and created resources + taking into consideration <resources> options (#478)
+  * Make `auto-refresh` ignore docInfo files to avoid copying them into output (#480)
 
 Bug Fixes::
 

--- a/src/main/java/org/asciidoctor/maven/AsciidoctorMojo.java
+++ b/src/main/java/org/asciidoctor/maven/AsciidoctorMojo.java
@@ -57,10 +57,6 @@ import static org.asciidoctor.maven.process.SourceDirectoryFinder.DEFAULT_SOURCE
  */
 @Mojo(name = "process-asciidoc", threadSafe = true)
 public class AsciidoctorMojo extends AbstractMojo {
-    // copied from org.asciidoctor.AsciiDocDirectoryWalker.ASCIIDOC_REG_EXP_EXTENSION
-    // should probably be configured in AsciidoctorMojo through @Parameter 'extension'
-    protected static final String ASCIIDOC_FILE_EXTENSIONS_REG_EXP = "a((sc(iidoc)?)|d(oc)?)";
-    protected static final String ASCIIDOC_NON_INTERNAL_REG_EXP = "^[^_.].*\\." + ASCIIDOC_FILE_EXTENSIONS_REG_EXP + "$";
 
     @Parameter(defaultValue = "${project.build.sourceEncoding}")
     protected String encoding;
@@ -319,10 +315,13 @@ public class AsciidoctorMojo extends AbstractMojo {
         // All resources must exclude AsciiDoc documents and folders beginning with underscore
         for (Resource resource : resources) {
             List<String> excludes = new ArrayList<>();
-            for (String value : AsciidoctorFileScanner.IGNORED_FOLDERS_AND_FILES) {
+            for (String value : AsciidoctorFileScanner.INTERNAL_FOLDERS_AND_FILES_PATTERNS) {
                 excludes.add(value);
             }
-            for (String value : AsciidoctorFileScanner.DEFAULT_FILE_EXTENSIONS) {
+            for (String value : AsciidoctorFileScanner.IGNORED_FILE_NAMES) {
+                excludes.add("**/" + value);
+            }
+            for (String value : AsciidoctorFileScanner.DEFAULT_ASCIIDOC_EXTENSIONS) {
                 excludes.add(value);
             }
             for (String docExtension : configuration.getSourceDocumentExtensions()) {

--- a/src/main/java/org/asciidoctor/maven/AsciidoctorRefreshMojo.java
+++ b/src/main/java/org/asciidoctor/maven/AsciidoctorRefreshMojo.java
@@ -25,6 +25,7 @@ import org.apache.maven.plugins.annotations.Mojo;
 import org.apache.maven.plugins.annotations.Parameter;
 import org.asciidoctor.maven.refresh.AsciidoctorConverterFileAlterationListenerAdaptor;
 import org.asciidoctor.maven.refresh.ResourceCopyFileAlterationListenerAdaptor;
+import org.asciidoctor.maven.refresh.ResourcesPatternBuilder;
 import org.asciidoctor.maven.refresh.TimeCounter;
 
 import java.io.File;
@@ -32,6 +33,7 @@ import java.io.FileFilter;
 import java.util.*;
 
 import static org.apache.commons.lang3.StringUtils.isBlank;
+import static org.asciidoctor.maven.io.AsciidoctorFileScanner.ASCIIDOC_NON_INTERNAL_REG_EXP;
 
 @Mojo(name = "auto-refresh")
 public class AsciidoctorRefreshMojo extends AsciidoctorMojo {
@@ -138,20 +140,8 @@ public class AsciidoctorRefreshMojo extends AsciidoctorMojo {
     }
 
     private FileFilter buildResourcesFileFilter() {
-
-        final StringJoiner filePattern = new StringJoiner("|")
-                .add(ASCIIDOC_FILE_EXTENSIONS_REG_EXP);
-        if (!sourceDocumentExtensions.isEmpty())
-            filePattern.add(String.join("|", sourceDocumentExtensions));
-
-        final String includedResourcesPattern = new StringBuilder()
-                .append("^")
-                .append(isBlank(sourceDocumentName) ? "" : "(?!(" + sourceDocumentName + "))")
-                .append("[^_.].*\\.(?!(")
-                .append(filePattern.toString())
-                .append(")).*$")
-                .toString();
-        return FileFilterUtils.or(FileFilterUtils.directoryFileFilter(), new RegexFileFilter(includedResourcesPattern));
+        final String resourcesRegexPattern = new ResourcesPatternBuilder(sourceDocumentName, sourceDocumentExtensions).build();
+        return FileFilterUtils.or(FileFilterUtils.directoryFileFilter(), new RegexFileFilter(resourcesRegexPattern));
     }
 
     private IOFileFilter buildSourcesFileFilter() {

--- a/src/main/java/org/asciidoctor/maven/io/AsciidoctorFileScanner.java
+++ b/src/main/java/org/asciidoctor/maven/io/AsciidoctorFileScanner.java
@@ -13,30 +13,39 @@ import java.util.*;
  */
 public class AsciidoctorFileScanner {
 
-    public static String[] DEFAULT_FILE_EXTENSIONS = {"**/*.adoc", "**/*.ad", "**/*.asc","**/*.asciidoc"};
+    // copied from org.asciidoctor.AsciiDocDirectoryWalker.ASCIIDOC_REG_EXP_EXTENSION
+    // should probably be configured in AsciidoctorMojo through @Parameter 'extension'
+    public static final String ASCIIDOC_FILE_EXTENSIONS_REG_EXP = "a((sc(iidoc)?)|d(oc)?)";
+    public static final String ASCIIDOC_NON_INTERNAL_REG_EXP = "^[^_.].*\\." + ASCIIDOC_FILE_EXTENSIONS_REG_EXP + "$";
 
-    public static String[] IGNORED_FOLDERS_AND_FILES = {
-            // Files and directories beginning with underscore are ignored
+    public static String[] DEFAULT_ASCIIDOC_EXTENSIONS = {"**/*.adoc", "**/*.ad", "**/*.asc", "**/*.asciidoc"};
+
+    // Files and directories beginning with underscore are ignored
+    public static String[] INTERNAL_FOLDERS_AND_FILES_PATTERNS = {
             "**/_*.*",
             "**/_*",
             "**/_*/**/*.*",
-            // docinfo snippets should not be copied
-            "**/docinfo.html",
-            "**/docinfo-header.html",
-            "**/docinfo-footer.html",
-            "**/*-docinfo.html",
-            "**/*-docinfo-header.html",
-            "**/*-docinfo-footer.html",
-            "**/docinfo.xml",
-            "**/docinfo-header.xml",
-            "**/docinfo-footer.xml",
-            "**/*-docinfo.xml",
-            "**/*-docinfo-header.xml",
-            "**/*-docinfo-footer.xml"};
+    };
 
-    private BuildContext buildContext;
+    // docinfo snippets should not be copied
+    public static String[] IGNORED_FILE_NAMES = {
+            "docinfo.html",
+            "docinfo-header.html",
+            "docinfo-footer.html",
+            "*-docinfo.html",
+            "*-docinfo-header.html",
+            "*-docinfo-footer.html",
+            "docinfo.xml",
+            "docinfo-header.xml",
+            "docinfo-footer.xml",
+            "*-docinfo.xml",
+            "*-docinfo-header.xml",
+            "*-docinfo-footer.xml"};
 
-    public AsciidoctorFileScanner(BuildContext buildContext) {
+
+    private final BuildContext buildContext;
+
+    public AsciidoctorFileScanner(final BuildContext buildContext) {
         this.buildContext = buildContext;
     }
 
@@ -50,7 +59,7 @@ public class AsciidoctorFileScanner {
         Scanner scanner = buildContext.newScanner(new File(resource.getDirectory()), true);
         setupScanner(scanner, resource);
         scanner.scan();
-        List<File> files = new ArrayList<File>();
+        List<File> files = new ArrayList<>();
         for (String file : scanner.getIncludedFiles()) {
             files.add(new File(resource.getDirectory(), file));
         }
@@ -64,8 +73,8 @@ public class AsciidoctorFileScanner {
      * @return List of found documents matching the resources properties
      */
     public List<File> scan(List<Resource> resources) {
-        List<File> files = new ArrayList<File>();
-        for (Resource resource: resources) {
+        final List<File> files = new ArrayList<>();
+        for (Resource resource : resources) {
             files.addAll(scan(resource));
         }
         return files;
@@ -79,36 +88,40 @@ public class AsciidoctorFileScanner {
      *     <li>includes adds extension .adoc, .ad, .asc and .asciidoc
      *     <li>excludes adds filters to avoid hidden files and directoris beginning with undersore
      * </ul>
-     *
+     * <p>
      * NOTE: Patterns both in inclusions and exclusions are automatically excluded.
      */
     private void setupScanner(Scanner scanner, Resource resource) {
 
-        if (resource.getIncludes() == null || resource.getIncludes().isEmpty()) {
-            scanner.setIncludes(DEFAULT_FILE_EXTENSIONS);
+        if (isEmpty(resource.getIncludes())) {
+            scanner.setIncludes(DEFAULT_ASCIIDOC_EXTENSIONS);
         } else {
-            scanner.setIncludes(resource.getIncludes().toArray(new String[] {}));
+            scanner.setIncludes(resource.getIncludes().toArray(new String[]{}));
         }
 
-        if (resource.getExcludes() == null || resource.getExcludes().isEmpty()) {
-            scanner.setExcludes(IGNORED_FOLDERS_AND_FILES);
+        if (isEmpty(resource.getExcludes())) {
+            scanner.setExcludes(IGNORED_FILE_NAMES);
         } else {
-            scanner.setExcludes(mergeAndConvert(resource.getExcludes(), IGNORED_FOLDERS_AND_FILES));
+            scanner.setExcludes(mergeAndConvert(resource.getExcludes(), IGNORED_FILE_NAMES));
         }
         // adds exclusions like SVN or GIT files
         scanner.addDefaultExcludes();
+    }
+
+    private boolean isEmpty(List<String> excludes) {
+        return excludes == null || excludes.isEmpty();
     }
 
     /**
      * Returns a String[] with the values of both input parameters.
      * Duplicated values are inserted only once.
      *
-     * @param list List of string
+     * @param list  List of string
      * @param array Array of String
      * @return Array of String with all values
      */
     private String[] mergeAndConvert(List<String> list, String[] array) {
-        Set<String> set = new HashSet<String>(Arrays.asList(array));
+        Set<String> set = new HashSet<>(Arrays.asList(array));
         set.addAll(list);
         return set.toArray(new String[set.size()]);
     }

--- a/src/main/java/org/asciidoctor/maven/refresh/ResourcesPatternBuilder.java
+++ b/src/main/java/org/asciidoctor/maven/refresh/ResourcesPatternBuilder.java
@@ -1,0 +1,49 @@
+package org.asciidoctor.maven.refresh;
+
+import org.asciidoctor.maven.io.AsciidoctorFileScanner;
+
+import java.util.Arrays;
+import java.util.List;
+import java.util.StringJoiner;
+import java.util.stream.Collectors;
+
+import static org.apache.commons.lang3.StringUtils.isBlank;
+import static org.asciidoctor.maven.io.AsciidoctorFileScanner.ASCIIDOC_FILE_EXTENSIONS_REG_EXP;
+
+/**
+ * Builds regular expression to include all valid resources, as well as exclude invalid ones
+ * to be copied for `auto-refresh` mojo.
+ *
+ * @author abelsromero
+ */
+public class ResourcesPatternBuilder {
+
+    private final String sourceDocumentName;
+    private final List<String> sourceDocumentExtensions;
+
+    public ResourcesPatternBuilder(final String sourceDocumentName, final List<String> sourceDocumentExtensions) {
+        this.sourceDocumentName = sourceDocumentName;
+        this.sourceDocumentExtensions = sourceDocumentExtensions;
+    }
+
+    public String build() {
+        final StringJoiner filePattern = new StringJoiner("|")
+                .add(ASCIIDOC_FILE_EXTENSIONS_REG_EXP);
+        if (!sourceDocumentExtensions.isEmpty())
+            filePattern.add(String.join("|", sourceDocumentExtensions));
+
+        final String specialFiles = Arrays.stream(AsciidoctorFileScanner.IGNORED_FILE_NAMES)
+                .map(pattern -> pattern.replaceAll("\\*", ".*"))
+                .map(pattern -> pattern.replaceAll("\\.", "\\\\."))
+                .collect(Collectors.joining("|"));
+
+        return new StringBuilder()
+                .append("^")
+                .append("(?!(" + specialFiles + (isBlank(sourceDocumentName) ? "" : "|" + sourceDocumentName) + "))")
+                .append("[^_.].*\\.(?!(")
+                .append(filePattern.toString())
+                .append(")).*$")
+                .toString();
+    }
+
+}

--- a/src/test/java/org/asciidoctor/maven/AsciidoctorRefreshMojoTest.java
+++ b/src/test/java/org/asciidoctor/maven/AsciidoctorRefreshMojoTest.java
@@ -19,11 +19,14 @@ import org.sonatype.plexus.build.incremental.DefaultBuildContext;
 import java.io.File;
 import java.io.IOException;
 import java.util.Arrays;
+import java.util.List;
 import java.util.UUID;
 import java.util.function.Consumer;
 import java.util.function.Supplier;
+import java.util.stream.Collectors;
 
 import static java.nio.charset.StandardCharsets.UTF_8;
+import static org.asciidoctor.maven.io.TestFilesHelper.createFileWithContent;
 import static org.asciidoctor.maven.io.TestFilesHelper.newOutputTestDirectory;
 import static org.assertj.core.api.Assertions.assertThat;
 import static org.codehaus.plexus.util.ReflectionUtils.setVariableValueInObject;
@@ -126,6 +129,7 @@ public class AsciidoctorRefreshMojoTest {
 
         final File srcDir = newOutputTestDirectory(TEST_DIR);
         final File outputDir = newOutputTestDirectory(TEST_DIR);
+        final List<File> docInfoFiles = createDocInfoFiles(srcDir);
 
         final String fileExtension = "adoc";
         final File sourceFile = new File(srcDir, "my-sourceFile-" + UUID.randomUUID() + "." + fileExtension);
@@ -158,6 +162,7 @@ public class AsciidoctorRefreshMojoTest {
                 .contains("Wow, this will be auto refreshed");
         assertThat(ignoredTarget)
                 .doesNotExist();
+        assertFilesNotPresentInOutput(docInfoFiles, outputDir);
 
         // cleanup
         consoleHolder.input("exit");
@@ -172,6 +177,7 @@ public class AsciidoctorRefreshMojoTest {
 
         final File srcDir = newOutputTestDirectory(TEST_DIR);
         final File outputDir = newOutputTestDirectory(TEST_DIR);
+        final List<File> docInfoFiles = createDocInfoFiles(srcDir);
 
         final String customFileExtension = "myadoc";
         final File sourceFile = new File(srcDir, "sourceFile." + customFileExtension);
@@ -198,6 +204,7 @@ public class AsciidoctorRefreshMojoTest {
         consoleHolder.awaitProcessingSource();
         assertThat(FileUtils.readFileToString(target, UTF_8))
                 .contains("Wow, this will be auto refreshed");
+        assertFilesNotPresentInOutput(docInfoFiles, outputDir);
 
         // cleanup
         consoleHolder.input("exit");
@@ -212,6 +219,7 @@ public class AsciidoctorRefreshMojoTest {
 
         final File srcDir = newOutputTestDirectory(TEST_DIR);
         final File outputDir = newOutputTestDirectory(TEST_DIR);
+        final List<File> docInfoFiles = createDocInfoFiles(srcDir);
 
         final File sourceFile = new File(srcDir, "sourceFile.asciidoc");
 
@@ -232,6 +240,7 @@ public class AsciidoctorRefreshMojoTest {
         consoleHolder.awaitProcessingSource();
         assertThat(FileUtils.readFileToString(target, UTF_8))
                 .contains("Wow, this will be auto refreshed");
+        assertFilesNotPresentInOutput(docInfoFiles, outputDir);
 
         // cleanup
         consoleHolder.input("exit");
@@ -246,6 +255,7 @@ public class AsciidoctorRefreshMojoTest {
 
         final File srcDir = newOutputTestDirectory(TEST_DIR);
         final File outputDir = newOutputTestDirectory(TEST_DIR);
+        final List<File> docInfoFiles = createDocInfoFiles(srcDir);
 
         final File sourceFile = new File(new File(srcDir, "sub-dir1/sub_dir2"), "sourceFile.asciidoc");
 
@@ -266,6 +276,7 @@ public class AsciidoctorRefreshMojoTest {
         consoleHolder.awaitProcessingSource();
         assertThat(FileUtils.readFileToString(target, UTF_8))
                 .contains("Wow, this will be auto refreshed");
+        assertFilesNotPresentInOutput(docInfoFiles, outputDir);
 
         // cleanup
         consoleHolder.input("exit");
@@ -280,6 +291,7 @@ public class AsciidoctorRefreshMojoTest {
 
         final File srcDir = newOutputTestDirectory(TEST_DIR);
         final File outputDir = newOutputTestDirectory(TEST_DIR);
+        final List<File> docInfoFiles = createDocInfoFiles(srcDir);
 
         final File sourceFile = new File(new File(srcDir, "sub-dir1/sub_dir2"), "sourceFile.asciidoc");
 
@@ -304,6 +316,7 @@ public class AsciidoctorRefreshMojoTest {
                 .contains("Wow, this is NEW!!");
         assertThat(FileUtils.readFileToString(target, UTF_8))
                 .contains("This is test, only a test");
+        assertFilesNotPresentInOutput(docInfoFiles, outputDir);
 
         // cleanup
         consoleHolder.input("exit");
@@ -318,6 +331,7 @@ public class AsciidoctorRefreshMojoTest {
 
         final File srcDir = newOutputTestDirectory(TEST_DIR);
         final File outputDir = newOutputTestDirectory(TEST_DIR);
+        final List<File> docInfoFiles = createDocInfoFiles(srcDir);
 
         final File resourceFile = new File(srcDir, "fakeImage.jpg");
 
@@ -338,6 +352,7 @@ public class AsciidoctorRefreshMojoTest {
         consoleHolder.awaitProcessingResource();
         assertThat(FileUtils.readFileToString(target, UTF_8))
                 .isEqualTo("Supposedly image content UPDATED!");
+        assertFilesNotPresentInOutput(docInfoFiles, outputDir);
 
         // cleanup
         consoleHolder.input("exit");
@@ -352,6 +367,7 @@ public class AsciidoctorRefreshMojoTest {
 
         final File srcDir = newOutputTestDirectory(TEST_DIR);
         final File outputDir = newOutputTestDirectory(TEST_DIR);
+        final List<File> docInfoFiles = createDocInfoFiles(srcDir);
 
         FileUtils.write(new File(srcDir, "sourceFile.asciidoc"),
                 "= Document Title\n\nThis is test, only a test.", UTF_8);
@@ -375,6 +391,7 @@ public class AsciidoctorRefreshMojoTest {
         consoleHolder.awaitProcessingResource();
         assertThat(FileUtils.readFileToString(target, UTF_8))
                 .isEqualTo("Supposedly image content UPDATED!");
+        assertFilesNotPresentInOutput(docInfoFiles, outputDir);
 
         // cleanup
         consoleHolder.input("exit");
@@ -389,6 +406,7 @@ public class AsciidoctorRefreshMojoTest {
 
         final File srcDir = newOutputTestDirectory(TEST_DIR);
         final File outputDir = newOutputTestDirectory(TEST_DIR);
+        final List<File> docInfoFiles = createDocInfoFiles(srcDir);
 
         FileUtils.write(new File(srcDir, "sourceFile.asciidoc"),
                 "= Document Title\n\nThis is test, only a test.", UTF_8);
@@ -413,6 +431,7 @@ public class AsciidoctorRefreshMojoTest {
         consoleHolder.awaitProcessingResource();
         assertThat(FileUtils.readFileToString(target, UTF_8))
                 .isEqualTo("Supposedly image content UPDATED!");
+        assertFilesNotPresentInOutput(docInfoFiles, outputDir);
 
         // cleanup
         consoleHolder.input("exit");
@@ -427,6 +446,7 @@ public class AsciidoctorRefreshMojoTest {
 
         final File srcDir = newOutputTestDirectory(TEST_DIR);
         final File outputDir = newOutputTestDirectory(TEST_DIR);
+        final List<File> docInfoFiles = createDocInfoFiles(srcDir);
 
         FileUtils.write(new File(srcDir, "sourceFile.asciidoc"),
                 "= Document Title\n\nThis is test, only a test.", UTF_8);
@@ -466,6 +486,7 @@ public class AsciidoctorRefreshMojoTest {
                 .isEqualTo("Supposedly image content UPDATED!");
         assertThat(new File(outputDir, resourceFile.getName()))
                 .doesNotExist();
+        assertFilesNotPresentInOutput(docInfoFiles, outputDir);
 
         // cleanup
         consoleHolder.input("exit");
@@ -480,6 +501,7 @@ public class AsciidoctorRefreshMojoTest {
 
         final File srcDir = newOutputTestDirectory(TEST_DIR);
         final File outputDir = newOutputTestDirectory(TEST_DIR);
+        final List<File> docInfoFiles = createDocInfoFiles(srcDir);
 
         FileUtils.write(new File(srcDir, "sourceFile.asciidoc"),
                 "= Document Title\n\nThis is test, only a test.", UTF_8);
@@ -516,6 +538,7 @@ public class AsciidoctorRefreshMojoTest {
         consoleHolder.awaitProcessingResource();
         assertThat(FileUtils.readFileToString(target, UTF_8))
                 .isEqualTo("Supposedly image content UPDATED!");
+        assertFilesNotPresentInOutput(docInfoFiles, outputDir);
 
         // cleanup
         consoleHolder.input("exit");
@@ -530,16 +553,13 @@ public class AsciidoctorRefreshMojoTest {
 
         final File srcDir = newOutputTestDirectory(TEST_DIR);
         final File outputDir = newOutputTestDirectory(TEST_DIR);
+        final List<File> docInfoFiles = createDocInfoFiles(srcDir);
 
-        final File sourceFile = new File(srcDir, "sourceFile.adoc");
-        final File resourceFile1 = new File(srcDir, "fakeImage.jpg");
-        final File resourceFile2 = new File(srcDir, "fakeImage.gif");
+        final File sourceFile = createFileWithContent(srcDir, "sourceFile.adoc", "= Document Title\n\nThis is test, only a test.");
+        final File resourceFile1 = createFileWithContent(srcDir, "fakeImage.jpg", "= Not an image\n\nThis is reality a Adoc source with jpg extension");
+        final File resourceFile2 = createFileWithContent(srcDir, "fakeImage.gif", "Supposedly image content");
 
         // when:
-        FileUtils.write(sourceFile, "= Document Title\n\nThis is test, only a test.", UTF_8);
-        FileUtils.write(resourceFile1, "= Not an image\n\nThis is reality a Adoc source with jpg extension", UTF_8);
-        FileUtils.write(resourceFile2, "Supposedly image content", UTF_8);
-
         Thread mojoThread = runMojoAsynchronously(mojo -> {
             mojo.backend = "html5";
             mojo.sourceDirectory = srcDir;
@@ -574,6 +594,7 @@ public class AsciidoctorRefreshMojoTest {
                 .exists();
         assertThat(targetSource)
                 .doesNotExist();
+        assertFilesNotPresentInOutput(docInfoFiles, outputDir);
 
         // cleanup
         consoleHolder.input("exit");
@@ -589,6 +610,7 @@ public class AsciidoctorRefreshMojoTest {
         final File srcDir = newOutputTestDirectory(TEST_DIR);
         final File outputDir = newOutputTestDirectory(TEST_DIR);
 
+        final List<File> docInfoFiles = createDocInfoFiles(srcDir);
         final File sourceFile = new File(srcDir, "sourceFile.adoc");
         final File resourceFile1 = new File(srcDir, "fakeImage.jpg");
         final File resourceFile2 = new File(srcDir, "fakeImage.gif");
@@ -632,6 +654,7 @@ public class AsciidoctorRefreshMojoTest {
                 .exists();
         assertThat(targetSource)
                 .doesNotExist();
+        assertFilesNotPresentInOutput(docInfoFiles, outputDir);
 
         // cleanup
         consoleHolder.input("exit");
@@ -647,6 +670,7 @@ public class AsciidoctorRefreshMojoTest {
         final File srcDir = newOutputTestDirectory(TEST_DIR);
         final File outputDir = newOutputTestDirectory(TEST_DIR);
 
+        final List<File> docInfoFiles = createDocInfoFiles(srcDir);
         FileUtils.write(new File(srcDir, "sourceFile.asciidoc"),
                 "= Document Title\n\nThis is test, only a test.", UTF_8);
         final File subDirectory = new File(srcDir, "sub-dir1/sub_dir2");
@@ -672,6 +696,7 @@ public class AsciidoctorRefreshMojoTest {
                 .isEqualTo("Supposedly NEW image content!!");
         assertThat(resourceFile)
                 .exists();
+        assertFilesNotPresentInOutput(docInfoFiles, outputDir);
 
         // cleanup
         consoleHolder.input("exit");
@@ -740,6 +765,21 @@ public class AsciidoctorRefreshMojoTest {
             else
                 Thread.sleep(pollTime);
         }
+    }
+
+    private List<File> createDocInfoFiles(final File srcDir) {
+        return Arrays.asList("docinfo.html", "docinfo-header.html", "my-docinfo-header.xml")
+                .stream()
+                .map(filename -> createFileWithContent(srcDir, filename))
+                .collect(Collectors.toList());
+    }
+
+    private void assertFilesNotPresentInOutput(final List<File> files, final File outputDir) {
+        assertThat(files
+                .stream()
+                .map(file -> new File(outputDir, file.getName()))
+                .collect(Collectors.toList()))
+                .allMatch(file -> !file.exists());
     }
 
 }

--- a/src/test/java/org/asciidoctor/maven/io/TestFilesHelper.java
+++ b/src/test/java/org/asciidoctor/maven/io/TestFilesHelper.java
@@ -1,16 +1,33 @@
 package org.asciidoctor.maven.io;
 
+import lombok.SneakyThrows;
+
 import java.io.File;
+import java.nio.file.Files;
 import java.util.UUID;
 
 public class TestFilesHelper {
 
+    public static final String TEST_OUTPUT_BASE_PATH = "target/asciidoctor-test-output/";
+
     public static File newOutputTestDirectory() {
-        return new File("target/asciidoctor-test-output/" + UUID.randomUUID());
+        return new File(TEST_OUTPUT_BASE_PATH + UUID.randomUUID());
     }
 
     public static File newOutputTestDirectory(String subDir) {
-        return new File("target/asciidoctor-test-output/" + subDir + "/" + UUID.randomUUID());
+        return new File(TEST_OUTPUT_BASE_PATH + subDir + "/" + UUID.randomUUID());
+    }
+
+    public static File createFileWithContent(File srcDir, String filename) {
+        return createFileWithContent(srcDir, filename, "Test content");
+    }
+
+    @SneakyThrows
+    public static File createFileWithContent(File srcDir, String filename, String content) {
+        srcDir.mkdirs();
+        final File file = new File(srcDir, filename);
+        Files.write(file.toPath(), content.getBytes());
+        return file;
     }
 
 }

--- a/src/test/java/org/asciidoctor/maven/refresh/ResourcesPatternBuilderTest.java
+++ b/src/test/java/org/asciidoctor/maven/refresh/ResourcesPatternBuilderTest.java
@@ -1,0 +1,48 @@
+package org.asciidoctor.maven.refresh;
+
+import org.junit.Test;
+
+import java.util.Arrays;
+import java.util.Collections;
+
+import static org.assertj.core.api.Assertions.assertThat;
+
+public class ResourcesPatternBuilderTest {
+
+    private static final String DOC_INFO_FILES = "docinfo\\.html|docinfo-header\\.html|docinfo-footer\\.html|\\.*-docinfo\\.html|\\.*-docinfo-header\\.html|\\.*-docinfo-footer\\.html|docinfo\\.xml|docinfo-header\\.xml|docinfo-footer\\.xml|\\.*-docinfo\\.xml|\\.*-docinfo-header\\.xml|\\.*-docinfo-footer\\.xml";
+    private static final String ASCIIDOC_SOURCES = "(a((sc(iidoc)?)|d(oc)?))";
+
+    @Test
+    public void should_build_default_pattern() {
+        // given
+        ResourcesPatternBuilder patternBuilder = new ResourcesPatternBuilder("", Collections.emptyList());
+        // when
+        final String pattern = patternBuilder.build();
+        // then
+        assertThat(pattern)
+                .isEqualTo("^(?!(" + DOC_INFO_FILES + "))[^_.].*\\.(?!" + ASCIIDOC_SOURCES + ").*$");
+    }
+
+    @Test
+    public void should_build_pattern_with_sourceDocumentName() {
+        // given
+        ResourcesPatternBuilder patternBuilder = new ResourcesPatternBuilder("fixed-source.name", Collections.emptyList());
+        // when
+        final String pattern = patternBuilder.build();
+        // then
+        assertThat(pattern)
+                .isEqualTo("^(?!(" + DOC_INFO_FILES + "|fixed-source.name))[^_.].*\\.(?!" + ASCIIDOC_SOURCES + ").*$");
+    }
+
+    @Test
+    public void should_build_pattern_with_sourceDocumentExtensions() {
+        // given
+        ResourcesPatternBuilder patternBuilder = new ResourcesPatternBuilder("", Arrays.asList("my-docs", "md"));
+        // when
+        final String pattern = patternBuilder.build();
+        // then
+        assertThat(pattern)
+                .isEqualTo("^(?!(" + DOC_INFO_FILES + "))[^_.].*\\.(?!(a((sc(iidoc)?)|d(oc)?)|my-docs|md)).*$");
+    }
+
+}


### PR DESCRIPTION
Thank you for opening a pull request and contributing to asciidoctor-maven-plugin!

**What kind of change does this PR introduce?** (check at least one)
<!-- Update "[ ]" to "[x]" to check a box -->

- [ ] Bugfix
- [x] Feature
- [ ] Documentation
- [ ] Refactor
- [ ] Build improvement
- [ ] Other (please describe)


**What is the goal of this pull request?**
Replicates the logic from `process-asciidoc` mojo that prevents docInfo files from being copied into the output directory.

**Are there any alternative ways to implement this?**
Following previous pattern, files that are not required in output ar filtered by `ResourceCopyFileAlterationListenerAdaptor` using a filename regular expression.
To make the pattern easier to mantain the logic has been extracted into a class `ResourcesPatternBuilder` with proper unit tests for it.

**Are there any implications of this pull request? Anything a user must know?**
Also includes:
- Moved all constants related with extentions, and file patterns to `AsciidoctorFileScanner`
- Minnor refactoring of AsciidoctorFileScanner. Mostly formatting.

**Is it related to an existing issue?**
<!-- If Yes, please add a line of the form: `Fixes #Issue` --> 
- [ ] Yes
- [x] No
Indirectly related with https://github.com/asciidoctor/asciidoctor-maven-plugin/issues/472.
I don't identify any missing feature now.

*Finally, please add a corresponding entry to CHANGELOG.adoc*
