### PR TITLE
Fix uri-license in README

### DIFF
--- a/README.adoc
+++ b/README.adoc
@@ -16,6 +16,7 @@ ifndef::env-github[:icons: font]
 :uri-asciidoctor: http://asciidoctor.org
 :uri-examples: https://github.com/asciidoctor/asciidoctor-maven-examples
 :uri-maven: http://maven.apache.org
+:uri-license: {uri-repo}/blob/master/LICENSE.txt
 // GitHub customization
 ifdef::env-github[]
 :badges:


### PR DESCRIPTION
Thank you for opening a pull request and contributing to asciidoctor-maven-plugin!

**What kind of change does this PR introduce?** (check at least one)
<!-- Update "[ ]" to "[x]" to check a box -->

- [x] Bugfix
- [ ] Feature
- [X] Documentation
- [ ] Refactor
- [ ] Build improvement
- [ ] Other (please describe)


**What is the goal of this pull request?**
Set the `uri-licence` attribute in README so the link in preview works.

**Are there any implications of this pull request? Anything a user must know?**
No

**Is it related to an existing issue?**
<!-- If Yes, please add a line of the form: `Fixes #Issue` --> 
- [ ] Yes
- [x] No

*Finally, please add a corresponding entry to CHANGELOG.adoc*
