### PR TITLE
Treat dot files and folders same as internal

### DIFF
--- a/CHANGELOG.adoc
+++ b/CHANGELOG.adoc
@@ -17,7 +17,8 @@ For a detailed view of what has changed, refer to the {uri-repo}/commits/main[co
 
 Bug Fixes::
 
-  * Fix excluding sources when enclosing parent path starts with _ (#544)
+  * Fix excluding sources when enclosing parent path starts with _ (#546)
+  * Treat dot files and folders same as internal #5505)
 
 == v2.2.0 (2021-07-18)
 

--- a/src/main/java/org/asciidoctor/maven/io/AsciidoctorFileScanner.java
+++ b/src/main/java/org/asciidoctor/maven/io/AsciidoctorFileScanner.java
@@ -24,6 +24,7 @@ public class AsciidoctorFileScanner {
     public static String[] INTERNAL_FOLDERS_AND_FILES_PATTERNS = {
             "**/_*.*",
             "**/_*",
+            "**/.*",
             "**/_*/**/*.*",
     };
 
@@ -40,7 +41,8 @@ public class AsciidoctorFileScanner {
             "docinfo-footer.xml",
             "*-docinfo.xml",
             "*-docinfo-header.xml",
-            "*-docinfo-footer.xml"};
+            "*-docinfo-footer.xml"
+    };
 
 
     private final BuildContext buildContext;

--- a/src/main/java/org/asciidoctor/maven/process/SourceDocumentFinder.java
+++ b/src/main/java/org/asciidoctor/maven/process/SourceDocumentFinder.java
@@ -59,7 +59,8 @@ public class SourceDocumentFinder {
                     .filter(path -> sourceDocumentPattern.matcher(path.getFileName().toString()).matches())
                     .filter(path -> {
                         for (Path part : sourceDirectory.relativize(path)) {
-                            if (part.toString().startsWith("_")) {
+                            char firstCharacter = part.toString().charAt(0);
+                            if (firstCharacter == '_' || firstCharacter == '.') {
                                 return false;
                             }
                         }

--- a/src/test/java/org/asciidoctor/maven/AsciidoctorMojoTest.java
+++ b/src/test/java/org/asciidoctor/maven/AsciidoctorMojoTest.java
@@ -667,9 +667,11 @@ public class AsciidoctorMojoTest {
      */
     private void assertEqualsStructure(File[] expected, File[] actual) {
 
-
         List<File> sanitizedExpected = Arrays.stream(expected)
-                .filter(file -> !file.getName().startsWith("_"))
+                .filter(file -> {
+                    char firstChar = file.getName().charAt(0);
+                    return firstChar != '_' && firstChar != '.';
+                })
                 .collect(Collectors.toList());
 
         List<String> expectedNames = sanitizedExpected.stream().map(File::getName).collect(Collectors.toList());
@@ -691,7 +693,7 @@ public class AsciidoctorMojoTest {
             if (htmls.length > 0) {
                 File[] asciidocs = expectedFile.listFiles(f -> {
                     String asciidocFilePattern = ".*\\." + AsciidoctorFileScanner.ASCIIDOC_FILE_EXTENSIONS_REG_EXP + "$";
-                    return f.getName().matches(asciidocFilePattern) && !f.getName().startsWith("_");
+                    return f.getName().matches(asciidocFilePattern) && !f.getName().startsWith("_") && !f.getName().startsWith(".");
                 });
                 Assertions.assertThat(htmls).hasSize(asciidocs.length);
             }

--- a/src/test/java/org/asciidoctor/maven/process/SourceDocumentFinderTest.java
+++ b/src/test/java/org/asciidoctor/maven/process/SourceDocumentFinderTest.java
@@ -105,7 +105,7 @@ public class SourceDocumentFinderTest {
         // then
         assertThat(files)
                 .hasSize(6)
-                .allMatch(file -> !file.getName().startsWith("_"));
+                .allMatch(file -> !file.getName().startsWith("_") || !file.getName().startsWith("."));
     }
 
     @Test
@@ -144,7 +144,7 @@ public class SourceDocumentFinderTest {
         int cursor = 0;
         do {
             cursor = path.indexOf(File.separator, cursor + 1);
-            if (path.charAt(cursor + 1) == '_')
+            if (path.charAt(cursor + 1) == '_' || path.charAt(cursor + 1) == '.')
                 return true;
         } while (cursor != -1);
         return false;

--- a/src/test/resources/src/asciidoctor/relative-path-treatment/.these_sources_are_not_processed/ignored.adoc
+++ b/src/test/resources/src/asciidoctor/relative-path-treatment/.these_sources_are_not_processed/ignored.adoc
@@ -1,0 +1,8 @@
+:toc: left
+:icons:
+
+== Summary
+This document won't get converted by default because it is inside a hidden folder. +
+Hidden folders begin with underscore `.`.
+
+TIP: How cool is this?

--- a/src/test/resources/src/asciidoctor/relative-path-treatment/level-1-1/.internal-dot-partial.adoc
+++ b/src/test/resources/src/asciidoctor/relative-path-treatment/level-1-1/.internal-dot-partial.adoc
@@ -1,0 +1,8 @@
+:toc: left
+:icons:
+
+== Summary
+This document won't get converted by default because it considered "internal". +
+That is, is prefixed with a dot `.`.
+
+TIP: How cool is this?


### PR DESCRIPTION
Thank you for opening a pull request and contributing to asciidoctor-maven-plugin!

**What kind of change does this PR introduce?** (check at least one)
<!-- Update "[ ]" to "[x]" to check a box -->

- [x] Bugfix
- [x] Feature
- [ ] Documentation
- [ ] Refactor
- [ ] Build improvement
- [ ] Other (please describe)


**What is the goal of this pull request?**
Seeing the recent light of an issue with internal files treatment #545 we have been able to spot similar issues with treatment of hidden (prefix "." files and directories).
For that reason I think it's reasonable the next changes:
- FIX: In v2.1.0 sources inside a hidden directory where not processed, but they are in 2.2.x
- FEATURE CHANGE: While in v2.1.0 resources folders with "." where copied, it's not consistent with sources and internal resources ("_"). So this PR applies same treatment as with "_" and aligns it with "." sources which are also ignored.

**Are there any alternative ways to implement this?**
We could have left behauviour as in 2.1.0 and copy "." folders, but that's an odd case not consistent with the rest.

**Are there any implications of this pull request? Anything a user must know?**
Users having resources in hidden folders "." will need to rename them.
This could impact Windows users that do not follow Unix "hidden" files conventions, but I struggle to argue using this naming is a good practice we want to promote.

**Is it related to an existing issue?**
<!-- If Yes, please add a line of the form: `Fixes #Issue` --> 
- [x] Yes
- [ ] No

*Finally, please add a corresponding entry to CHANGELOG.adoc*
