### PR TITLE
Set maven wrapper to use maven v3.8.1

### DIFF
--- a/.mvn/wrapper/maven-wrapper.properties
+++ b/.mvn/wrapper/maven-wrapper.properties
@@ -1,2 +1,2 @@
-distributionUrl=https://repo.maven.apache.org/maven2/org/apache/maven/apache-maven/3.6.3/apache-maven-3.6.3-bin.zip
+distributionUrl=https://repo.maven.apache.org/maven2/org/apache/maven/apache-maven/3.8.1/apache-maven-3.8.1-bin.zip
 wrapperUrl=https://repo.maven.apache.org/maven2/io/takari/maven-wrapper/0.5.6/maven-wrapper-0.5.6.jar

--- a/CHANGELOG.adoc
+++ b/CHANGELOG.adoc
@@ -31,6 +31,7 @@ Maintenance::
   * Rewrite `AsciidoctorDoxiaParserTest` to Java + remove Groovy & Spock configurations (#519)
   * Upgrade tests to JUni5 (#521)
   * Rename main branch (#524)
+  * Set maven wrapper to use maven v3.8.1 (#525)
 
 == v2.1.0 (2020-09-15)
 

--- a/pom.xml
+++ b/pom.xml
@@ -63,11 +63,11 @@
         <asciidoctorj.version>2.4.1</asciidoctorj.version>
         <jruby.version>9.2.13.0</jruby.version>
         <maven.coveralls.plugin.version>4.3.0</maven.coveralls.plugin.version>
-        <maven.jacoco.plugin.version>0.8.5</maven.jacoco.plugin.version>
+        <maven.jacoco.plugin.version>0.8.6</maven.jacoco.plugin.version>
         <maven.plugin.plugin.version>3.5</maven.plugin.plugin.version>
         <maven.project.version>3.0.5</maven.project.version>
-        <maven.compiler.plugin.version>3.7.0</maven.compiler.plugin.version>
-        <maven.filtering.version>3.1.1</maven.filtering.version>
+        <maven.compiler.plugin.version>3.8.1</maven.compiler.plugin.version>
+        <maven.filtering.version>3.2.0</maven.filtering.version>
         <plexus.utils.version>3.0.23</plexus.utils.version>
         <plexus.component.metadata.version>1.7</plexus.component.metadata.version>
         <netty.version>4.1.59.Final</netty.version>


### PR DESCRIPTION

Thank you for opening a pull request and contributing to asciidoctor-maven-plugin!

**What kind of change does this PR introduce?** (check at least one)
<!-- Update "[ ]" to "[x]" to check a box -->

- [ ] Bugfix
- [ ] Feature
- [ ] Documentation
- [ ] Refactor
- [ ] Build improvement
- [x] Other (please describe) :point_right: Maintenance


**What is the goal of this pull request?**
* Upgrade maven wrapper to use latest Maven v3.8.1 wich contains security fixes https://maven.apache.org/docs/3.8.1/release-notes.html.
It also:
* Bumps maven-compiler-plugin to v3.8.1
* Bumps jacoco-maven-plugin to 0.8.6
* Bumps maven-filtering to 3.2.0

**Are there any alternative ways to implement this?**
No

**Are there any implications of this pull request? Anything a user must know?**
No

**Is it related to an existing issue?**
<!-- If Yes, please add a line of the form: `Fixes #Issue` --> 
- [ ] Yes
- [x] No

*Finally, please add a corresponding entry to CHANGELOG.adoc*
