### PR TITLE
Remove apache commons direct dependencies

### DIFF
--- a/pom.xml
+++ b/pom.xml
@@ -71,7 +71,6 @@
         <plexus.utils.version>3.0.23</plexus.utils.version>
         <plexus.component.metadata.version>1.7</plexus.component.metadata.version>
         <netty.version>4.1.59.Final</netty.version>
-        <commons.io.version>2.5</commons.io.version>
         <doxia.version>1.8</doxia.version>
     </properties>
 
@@ -130,11 +129,6 @@
             <version>${asciidoctorj.version}</version>
         </dependency>
         <dependency>
-            <groupId>org.apache.commons</groupId>
-            <artifactId>commons-lang3</artifactId>
-            <version>3.8.1</version>
-        </dependency>
-        <dependency>
             <groupId>io.netty</groupId>
             <artifactId>netty-codec-http</artifactId>
             <version>${netty.version}</version>
@@ -143,11 +137,6 @@
             <groupId>org.apache.maven.doxia</groupId>
             <artifactId>doxia-core</artifactId>
             <version>${doxia.version}</version>
-        </dependency>
-        <dependency>
-            <groupId>commons-io</groupId>
-            <artifactId>commons-io</artifactId>
-            <version>${commons.io.version}</version>
         </dependency>
         <dependency>
             <groupId>org.apache.maven.doxia</groupId>

--- a/src/main/java/org/asciidoctor/maven/site/SiteConversionConfigurationParser.java
+++ b/src/main/java/org/asciidoctor/maven/site/SiteConversionConfigurationParser.java
@@ -1,6 +1,5 @@
 package org.asciidoctor.maven.site;
 
-import org.apache.commons.lang3.StringUtils;
 import org.apache.maven.project.MavenProject;
 import org.asciidoctor.AttributesBuilder;
 import org.asciidoctor.OptionsBuilder;
@@ -8,11 +7,12 @@ import org.asciidoctor.maven.process.AsciidoctorHelper;
 import org.codehaus.plexus.util.xml.Xpp3Dom;
 
 import java.io.File;
-import java.util.*;
+import java.util.ArrayList;
+import java.util.Arrays;
+import java.util.Collections;
+import java.util.List;
 import java.util.stream.Collectors;
 import java.util.stream.Stream;
-
-import static org.apache.commons.lang3.StringUtils.isNotBlank;
 
 public class SiteConversionConfigurationParser {
 
@@ -51,7 +51,7 @@ public class SiteConversionConfigurationParser {
                             // <requires>time, base64</requires>
                             Stream.of(requireNode.getValue().split(","))
                                     .map(String::trim)
-                                    .filter(StringUtils::isNotBlank)
+                                    .filter(this::isNotBlank)
                                     .forEach(value -> gemsToRequire.add(value));
                         } else {
                             // <requires>
@@ -81,6 +81,12 @@ public class SiteConversionConfigurationParser {
         }
 
         return new SiteConversionConfiguration(presetOptions.attributes(presetAttributes).get(), gemsToRequire);
+    }
+
+    public boolean isNotBlank(String value) {
+        return value != null
+                && !value.isEmpty()
+                && value.chars().anyMatch(c -> !Character.isWhitespace(c));
     }
 
     private File resolveProjectDir(MavenProject project, String path) {


### PR DESCRIPTION
Removed because security alerts with commons-io:2.5 and
that the actual versions are out of our control because
they are provided by Maven runtime.

Thank you for opening a pull request and contributing to asciidoctor-maven-plugin!

**What kind of change does this PR introduce?** (check at least one)
<!-- Update "[ ]" to "[x]" to check a box -->

- [ ] Bugfix
- [ ] Feature
- [ ] Documentation
- [x] Refactor
- [ ] Build improvement
- [ ] Other (please describe)


**What is the goal of this pull request?**
Reduce maintenance efforts on dependencies that are actually out of our control.
Both `commons-io` and `commons-lang3` are provided by Maven runtime, so even if we override for a newer versions we will still use the one in Maven.
So, it's better to just use the version provided.

**Are there any alternative ways to implement this?**
No that I am aware.

**Are there any implications of this pull request? Anything a user must know?**
The initial motivation was removing the security warning that github shows, but I don't think it will fix it.

**Is it related to an existing issue?**
<!-- If Yes, please add a line of the form: `Fixes #Issue` --> 
- [ ] Yes
- [x] No

And I don't thinks it's relevant for the CHANGELOG.

*Finally, please add a corresponding entry to CHANGELOG.adoc*
