### PR TITLE
Fix excluding sources when enclosing parent path starts with _

### DIFF
--- a/CHANGELOG.adoc
+++ b/CHANGELOG.adoc
@@ -13,6 +13,9 @@ For a detailed view of what has changed, refer to the {uri-repo}/commits/main[co
 
 == Unreleased
 
+Bug Fixes::
+
+  * Fix excluding sources when enclosing parent path starts with _ (#544)
 
 == v2.2.0 (2021-07-18)
 

--- a/src/main/java/org/asciidoctor/maven/AsciidoctorMojo.java
+++ b/src/main/java/org/asciidoctor/maven/AsciidoctorMojo.java
@@ -190,7 +190,7 @@ public class AsciidoctorMojo extends AbstractMojo {
         }
 
         if (sourceFiles == null) {
-            sourceFiles = calculateSourceFiles(sourceDirectoryCandidate.get());
+            sourceFiles = findSourceFiles(sourceDirectoryCandidate.get());
         }
         if (sourceFiles.isEmpty()) {
             getLog().info("No sources found. Skipping processing");
@@ -435,7 +435,7 @@ public class AsciidoctorMojo extends AbstractMojo {
         return asciidoctor;
     }
 
-    protected List<File> calculateSourceFiles(File sourceDirectory) {
+    protected List<File> findSourceFiles(File sourceDirectory) {
         if (sourceDocumentName != null)
             return Arrays.asList(new File(sourceDirectory, sourceDocumentName));
 
@@ -443,8 +443,8 @@ public class AsciidoctorMojo extends AbstractMojo {
         SourceDocumentFinder finder = new SourceDocumentFinder();
 
         return sourceDocumentExtensions.isEmpty() ?
-            finder.find(sourceDirectoryPath) :
-            finder.find(sourceDirectoryPath, sourceDocumentExtensions);
+                finder.find(sourceDirectoryPath) :
+                finder.find(sourceDirectoryPath, sourceDocumentExtensions);
     }
 
     protected void convertFile(Asciidoctor asciidoctor, Map<String, Object> options, File f) {

--- a/src/main/java/org/asciidoctor/maven/process/SourceDocumentFinder.java
+++ b/src/main/java/org/asciidoctor/maven/process/SourceDocumentFinder.java
@@ -47,27 +47,27 @@ public class SourceDocumentFinder {
      * @return the list of all matching source documents.
      */
     public List<File> find(Path sourceDirectory, List<String> sourceDocumentExtensions) {
-        String extensionPattern = sourceDocumentExtensions.stream().collect(Collectors
-            .joining("|", CUSTOM_FILE_EXTENSIONS_PATTERN_PREFIX, CUSTOM_FILE_EXTENSIONS_PATTERN_SUFFIX));
+        String extensionPattern = sourceDocumentExtensions.stream()
+                .collect(Collectors.joining("|", CUSTOM_FILE_EXTENSIONS_PATTERN_PREFIX, CUSTOM_FILE_EXTENSIONS_PATTERN_SUFFIX));
         return find(sourceDirectory, Pattern.compile(extensionPattern));
     }
 
     private List<File> find(Path sourceDirectory, Pattern sourceDocumentPattern) {
         try (Stream<Path> sourceDocumentCandidates = Files.walk(sourceDirectory)) {
-            return sourceDocumentCandidates.filter(Files::isRegularFile)
-                // Filter all documents that don't match the file extension pattern.
-                .filter(p -> sourceDocumentPattern.matcher(p.getFileName().toString()).matches())
-                // Filter all documents that are part of ignored directories.
-                .filter(p -> {
-                    for (Path part : p) {
-                        if (part.toString().startsWith("_")) {
-                            return false;
+            return sourceDocumentCandidates
+                    .filter(Files::isRegularFile)
+                    .filter(path -> sourceDocumentPattern.matcher(path.getFileName().toString()).matches())
+                    .filter(path -> {
+                        for (Path part : sourceDirectory.relativize(path)) {
+                            if (part.toString().startsWith("_")) {
+                                return false;
+                            }
                         }
-                    }
-                    return true;
-                }).map(Path::toFile).collect(Collectors.toList());
+                        return true;
+                    })
+                    .map(Path::toFile)
+                    .collect(Collectors.toList());
         } catch (IOException e) {
-            // Can't access the source directory.
             return Collections.emptyList();
         }
     }

--- a/src/test/java/org/asciidoctor/maven/process/SourceDocumentFinderTest.java
+++ b/src/test/java/org/asciidoctor/maven/process/SourceDocumentFinderTest.java
@@ -1,12 +1,12 @@
 package org.asciidoctor.maven.process;
 
+import org.junit.jupiter.api.Test;
+
 import java.io.File;
 import java.nio.file.Paths;
-import java.util.ArrayList;
+import java.util.Arrays;
 import java.util.Collections;
 import java.util.List;
-
-import org.junit.jupiter.api.Test;
 
 import static org.assertj.core.api.Assertions.assertThat;
 
@@ -32,10 +32,9 @@ public class SourceDocumentFinderTest {
 
         // then
         assertThat(files)
-            .isNotEmpty()
-            .map(File::getName)
-            .allMatch(name -> name.endsWith("ad") || name.endsWith("adoc") || name.endsWith("asc") ||
-                name.endsWith("asciidoc"));
+                .hasSize(4)
+                .map(File::getName)
+                .allMatch(name -> name.endsWith("ad") || name.endsWith("adoc") || name.endsWith("asc") || name.endsWith("asciidoc"));
     }
 
     @Test
@@ -48,26 +47,24 @@ public class SourceDocumentFinderTest {
 
         // then
         assertThat(files)
-            .isNotEmpty()
-            .allMatch(file -> file.getName().endsWith("my-adoc"));
+                .hasSize(1)
+                .allMatch(file -> file.getName().endsWith("my-adoc"));
     }
 
     @Test
     public void should_match_custom_file_extensions() {
         // given
         final String rootDirectory = DEFAULT_SOURCE_DIRECTORY + "/file-extensions";
-        List<String> customFileExtensions = new ArrayList<>();
-        customFileExtensions.add("my-adoc");
-        customFileExtensions.add("adoc");
+        List<String> customFileExtensions = Arrays.asList("my-adoc", "adoc");
 
         // when
         List<File> files = new SourceDocumentFinder().find(Paths.get(rootDirectory), customFileExtensions);
 
         // then
         assertThat(files)
-            .isNotEmpty()
-            .map(File::getName)
-            .allMatch(name -> name.endsWith("my-adoc") || name.endsWith("adoc"));
+                .hasSize(2)
+                .map(File::getName)
+                .allMatch(name -> name.endsWith("my-adoc") || name.endsWith("adoc"));
     }
 
     @Test
@@ -80,7 +77,7 @@ public class SourceDocumentFinderTest {
 
         // then
         assertThat(files)
-            .isEmpty();
+                .isEmpty();
     }
 
     @Test
@@ -93,11 +90,11 @@ public class SourceDocumentFinderTest {
 
         // then
         assertThat(files)
-            .isEmpty();
+                .isEmpty();
     }
 
     @Test
-    public void should_exclude_internal_sources() {
+    public void should_exclude_hidden_sources() {
         // given
         final String rootDirectory = DEFAULT_SOURCE_DIRECTORY + "/relative-path-treatment";
         final List<String> fileExtensions = Collections.singletonList("adoc");
@@ -107,12 +104,28 @@ public class SourceDocumentFinderTest {
 
         // then
         assertThat(files)
-                .isNotEmpty()
+                .hasSize(6)
                 .allMatch(file -> !file.getName().startsWith("_"));
     }
 
     @Test
-    public void should_exclude_internal_directories() {
+    public void should_not_treat_enclosing_parent_paths_as_hidden() {
+        // given
+        final String rootDirectory = DEFAULT_SOURCE_DIRECTORY + "/source-finder/_enclosing/src/";
+        final List<String> fileExtensions = Collections.singletonList("adoc");
+
+        // when
+        List<File> files = new SourceDocumentFinder().find(Paths.get(rootDirectory), fileExtensions);
+
+        // then
+        assertThat(files)
+                .hasSize(1);
+        assertThat(files.get(0))
+                .hasName("simple.adoc");
+    }
+
+    @Test
+    public void should_exclude_hidden_directories() {
         // given
         final String rootDirectory = DEFAULT_SOURCE_DIRECTORY + "/relative-path-treatment";
         final List<String> fileExtensions = Collections.singletonList("adoc");
@@ -122,7 +135,7 @@ public class SourceDocumentFinderTest {
 
         // then
         assertThat(files)
-                .isNotEmpty()
+                .hasSize(6)
                 .allMatch(file -> !isContainedInInternalDirectory(file));
     }
 

--- a/src/test/resources/src/asciidoctor/source-finder/_enclosing/src/simple.adoc
+++ b/src/test/resources/src/asciidoctor/source-finder/_enclosing/src/simple.adoc
@@ -1,0 +1,3 @@
+= Document Title
+
+Preamble paragraph.


### PR DESCRIPTION
Thank you for opening a pull request and contributing to asciidoctor-maven-plugin!

**What kind of change does this PR introduce?** (check at least one)
<!-- Update "[ ]" to "[x]" to check a box -->

- [x] Bugfix
- [ ] Feature
- [ ] Documentation
- [ ] Refactor
- [ ] Build improvement
- [ ] Other (please describe)


**What is the goal of this pull request?**
Fix sources not being included when enclosing path started with `_`.
That is some directory in the upper path containing the project had the hidden preffix.

The fix is simply checking for paths ONLY in the project path.

**Are there any alternative ways to implement this?**
No.

**Are there any implications of this pull request? Anything a user must know?**
Did some formatting and minnor refactors.
Sicne it's first PR after a release, also opens new unreleased section in CHANGELOG.

**Is it related to an existing issue?**
<!-- If Yes, please add a line of the form: `Fixes #Issue` --> 
- [x] Yes 
- [ ] No
Fixes #545 

*Finally, please add a corresponding entry to CHANGELOG.adoc*
