### PR TITLE
Avoid crash when processing logs of files not under the source dir

### DIFF
--- a/CHANGELOG.adoc
+++ b/CHANGELOG.adoc
@@ -20,6 +20,7 @@ Documentation::
 Bug Fixes::
 
   * Exclude dot files and folders from conversion (#555)
+  * Fix `StringIndexOutOfBoundsException` parsing log records when cursor file is above source directory (#563)
 
 Build / Infrastructure::
 

--- a/src/main/java/org/asciidoctor/maven/AsciidoctorMojo.java
+++ b/src/main/java/org/asciidoctor/maven/AsciidoctorMojo.java
@@ -19,7 +19,7 @@ import org.asciidoctor.maven.extensions.ExtensionConfiguration;
 import org.asciidoctor.maven.extensions.ExtensionRegistry;
 import org.asciidoctor.maven.io.AsciidoctorFileScanner;
 import org.asciidoctor.maven.log.LogHandler;
-import org.asciidoctor.maven.log.LogRecordHelper;
+import org.asciidoctor.maven.log.LogRecordFormatter;
 import org.asciidoctor.maven.log.LogRecordsProcessors;
 import org.asciidoctor.maven.log.MemoryLogHandler;
 import org.asciidoctor.maven.process.AsciidoctorHelper;
@@ -236,7 +236,7 @@ public class AsciidoctorMojo extends AbstractMojo {
         // register LogHandler to capture asciidoctor messages
         final Boolean outputToConsole = logHandler.getOutputToConsole() == null ? Boolean.TRUE : logHandler.getOutputToConsole();
         final MemoryLogHandler memoryLogHandler = new MemoryLogHandler(outputToConsole, sourceDir,
-                logRecord -> getLog().info(LogRecordHelper.format(logRecord, sourceDir)));
+                logRecord -> getLog().info(LogRecordFormatter.format(logRecord, sourceDir)));
         asciidoctor.registerLogHandler(memoryLogHandler);
         // disable default console output of AsciidoctorJ
         Logger.getLogger("asciidoctor").setUseParentHandlers(false);

--- a/src/main/java/org/asciidoctor/maven/log/LogRecordsProcessors.java
+++ b/src/main/java/org/asciidoctor/maven/log/LogRecordsProcessors.java
@@ -30,7 +30,7 @@ public class LogRecordsProcessors {
             final List<LogRecord> records = memoryLogHandler.filter(severity, textToSearch);
             if (records.size() > 0) {
                 for (LogRecord record : records) {
-                    errorMessageConsumer.accept(LogRecordHelper.format(record, sourceDirectory));
+                    errorMessageConsumer.accept(LogRecordFormatter.format(record, sourceDirectory));
                 }
                 throw new Exception(String.format("Found %s issue(s) matching severity %s or higher and text '%s'", records.size(), severity, textToSearch));
             }
@@ -39,7 +39,7 @@ public class LogRecordsProcessors {
             final List<LogRecord> records = memoryLogHandler.filter(severity);
             if (records.size() > 0) {
                 for (LogRecord record : records) {
-                    errorMessageConsumer.accept(LogRecordHelper.format(record, sourceDirectory));
+                    errorMessageConsumer.accept(LogRecordFormatter.format(record, sourceDirectory));
                 }
                 throw new Exception(String.format("Found %s issue(s) of severity %s or higher during conversion", records.size(), severity));
             }
@@ -48,7 +48,7 @@ public class LogRecordsProcessors {
             final List<LogRecord> records = memoryLogHandler.filter(textToSearch);
             if (records.size() > 0) {
                 for (LogRecord record : records) {
-                    errorMessageConsumer.accept(LogRecordHelper.format(record, sourceDirectory));
+                    errorMessageConsumer.accept(LogRecordFormatter.format(record, sourceDirectory));
                 }
                 throw new Exception(String.format("Found %s issue(s) containing '%s'", records.size(), textToSearch));
             }

--- a/src/main/java/org/asciidoctor/maven/site/AsciidoctorDoxiaParser.java
+++ b/src/main/java/org/asciidoctor/maven/site/AsciidoctorDoxiaParser.java
@@ -7,7 +7,7 @@ import org.apache.maven.doxia.sink.Sink;
 import org.apache.maven.project.MavenProject;
 import org.asciidoctor.*;
 import org.asciidoctor.maven.log.LogHandler;
-import org.asciidoctor.maven.log.LogRecordHelper;
+import org.asciidoctor.maven.log.LogRecordFormatter;
 import org.asciidoctor.maven.log.LogRecordsProcessors;
 import org.asciidoctor.maven.log.MemoryLogHandler;
 import org.codehaus.plexus.component.annotations.Component;
@@ -91,7 +91,7 @@ public class AsciidoctorDoxiaParser extends XhtmlParser {
     private MemoryLogHandler asciidoctorLoggingSetup(Asciidoctor asciidoctor, LogHandler logHandler, File siteDirectory) {
 
         final MemoryLogHandler memoryLogHandler = new MemoryLogHandler(logHandler.getOutputToConsole(), siteDirectory,
-                logRecord -> getLog().info(LogRecordHelper.format(logRecord, siteDirectory)));
+                logRecord -> getLog().info(LogRecordFormatter.format(logRecord, siteDirectory)));
         asciidoctor.registerLogHandler(memoryLogHandler);
         // disable default console output of AsciidoctorJ
         Logger.getLogger("asciidoctor").setUseParentHandlers(false);


### PR DESCRIPTION
Thank you for opening a pull request and contributing to asciidoctor-maven-plugin!

**What kind of change does this PR introduce?** (check at least one)
<!-- Update "[ ]" to "[x]" to check a box -->

- [x] Bugfix
- [ ] Feature
- [ ] Documentation
- [ ] Refactor
- [ ] Build improvement
- [ ] Other (please describe)


**What is the goal of this pull request?**
Validates if the cursor file path is contained in the configured source directory of the plugin to avoid crashing.
It also checks if the cursor is a remote url to prevent similar crash.

**Are there any alternative ways to implement this?**
The subpath and http validations could be done with java.io.Path but required methods are not available in Java8. This can be refactored with we drop compat for Java8 in v3.0.0.

**Are there any implications of this pull request? Anything a user must know?**
No.

**Is it related to an existing issue?**
<!-- If Yes, please add a line of the form: `Fixes #Issue` --> 
- [x] Yes  #554 
- [ ] No

*Finally, please add a corresponding entry to CHANGELOG.adoc*
