### PR TITLE
automates application of licence header to source files with license-maven-plugin

### DIFF
--- a/CHANGELOG.adoc
+++ b/CHANGELOG.adoc
@@ -35,6 +35,7 @@ Documentation::
   * Fix broken link to V2 migration guide (https://github.com/ge0ffrey[@ge0ffrey]) (#446)
   * Add GitHub's PR and issue templates (#465)
   * Add `auto-refresh` mojo documentation (#466)
+  * Add copyright notice to README and remove unnecessary license header from sources (#482)
 
 Build / Infrastructure::
 

--- a/README.adoc
+++ b/README.adoc
@@ -787,3 +787,10 @@ If you are not sure what version of the Asciidoctor converter is being used.
 You can obtain it using the version attribute like in the example blow.
 
  Asciidoctor version: {asciidoctor-version}
+
+== Copyright and License
+
+Copyright (C) 2013-2020 Jason Porter, Dan Allen, Abel Salgado Romero and the individual contributors.
+Use of this software is granted under the terms of the Apache License, Version 2.0.
+
+See the {uri-license}[LICENSE] for the full license text.

--- a/src/main/java/org/asciidoctor/maven/AsciidoctorHttpMojo.java
+++ b/src/main/java/org/asciidoctor/maven/AsciidoctorHttpMojo.java
@@ -1,15 +1,3 @@
-/*
- * Licensed under the Apache License, Version 2.0 (the &quot;License&quot;);
- * you may not use this file except in compliance with the License.
- * You may obtain a copy of the License at
- * http://www.apache.org/licenses/LICENSE-2.0
- * Unless required by applicable law or agreed to in writing, software
- * distributed under the License is distributed on an &quot;AS IS&quot; BASIS,
- * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
- * See the License for the specific language governing permissions and
- * limitations under the License.
- */
-
 package org.asciidoctor.maven;
 
 import org.apache.commons.io.IOUtils;

--- a/src/main/java/org/asciidoctor/maven/AsciidoctorMaven.java
+++ b/src/main/java/org/asciidoctor/maven/AsciidoctorMaven.java
@@ -1,16 +1,5 @@
-/*
- * Licensed under the Apache License, Version 2.0 (the &quot;License&quot;);
- * you may not use this file except in compliance with the License.
- * You may obtain a copy of the License at
- * http://www.apache.org/licenses/LICENSE-2.0
- * Unless required by applicable law or agreed to in writing, software
- * distributed under the License is distributed on an &quot;AS IS&quot; BASIS,
- * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
- * See the License for the specific language governing permissions and
- * limitations under the License.
- */
 package org.asciidoctor.maven;
 
 public interface AsciidoctorMaven {
-    static final String PREFIX = "asciidoctor.";
+    String PREFIX = "asciidoctor.";
 }

--- a/src/main/java/org/asciidoctor/maven/AsciidoctorMojo.java
+++ b/src/main/java/org/asciidoctor/maven/AsciidoctorMojo.java
@@ -1,15 +1,3 @@
-/*
- * Licensed under the Apache License, Version 2.0 (the &quot;License&quot;);
- * you may not use this file except in compliance with the License.
- * You may obtain a copy of the License at
- * http://www.apache.org/licenses/LICENSE-2.0
- * Unless required by applicable law or agreed to in writing, software
- * distributed under the License is distributed on an &quot;AS IS&quot; BASIS,
- * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
- * See the License for the specific language governing permissions and
- * limitations under the License.
- */
-
 package org.asciidoctor.maven;
 
 import org.apache.maven.execution.MavenSession;
@@ -53,7 +41,7 @@ import static org.asciidoctor.maven.process.SourceDirectoryFinder.DEFAULT_SOURCE
 
 
 /**
- * Basic maven plugin goal to convert AsciiDoc files using Asciidoctor, a ruby port.
+ * Basic maven plugin goal to convert AsciiDoc files using AsciidoctorJ.
  */
 @Mojo(name = "process-asciidoc", threadSafe = true)
 public class AsciidoctorMojo extends AbstractMojo {

--- a/src/main/java/org/asciidoctor/maven/AsciidoctorRefreshMojo.java
+++ b/src/main/java/org/asciidoctor/maven/AsciidoctorRefreshMojo.java
@@ -1,15 +1,3 @@
-/*
- * Licensed under the Apache License, Version 2.0 (the &quot;License&quot;);
- * you may not use this file except in compliance with the License.
- * You may obtain a copy of the License at
- * http://www.apache.org/licenses/LICENSE-2.0
- * Unless required by applicable law or agreed to in writing, software
- * distributed under the License is distributed on an &quot;AS IS&quot; BASIS,
- * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
- * See the License for the specific language governing permissions and
- * limitations under the License.
- */
-
 package org.asciidoctor.maven;
 
 import org.apache.commons.io.filefilter.FileFilterUtils;
@@ -54,7 +42,7 @@ public class AsciidoctorRefreshMojo extends AsciidoctorMojo {
         stopMonitors();
     }
 
-    protected void doWork() throws MojoFailureException, MojoExecutionException {
+    protected void doWork() {
         long timeInMillis = TimeCounter.timed(() -> {
             try {
                 processAllSources(defaultResourcesProcessor);
@@ -65,7 +53,7 @@ public class AsciidoctorRefreshMojo extends AsciidoctorMojo {
         getLog().info("Converted document(s) in " + timeInMillis + "ms");
     }
 
-    protected void doWait() throws MojoExecutionException, MojoFailureException {
+    protected void doWait() {
         showWaitMessage();
 
         String line;

--- a/src/main/java/org/asciidoctor/maven/AsciidoctorZipMojo.java
+++ b/src/main/java/org/asciidoctor/maven/AsciidoctorZipMojo.java
@@ -1,15 +1,3 @@
-/*
- * Licensed under the Apache License, Version 2.0 (the &quot;License&quot;);
- * you may not use this file except in compliance with the License.
- * You may obtain a copy of the License at
- * http://www.apache.org/licenses/LICENSE-2.0
- * Unless required by applicable law or agreed to in writing, software
- * distributed under the License is distributed on an &quot;AS IS&quot; BASIS,
- * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
- * See the License for the specific language governing permissions and
- * limitations under the License.
- */
-
 package org.asciidoctor.maven;
 
 import org.apache.maven.plugin.MojoExecutionException;

--- a/src/main/java/org/asciidoctor/maven/http/AsciidoctorHandler.java
+++ b/src/main/java/org/asciidoctor/maven/http/AsciidoctorHandler.java
@@ -1,14 +1,3 @@
-/*
- * Licensed under the Apache License, Version 2.0 (the &quot;License&quot;);
- * you may not use this file except in compliance with the License.
- * You may obtain a copy of the License at
- * http://www.apache.org/licenses/LICENSE-2.0
- * Unless required by applicable law or agreed to in writing, software
- * distributed under the License is distributed on an &quot;AS IS&quot; BASIS,
- * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
- * See the License for the specific language governing permissions and
- * limitations under the License.
- */
 package org.asciidoctor.maven.http;
 
 import java.io.ByteArrayOutputStream;

--- a/src/main/java/org/asciidoctor/maven/http/AsciidoctorHttpServer.java
+++ b/src/main/java/org/asciidoctor/maven/http/AsciidoctorHttpServer.java
@@ -1,14 +1,3 @@
-/*
- * Licensed under the Apache License, Version 2.0 (the &quot;License&quot;);
- * you may not use this file except in compliance with the License.
- * You may obtain a copy of the License at
- * http://www.apache.org/licenses/LICENSE-2.0
- * Unless required by applicable law or agreed to in writing, software
- * distributed under the License is distributed on an &quot;AS IS&quot; BASIS,
- * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
- * See the License for the specific language governing permissions and
- * limitations under the License.
- */
 package org.asciidoctor.maven.http;
 
 import java.io.File;

--- a/src/main/java/org/asciidoctor/maven/io/Zips.java
+++ b/src/main/java/org/asciidoctor/maven/io/Zips.java
@@ -1,16 +1,6 @@
-/*
- * Licensed under the Apache License, Version 2.0 (the &quot;License&quot;);
- * you may not use this file except in compliance with the License.
- * You may obtain a copy of the License at
- * http://www.apache.org/licenses/LICENSE-2.0
- * Unless required by applicable law or agreed to in writing, software
- * distributed under the License is distributed on an &quot;AS IS&quot; BASIS,
- * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
- * See the License for the specific language governing permissions and
- * limitations under the License.
- */
-
 package org.asciidoctor.maven.io;
+
+import org.apache.commons.io.IOUtils;
 
 import java.io.File;
 import java.io.FileInputStream;
@@ -19,9 +9,8 @@ import java.io.IOException;
 import java.util.zip.ZipEntry;
 import java.util.zip.ZipOutputStream;
 
-import org.apache.commons.io.IOUtils;
-
 public final class Zips {
+
     public static void zip(final File dir, final File zipName) throws IOException, IllegalArgumentException {
         final String[] entries = dir.list();
         final ZipOutputStream out = new ZipOutputStream(new FileOutputStream(zipName));

--- a/src/main/java/org/asciidoctor/maven/process/AsciidoctorHelper.java
+++ b/src/main/java/org/asciidoctor/maven/process/AsciidoctorHelper.java
@@ -1,15 +1,3 @@
-/*
- * Licensed under the Apache License, Version 2.0 (the &quot;License&quot;);
- * you may not use this file except in compliance with the License.
- * You may obtain a copy of the License at
- * http://www.apache.org/licenses/LICENSE-2.0
- * Unless required by applicable law or agreed to in writing, software
- * distributed under the License is distributed on an &quot;AS IS&quot; BASIS,
- * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
- * See the License for the specific language governing permissions and
- * limitations under the License.
- */
-
 package org.asciidoctor.maven.process;
 
 import org.apache.maven.project.MavenProject;

--- a/src/main/java/org/asciidoctor/maven/site/AsciidoctorDoxiaParser.java
+++ b/src/main/java/org/asciidoctor/maven/site/AsciidoctorDoxiaParser.java
@@ -1,18 +1,3 @@
-/*
- * Copyright 2015 The Ascidoctor Project
- *
- * Licensed under the Apache License, Version 2.0 (the "License");
- * you may not use this file except in compliance with the License.
- * You may obtain a copy of the License at
- *
- *   http://www.apache.org/licenses/LICENSE-2.0
- *
- * Unless required by applicable law or agreed to in writing, software
- * distributed under the License is distributed on an "AS IS" BASIS,
- * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
- * See the License for the specific language governing permissions and
- * limitations under the License.
- */
 package org.asciidoctor.maven.site;
 
 import org.apache.maven.doxia.module.xhtml.XhtmlParser;

--- a/src/main/java/org/asciidoctor/maven/site/AsciidoctorDoxiaParserModule.java
+++ b/src/main/java/org/asciidoctor/maven/site/AsciidoctorDoxiaParserModule.java
@@ -1,18 +1,3 @@
-/*
- * Copyright 2015 The Ascidoctor Project
- *
- * Licensed under the Apache License, Version 2.0 (the "License");
- * you may not use this file except in compliance with the License.
- * You may obtain a copy of the License at
- *
- *   http://www.apache.org/licenses/LICENSE-2.0
- *
- * Unless required by applicable law or agreed to in writing, software
- * distributed under the License is distributed on an "AS IS" BASIS,
- * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
- * See the License for the specific language governing permissions and
- * limitations under the License.
- */
 package org.asciidoctor.maven.site;
 
 import org.apache.maven.doxia.parser.module.AbstractParserModule;


### PR DESCRIPTION
Thank you for opening a pull request and contributing to asciidoctor-maven-plugin!

**What kind of change does this PR introduce?** (check at least one)
<!-- Update "[ ]" to "[x]" to check a box -->

- [ ] Bugfix
- [] Feature
- [x] Documentation
- [ ] Refactor
- [ ] Build improvement
- [ ] Other (please describe)


**What is the goal of this pull request?**
~Add & automate copyright to all source files.~
Original intention changed as per discusion below, now:
* Add copyright notice to readme.
* Remove unnecessary licence headers. All those that comply with license set at project level.

**Are there any alternative ways to implement this?**
~First, there's al anternative plugin (https://www.mojohaus.org/license-maven-plugin) but I found it seems less mantained.
Secondly, the year could be automated using `<maven.build.timestamp.format>yyyy</maven.build.timestamp.format>`, but I am afraid of possible side effects during release.~
No

**Are there any implications of this pull request? Anything a user must know?**
No

**Is it related to an existing issue?**
<!-- If Yes, please add a line of the form: `Fixes #Issue` --> 
- [ ] Yes
- [x] No

*Finally, please add a corresponding entry to CHANGELOG.adoc*
