### PR TITLE
Add missing 2.1.0 readme reference to README

### DIFF
--- a/README.adoc
+++ b/README.adoc
@@ -62,6 +62,8 @@ ifeval::['{tag}' == 'main']
 ====
 You're viewing the documentation for the upcoming release.
 If you're looking for the documentation for an older release, please refer to one of the following tags: +
+{uri-repo}/tree/asciidoctor-maven-plugin-2.1.0#readme[2.1.0]
+&hybull;
 {uri-repo}/tree/asciidoctor-maven-plugin-2.0.0#readme[2.0.0]
 &hybull;
 {uri-repo}/tree/asciidoctor-maven-plugin-1.6.0#readme[1.6.0]


### PR DESCRIPTION
Thank you for opening a pull request and contributing to asciidoctor-maven-plugin!

**What kind of change does this PR introduce?** (check at least one)
<!-- Update "[ ]" to "[x]" to check a box -->

- [ ] Bugfix
- [ ] Feature
- [x] Documentation
- [ ] Refactor
- [ ] Build improvement
- [ ] Other (please describe)


**What is the goal of this pull request?**
Add missing reference to 2.1.0 readme.
2.1.0 is the last version not present in docs.asciidoctor.org but still supported, so we need to make it more visible.

**Are there any alternative ways to implement this?**
No

**Are there any implications of this pull request? Anything a user must know?**
No

**Is it related to an existing issue?**
<!-- If Yes, please add a line of the form: `Fixes #Issue` --> 
- [ ] Yes
- [x] No

This is so minor is not worth mentioning.

*Finally, please add a corresponding entry to CHANGELOG.adoc*
