### PR TITLE
Fix site integration failing with maven-site-plugin v3.10.0

### DIFF
--- a/CHANGELOG.adoc
+++ b/CHANGELOG.adoc
@@ -22,6 +22,7 @@ Bug Fixes::
 
   * Exclude dot files and folders from conversion (#555)
   * Fix `StringIndexOutOfBoundsException` parsing log records when cursor file is above source directory (#563)
+  * Fix compatibility with maven-site-plugin v3.10.0 (previous versions no longer supported) (https://github.com/michael-o[@michael-o]) (#566)
 
 Build / Infrastructure::
 

--- a/pom.xml
+++ b/pom.xml
@@ -76,7 +76,7 @@
         <plexus.utils.version>3.0.23</plexus.utils.version>
         <plexus.component.metadata.version>1.7</plexus.component.metadata.version>
         <netty.version>4.1.71.Final</netty.version>
-        <doxia.version>1.8</doxia.version>
+        <doxia.version>1.10</doxia.version>
     </properties>
 
     <dependencyManagement>
@@ -141,11 +141,6 @@
         <dependency>
             <groupId>org.apache.maven.doxia</groupId>
             <artifactId>doxia-core</artifactId>
-            <version>${doxia.version}</version>
-        </dependency>
-        <dependency>
-            <groupId>org.apache.maven.doxia</groupId>
-            <artifactId>doxia-module-xhtml</artifactId>
             <version>${doxia.version}</version>
         </dependency>
         <dependency>

--- a/src/it/maven-site-plugin/pom.xml
+++ b/src/it/maven-site-plugin/pom.xml
@@ -15,21 +15,21 @@
     <build>
         <plugins>
             <!--
-             Workaround to prevent `java.lang.ClassNotFoundException: org.apache.maven.doxia.siterenderer.DocumentContent`
+             Up to v2.2.1, use v2.8.1 as workaround to prevent `java.lang.ClassNotFoundException: org.apache.maven.doxia.siterenderer.DocumentContent`
              with `maven-site-plugin` v3.6 or lower.
              This only affects the it tests, normal executions (e.g. in asciidoctor-maven-examples) work fine.
             -->
             <plugin>
                 <groupId>org.apache.maven.plugins</groupId>
                 <artifactId>maven-project-info-reports-plugin</artifactId>
-                <version>2.8.1</version>
+                <version>3.1.2</version>
             </plugin>
             <!-- tag::plugin-decl[] -->
             <plugin>
                 <groupId>org.apache.maven.plugins</groupId>
                 <artifactId>maven-site-plugin</artifactId>
-                <!-- doxia 1.7 is only compatible with maven-site-plugin 3.4 or + -->
-                <version>3.4</version>
+                <!-- v2.2.2 of the plugin require Maven Site Plugin 3.10.0 alongside Doxia 1.11.1 -->
+                <version>3.10.0</version>
                 <configuration>
                     <asciidoc>
                         <baseDir>${project.basedir}/src/site/asciidoc</baseDir>

--- a/src/main/java/org/asciidoctor/maven/site/AsciidoctorDoxiaParser.java
+++ b/src/main/java/org/asciidoctor/maven/site/AsciidoctorDoxiaParser.java
@@ -1,6 +1,6 @@
 package org.asciidoctor.maven.site;
 
-import org.apache.maven.doxia.module.xhtml.XhtmlParser;
+import org.apache.maven.doxia.parser.AbstractTextParser;
 import org.apache.maven.doxia.parser.ParseException;
 import org.apache.maven.doxia.parser.Parser;
 import org.apache.maven.doxia.sink.Sink;
@@ -31,7 +31,7 @@ import java.util.logging.Logger;
  * @author mojavelinux
  */
 @Component(role = Parser.class, hint = AsciidoctorDoxiaParser.ROLE_HINT)
-public class AsciidoctorDoxiaParser extends XhtmlParser {
+public class AsciidoctorDoxiaParser extends AbstractTextParser {
 
     @Inject
     protected Provider<MavenProject> mavenProjectProvider;
@@ -45,7 +45,7 @@ public class AsciidoctorDoxiaParser extends XhtmlParser {
      * {@inheritDoc}
      */
     @Override
-    public void parse(Reader reader, Sink sink) throws ParseException {
+    public void parse(Reader reader, Sink sink, String reference) throws ParseException {
         String source;
         try {
             if ((source = IOUtil.toString(reader)) == null) {


### PR DESCRIPTION
**What kind of change does this PR introduce?** (check at least one)
<!-- Update "[ ]" to "[x]" to check a box -->

- [x] Bugfix
- [ ] Feature
- [ ] Documentation
- [ ] Refactor
- [ ] Build improvement
- [ ] Other (please describe)


**What is the goal of this pull request?**
Fixes #564 
* Make AsciidoctorDoxiaParser extend AbstractTextParser instad of XhtmlParser
* Bump minimum Doxia version to v1.10

**Are there any alternative ways to implement this?**
The issue does not appear when overriding `doxia-core` v1.11.1 with v1.9.1, so it could be there's some other issue on doxia.
However, it is also true `AsciidoctorDoxiaParser` extended `XhtmlParser` which makes no sense and which is consistent with the error that points to invalid XML document (of course AsciiDoc is not XML compatible).


**Are there any implications of this pull request? Anything a user must know?**
* Minimum supported version for doxia-core is v1.10 now (to be sure maven-site-plugin v3.10.0, since site-plugin 3.9.1 uses doxia 1.9.1).
* We now implement parse() method that recieves the file reference necessary for https://github.com/asciidoctor/asciidoctor-maven-plugin/issues/323, but it does not work since an extra fix in `doxia-site-renderer` has not yet been release.

**Is it related to an existing issue?**
<!-- If Yes, please add a line of the form: `Fixes #Issue` --> 
- [x] Yes
- [ ] No

*Finally, please add a corresponding entry to CHANGELOG.adoc*
