### PR TITLE
Add 'Asciidoctor' organization to pom.xml

### DIFF
--- a/pom.xml
+++ b/pom.xml
@@ -10,6 +10,11 @@
     <description>Asciidoctor Maven Plugin and Doxia Parser (for Maven Site integration)</description>
     <url>https://github.com/asciidoctor/asciidoctor-maven-plugin</url>
 
+    <organization>
+        <name>Asciidoctor</name>
+        <url>https://asciidoctor.org/</url>
+    </organization>
+    
     <developers>
         <developer>
             <id>lightguard</id>


### PR DESCRIPTION
Thank you for opening a pull request and contributing to asciidoctor-maven-plugin!

**What kind of change does this PR introduce?** (check at least one)
<!-- Update "[ ]" to "[x]" to check a box -->

- [ ] Bugfix
- [ ] Feature
- [ ] Documentation
- [ ] Refactor
- [x] Build improvement
- [ ] Other (please describe)


**What is the goal of this pull request?**
Add reference to organization to pom. That way uses using it can get more insight of the community and a reference to the page.


**Are there any alternative ways to implement this?**
It could be argued we could set url to docs.asciidoctor.org, but I think the current one is nicer for a first impressio and the docs under "Docs" option already point to docs.asciidoctor.org.

**Are there any implications of this pull request? Anything a user must know?**
Not in terms of actual features.

**Is it related to an existing issue?**
<!-- If Yes, please add a line of the form: `Fixes #Issue` --> 
- [x] Yes
- [ ] No

Fixes #537 
