### PR TITLE
Allow setting included sources to run full refresh on change

### DIFF
--- a/.github/workflows/build.yaml
+++ b/.github/workflows/build.yaml
@@ -36,4 +36,4 @@ jobs:
           key: ${{ runner.os }}-mvn-cache-${{ hashFiles('**/pom.xml') }}
           restore-keys: ${{ runner.os }}-mvn-cache-
       - name: Build
-        run: ./mvnw -B -V -Prun-its clean verify -Dtest="AsciidoctorRefreshMojoTest#should_convert_additional_sources_when_set_in_refreshOn"
+        run: ./mvnw -B -V -Prun-its clean verify

--- a/.github/workflows/build.yaml
+++ b/.github/workflows/build.yaml
@@ -36,4 +36,4 @@ jobs:
           key: ${{ runner.os }}-mvn-cache-${{ hashFiles('**/pom.xml') }}
           restore-keys: ${{ runner.os }}-mvn-cache-
       - name: Build
-        run: ./mvnw -B -V -Prun-its clean verify
+        run: ./mvnw -B -V -Prun-its clean verify -Dtest="AsciidoctorRefreshMojoTest#should_convert_additional_sources_when_set_in_refreshOn"

--- a/CHANGELOG.adoc
+++ b/CHANGELOG.adoc
@@ -13,6 +13,10 @@ For a detailed view of what has changed, refer to the {uri-repo}/commits/main[co
 
 == Unreleased
 
+Improvements::
+
+  * Allow running a refresh build on included sources (for `auto-refresh` & `http` mojos) (#542)
+
 Documentation::
 
   * Migrate docs (README) to Antora site and publish them in gh-pages (#498)

--- a/docs/modules/plugin/partials/auto-refresh-mojo-parameters.adoc
+++ b/docs/modules/plugin/partials/auto-refresh-mojo-parameters.adoc
@@ -1,2 +1,6 @@
 interval:: time in milliseconds between checks of the filesystem.
 Defaults to `2000`
+
+refreshOn:: regular expression describing additional sources that force a full refresh.
+Useful when working with included/partial sources that aren't converted individually.
+Defaults to `empty`

--- a/src/main/java/org/asciidoctor/maven/process/SourceDocumentFinder.java
+++ b/src/main/java/org/asciidoctor/maven/process/SourceDocumentFinder.java
@@ -24,10 +24,10 @@ public class SourceDocumentFinder {
     private static final String STANDARD_FILE_EXTENSIONS_PATTERN = "^[^_.].*\\.a((sc(iidoc)?)|d(oc)?)$";
 
     /** Prefix for matching custom file extensions. */
-    private static final String CUSTOM_FILE_EXTENSIONS_PATTERN_PREFIX = "^[^_.].*\\.(";
+    public static final String CUSTOM_FILE_EXTENSIONS_PATTERN_PREFIX = "^[^_.].*\\.(";
 
     /** Suffix for matching custom file extensions. */
-    private static final String CUSTOM_FILE_EXTENSIONS_PATTERN_SUFFIX = ")$";
+    public static final String CUSTOM_FILE_EXTENSIONS_PATTERN_SUFFIX = ")$";
 
     /**
      * Finds all source documents inside the source directory with standard file extensions.

--- a/src/main/java/org/asciidoctor/maven/refresh/AdditionalSourceFileAlterationListenerAdaptor.java
+++ b/src/main/java/org/asciidoctor/maven/refresh/AdditionalSourceFileAlterationListenerAdaptor.java
@@ -1,0 +1,35 @@
+package org.asciidoctor.maven.refresh;
+
+import org.apache.maven.plugin.MojoExecutionException;
+import org.apache.maven.plugin.logging.Log;
+import org.asciidoctor.maven.AsciidoctorRefreshMojo;
+import org.asciidoctor.maven.process.ResourcesProcessor;
+
+import java.io.File;
+import java.util.Collections;
+
+public class AdditionalSourceFileAlterationListenerAdaptor extends AbstractFileAlterationListenerAdaptor {
+
+    private static final ResourcesProcessor EMPTY_RESOURCES_PROCESSOR = (sourcesDir, outputDir, encoding, configuration) -> {
+    };
+
+
+    public AdditionalSourceFileAlterationListenerAdaptor(AsciidoctorRefreshMojo mojo, Runnable postAction, Log log) {
+        super(mojo, postAction, log);
+    }
+
+    @Override
+    synchronized void processFile(File file, String actionName) {
+        getLog().info(String.format("Additional source file %s %s", file.getAbsolutePath(), actionName));
+        getLog().info("Full refresh");
+        long timeInMillis = TimeCounter.timed(() -> {
+            try {
+                getMojo().processAllSources(EMPTY_RESOURCES_PROCESSOR);
+            } catch (MojoExecutionException e) {
+                getLog().error(e);
+            }
+        });
+        getLog().info("Converted document(s) in " + timeInMillis + "ms");
+    }
+
+}


### PR DESCRIPTION
Thank you for opening a pull request and contributing to asciidoctor-maven-plugin!

**What kind of change does this PR introduce?** (check at least one)
<!-- Update "[ ]" to "[x]" to check a box -->

- [ ] Bugfix
- [x] Feature
- [ ] Documentation
- [ ] Refactor
- [ ] Build improvement
- [ ] Other (please describe)


**What is the goal of this pull request?**
Fix conversion not happending when included sources where modified in `autp-refresh` and `http` mojo.
As discussed in #403 at the end we added a new option available for those mojos to allow users to specify other files to "listen to changes on". On a change or creation, a full rebuild will be done.

**Are there any alternative ways to implement this?**
Current  approach allows users to specify a set of extra sources to monitor.
On change a full rebuild (without copying resources) will happen. A full rebuild is necessary since we don't know which sources are affected.

**Are there any implications of this pull request? Anything a user must know?**
1. Creating an extension (include processor or preprocessor) that creates a tree of dependencies to know exactly which files to modify.
Discarded because custom filters may interfere with other extensions used by users.
2. Manually parsing all sources as texts files and build such index manually.
Discarded because configurations that maniputale paths (with basePath for example) and have files with same names may be impossible to properly resolve or we may have to also resort to "full builds".


**Is it related to an existing issue?**
<!-- If Yes, please add a line of the form: `Fixes #Issue` --> 
- [x] Yes
- [ ] No

*Finally, please add a corresponding entry to CHANGELOG.adoc*
