### PR TITLE
Remove ambiguity in usage of maven properties docs

### DIFF
--- a/CHANGELOG.adoc
+++ b/CHANGELOG.adoc
@@ -16,6 +16,7 @@ For a detailed view of what has changed, refer to the {uri-repo}/commits/master[
 Documentation::
 
   * Migrate docs (README) to Antora site and publish them in gh-pages (#498)
+  * Remove ambiguity in usage of maven properties docs (#507)
 
 == v2.1.0 (2020-09-15)
 

--- a/docs/modules/plugin/partials/process-asciidoc-mojo-parameters.adoc
+++ b/docs/modules/plugin/partials/process-asciidoc-mojo-parameters.adoc
@@ -91,7 +91,8 @@ Refer to the http://asciidoctor.org/docs/user-manual/#attribute-catalog[catalog 
     <source-highlighter>coderay</source-highlighter>
 </attributes>
 ----
-In addition to those attributes found in this section, any Maven property is also passed as attribute (replacing . by -).
+In addition to attributes set in this section, Maven properties are also passed as attribute (replacing . by - in the name).
+These include those defined in the `<properties>` section of the project, parent projects and the user's `settings.xml`.
 +
 [source,xml]
 ----

--- a/docs/modules/site-integration/pages/index.adoc
+++ b/docs/modules/site-integration/pages/index.adoc
@@ -135,7 +135,8 @@ Specifies additional Ruby libraries not packaged in AsciidoctorJ, `empty` by def
 attributes::
 Similar to the plugin's `attributes`. +
 Allows defining a set of Asciidoctor attributes to be passed to the conversion. +
-In addition to those attributes found in this section, any Maven property is also passed as attribute (replacing . by -).
+In addition to attributes set in this section, Maven properties are also passed as attribute (replacing . by - in the name).
+These include those defined in the `<properties>` section of the project, parent projects and the user's `settings.xml`.
 +
 [source,xml]
 ----


### PR DESCRIPTION
Thank you for opening a pull request and contributing to asciidoctor-maven-plugin!

**What kind of change does this PR introduce?** (check at least one)
<!-- Update "[ ]" to "[x]" to check a box -->

- [ ] Bugfix
- [ ] Feature
- [x] Documentation
- [ ] Refactor
- [ ] Build improvement
- [ ] Other (please describe)


**What is the goal of this pull request?**
Improve docs about usage of Maven properties.
Now it should be more clear that now only properties set in the pom are passed as attributes.

**Are there any alternative ways to implement this?**
Explanation could be extended to explicitely state that Maven Model are NOT set. But for now I'd like to keep it simple.
Also, the text is duplu

**Are there any implications of this pull request? Anything a user must know?**
Need to refresh general docs site.

**Is it related to an existing issue?**
<!-- If Yes, please add a line of the form: `Fixes #Issue` --> 
- [x] Yes https://github.com/asciidoctor/asciidoctor-maven-plugin/issues/506
- [ ] No

*Finally, please add a corresponding entry to CHANGELOG.adoc*
