### PR TITLE
Bump netty-codec-http to v4.1.71.Final

### DIFF
--- a/CHANGELOG.adoc
+++ b/CHANGELOG.adoc
@@ -25,6 +25,7 @@ Build / Infrastructure::
 
   * Upgrade Asciidoctorj to v2.5.2 (#555)
   * Support Java 17 (#557)
+  * Bump netty-codec-http to v4.1.71.Final (#561)
 
 == v2.2.1 (2021-07-24)
 

--- a/pom.xml
+++ b/pom.xml
@@ -75,7 +75,7 @@
         <maven.filtering.version>3.2.0</maven.filtering.version>
         <plexus.utils.version>3.0.23</plexus.utils.version>
         <plexus.component.metadata.version>1.7</plexus.component.metadata.version>
-        <netty.version>4.1.59.Final</netty.version>
+        <netty.version>4.1.71.Final</netty.version>
         <doxia.version>1.8</doxia.version>
     </properties>
 


### PR DESCRIPTION
**What kind of change does this PR introduce?** (check at least one)
<!-- Update "[ ]" to "[x]" to check a box -->

- [ ] Bugfix
- [ ] Feature
- [ ] Documentation
- [ ] Refactor
- [ ] Build improvement
- [x] Other (please describe) :point_right: maintenance initiated by dependabot CVS alert  https://github.com/asciidoctor/asciidoctor-maven-plugin/pull/560


**What is the goal of this pull request?**
Update netty dependency used for life preview of refresh mojos and fix possible CVS.

**Are there any alternative ways to implement this?**
n/a

**Are there any implications of this pull request? Anything a user must know?**
No, test pass and not feature is added or changes.

**Is it related to an existing issue?**
<!-- If Yes, please add a line of the form: `Fixes #Issue` --> 
- [ ] Yes
- [x] No

*Finally, please add a corresponding entry to CHANGELOG.adoc*
