### PR TITLE
Add ID to 'attributes' to be able to generate direct url from other docs

### DIFF
--- a/CHANGELOG.adoc
+++ b/CHANGELOG.adoc
@@ -17,6 +17,7 @@ Documentation::
 
   * Migrate docs (README) to Antora site and publish them in gh-pages (#498)
   * Remove ambiguity in usage of maven properties docs (#507)
+  * Add ID to 'attributes' description, to be able to generate direct url from other docs (#509)
 
 == v2.1.0 (2020-09-15)
 

--- a/docs/modules/plugin/partials/process-asciidoc-mojo-parameters.adoc
+++ b/docs/modules/plugin/partials/process-asciidoc-mojo-parameters.adoc
@@ -78,7 +78,7 @@ templateCache:: enables the built-in cache used by the template converter when r
 Only relevant if the `:template_dirs` option is specified, defaults to `true`.
 sourcemap:: adds file and line number information to each parsed block (`lineno` and `source_location` attributes), defaults to `false`
 catalogAssets:: tells the parser to capture images and links in the reference table available via the `references` property on the document AST object (experimental), defaults to `false`
-attributes:: a `Map<String,Object>` of Asciidoctor attributes to pass for conversion, defaults to `null`.
+[[configuration-attributes]]attributes:: a `Map<String,Object>` of Asciidoctor attributes to pass for conversion, defaults to `null`.
 Refer to the http://asciidoctor.org/docs/user-manual/#attribute-catalog[catalog of document attributes] in the Asciidoctor user manual for a complete list.
 +
 [source,xml]


### PR DESCRIPTION
Thank you for opening a pull request and contributing to asciidoctor-maven-plugin!

**What kind of change does this PR introduce?** (check at least one)
<!-- Update "[ ]" to "[x]" to check a box -->

- [ ] Bugfix
- [ ] Feature
- [x] Documentation
- [ ] Refactor
- [ ] Build improvement
- [ ] Other (please describe)


**What is the goal of this pull request?**
Add an ID to the attributes description on the mojos so it can be directly referenced by URL.
More specifically, this is so we can do a redirect to sections that no longer exists and which content is found in the attributes description in https://asciidoctor.org/docs/. Similar to https://github.com/asciidoctor/asciidoctor.org/pull/995.

**Are there any alternative ways to implement this?**
Not that I know of.

**Are there any implications of this pull request? Anything a user must know?**
Docs in docs.asciidoctor.org/ need to be rebuild.

**Is it related to an existing issue?**
<!-- If Yes, please add a line of the form: `Fixes #Issue` --> 
- [ ] Yes
- [x] No

*Finally, please add a corresponding entry to CHANGELOG.adoc*
