### PR TITLE
bumps maven-javadoc-plugin to latest 3.2.0

### DIFF
--- a/CHANGELOG.adoc
+++ b/CHANGELOG.adoc
@@ -43,3 +43,4 @@ Build / Infrastructure::
   * Simplify TravisCI and AppVeyor to run Java 8 and 11 only (#460)
   * Upgrade Maven from v3.5.0 to 3.6.3 in AppVeyor (#460)
   * Updated jacoco-maven-plugin version from v0.8.2 to 0.8.5 (#479)
+  * Use maven-javadoc-plugin version defined in `pluginManagement` + update to v3.2.0 (#481)

--- a/pom.xml
+++ b/pom.xml
@@ -370,7 +370,7 @@
                 <plugin>
                     <groupId>org.apache.maven.plugins</groupId>
                     <artifactId>maven-javadoc-plugin</artifactId>
-                    <version>3.0.0</version>
+                    <version>3.2.0</version>
                 </plugin>
                 <plugin>
                     <groupId>org.apache.maven.plugins</groupId>
@@ -421,7 +421,6 @@
                     <plugin>
                         <groupId>org.apache.maven.plugins</groupId>
                         <artifactId>maven-javadoc-plugin</artifactId>
-                        <version>3.2.0</version>
                         <configuration>
                             <detectJavaApiLink>false</detectJavaApiLink>
                         </configuration>

--- a/src/main/java/org/asciidoctor/maven/AsciidoctorMojo.java
+++ b/src/main/java/org/asciidoctor/maven/AsciidoctorMojo.java
@@ -368,6 +368,7 @@ public class AsciidoctorMojo extends AbstractMojo {
      * @param sourceDirectory Source directory configured (`sourceFile` may include relative path).
      * @param configuration   AsciidoctorMojo containing conversion configuration.
      * @return the final destination file path.
+     * @throws MojoExecutionException If output is not valid
      */
     public File setDestinationPaths(final File sourceFile, final OptionsBuilder optionsBuilder, final File sourceDirectory,
                                     final AsciidoctorMojo configuration) throws MojoExecutionException {


### PR DESCRIPTION
Thank you for opening a pull request and contributing to asciidoctor-maven-plugin!

**What kind of change does this PR introduce?** (check at least one)
<!-- Update "[ ]" to "[x]" to check a box -->

- [ ] Bugfix
- [x] Feature
- [ ] Documentation
- [ ] Refactor
- [ ] Build improvement
- [ ] Other (please describe)

**What is the goal of this pull request?**
Originally `maven-javadoc-plugin` version configuration, using the version defined in `<pluginManagement>`.
But also upgrades the version to latest v3.2.0.

**Are there any alternative ways to implement this?**
Given the plugin is used only once, could define it explicitely.
But for consistency I'd rather have all maven plugin version defined togetherd under pluginManagement.

**Are there any implications of this pull request? Anything a user must know?**
No.

**Is it related to an existing issue?**
<!-- If Yes, please add a line of the form: `Fixes #Issue` --> 
- [ ] Yes
- [ ] No

*Finally, please add a corresponding entry to CHANGELOG.adoc*
