### PR TITLE
Bump netty-codec-http to latest v4.1.77.Final

### DIFF
--- a/CHANGELOG.adoc
+++ b/CHANGELOG.adoc
@@ -16,6 +16,7 @@ For a detailed view of what has changed, refer to the {uri-repo}/commits/main[co
 Build / Infrastructure::
   
   * Bump Doxia to v1.11.1 and maven-site-plugin in IT to 3.12.0 (#579)
+  * Bump netty-codec-http to v4.1.77.Final (fix CVE-2021-21290) (#582)
 
 == v2.2.2 (2022-01-30)
 

--- a/pom.xml
+++ b/pom.xml
@@ -75,7 +75,7 @@
         <maven.filtering.version>3.2.0</maven.filtering.version>
         <plexus.utils.version>3.0.23</plexus.utils.version>
         <plexus.component.metadata.version>1.7</plexus.component.metadata.version>
-        <netty.version>4.1.71.Final</netty.version>
+        <netty.version>4.1.77.Final</netty.version>
         <doxia.version>1.11.1</doxia.version>
     </properties>
 


### PR DESCRIPTION
Fix CVE-2021-21290

Thank you for opening a pull request and contributing to asciidoctor-maven-plugin!

**What kind of change does this PR introduce?** (check at least one)
<!-- Update "[ ]" to "[x]" to check a box -->

- [ ] Bugfix
- [ ] Feature
- [ ] Documentation
- [ ] Refactor
- [ ] Build improvement
- [x] Other (please describe)

**What is the goal of this pull request?**
Fix security warning related to CVE-2021-21290.
This ONLY impacts `http` and `auto-refresh` mojos, pipelinas using the plugin for normal conversion are not impacted.

**Are there any alternative ways to implement this?**
No

**Are there any implications of this pull request? Anything a user must know?**
No

**Is it related to an existing issue?**
<!-- If Yes, please add a line of the form: `Fixes #Issue` --> 
- [ ] Yes
- [x] No

*Finally, please add a corresponding entry to CHANGELOG.adoc*
