### PR TITLE
Bump Doxia to v1.11.1 & maven-site-plugin IT to v3.12.0

### DIFF
--- a/CHANGELOG.adoc
+++ b/CHANGELOG.adoc
@@ -11,6 +11,12 @@ endif::[]
 This document provides a high-level view of the changes introduced on Asciidoctor Maven Plugin by release.
 For a detailed view of what has changed, refer to the {uri-repo}/commits/main[commit history] on GitHub.
 
+== Unreleased
+
+Build / Infrastructure::
+  
+  * Bump Doxia to v1.11.1 and maven-site-plugin in IT to 3.12.0 (#579)
+
 == v2.2.2 (2022-01-30)
 
 Bug Fixes::
@@ -21,9 +27,9 @@ Bug Fixes::
 
 Documentation::
 
-* Add ID's for all parameters of process-asciidoc, auto-refresh and http mojo, to be able to generate direct urls (https://github.com/uniqueck[@uniqueck]) (#533)
-* Clarify where to put the plugin section in `pom.xml` (#558)
-* Add compatibility matrix (#569)
+  * Add ID's for all parameters of process-asciidoc, auto-refresh and http mojo, to be able to generate direct urls (https://github.com/uniqueck[@uniqueck]) (#533)
+  * Clarify where to put the plugin section in `pom.xml` (#558)
+  * Add compatibility matrix (#569)
 
 Build / Infrastructure::
 

--- a/docs/modules/site-integration/pages/compatibility-matrix.adoc
+++ b/docs/modules/site-integration/pages/compatibility-matrix.adoc
@@ -9,7 +9,7 @@ Release candidate releases are not accounted.
 |Asciidoctor Maven Plugin | Maven Site Plugin | Supported
 
 |v2.2.2
-|v3.10.x
+|v3.1x.x
 |Yes
 
 |v2.0.x ~ v2.2.1

--- a/pom.xml
+++ b/pom.xml
@@ -76,7 +76,7 @@
         <plexus.utils.version>3.0.23</plexus.utils.version>
         <plexus.component.metadata.version>1.7</plexus.component.metadata.version>
         <netty.version>4.1.71.Final</netty.version>
-        <doxia.version>1.10</doxia.version>
+        <doxia.version>1.11.1</doxia.version>
     </properties>
 
     <dependencyManagement>

--- a/src/it/maven-site-plugin/pom.xml
+++ b/src/it/maven-site-plugin/pom.xml
@@ -28,8 +28,8 @@
             <plugin>
                 <groupId>org.apache.maven.plugins</groupId>
                 <artifactId>maven-site-plugin</artifactId>
-                <!-- v2.2.2 of the plugin require Maven Site Plugin 3.10.0 alongside Doxia 1.11.1 -->
-                <version>3.10.0</version>
+                <!-- v2.2.2 of the plugin require Maven Site Plugin 3.1x.0 alongside Doxia 1.11.1 -->
+                <version>3.12.0</version>
                 <configuration>
                     <asciidoc>
                         <baseDir>${project.basedir}/src/site/asciidoc</baseDir>


### PR DESCRIPTION
Thank you for opening a pull request and contributing to asciidoctor-maven-plugin!

**What kind of change does this PR introduce?** (check at least one)
<!-- Update "[ ]" to "[x]" to check a box -->

- [ ] Bugfix
- [ ] Feature
- [ ] Documentation
- [ ] Refactor
- [ ] Build improvement
- [x] Other (please describe)

**What is the goal of this pull request?**

Maintenance chore, bumping site related dependencies to most up to date compatible versions (docs included.)
Also tested maven-site-plugin v3.11.0 locally to make sure all versions between 3.10 and 3.12 are fine.

**Are there any alternative ways to implement this?**

N/A

**Are there any implications of this pull request? Anything a user must know?**

No big change, just maintenance

**Is it related to an existing issue?**
<!-- If Yes, please add a line of the form: `Fixes #Issue` --> 
- [ ] Yes
- [x] No

Not closing, but inspired by https://github.com/asciidoctor/asciidoctor-maven-plugin/issues/578

*Finally, please add a corresponding entry to CHANGELOG.adoc*
