### PR TITLE
Bump Asciidoctorj to latest v2.5.4

### DIFF
--- a/CHANGELOG.adoc
+++ b/CHANGELOG.adoc
@@ -17,6 +17,7 @@ Build / Infrastructure::
   
   * Bump Doxia to v1.11.1 and maven-site-plugin in IT to 3.12.0 (#579)
   * Bump netty-codec-http to v4.1.77.Final (fix CVE-2021-21290) (#582)
+  * Upgrade Asciidoctorj to v2.5.4 and jRuby to v9.3.4.0 (#584)
 
 == v2.2.2 (2022-01-30)
 

--- a/pom.xml
+++ b/pom.xml
@@ -65,8 +65,8 @@
         <project.build.sourceEncoding>UTF-8</project.build.sourceEncoding>
         <project.java.version>1.8</project.java.version>
         <project.execution.environment>JavaSE-1.8</project.execution.environment>
-        <asciidoctorj.version>2.5.3</asciidoctorj.version>
-        <jruby.version>9.2.20.1</jruby.version>
+        <asciidoctorj.version>2.5.4</asciidoctorj.version>
+        <jruby.version>9.3.4.0</jruby.version>
         <maven.coveralls.plugin.version>4.3.0</maven.coveralls.plugin.version>
         <maven.jacoco.plugin.version>0.8.7</maven.jacoco.plugin.version>
         <maven.plugin.plugin.version>3.5</maven.plugin.plugin.version>


### PR DESCRIPTION
* Align jRuby to v9.3.4.0

Thank you for opening a pull request and contributing to asciidoctor-maven-plugin!

**What kind of change does this PR introduce?** (check at least one)
<!-- Update "[ ]" to "[x]" to check a box -->

- [ ] Bugfix
- [ ] Feature
- [ ] Documentation
- [ ] Refactor
- [ ] Build improvement
- [x] Other (please describe)


**What is the goal of this pull request?**
Maintenance

**Are there any alternative ways to implement this?**
n/a

**Are there any implications of this pull request? Anything a user must know?**
Users can still use Asciidoctorj v2.5.4 with current released asciidoctor-maven-plugin.

**Is it related to an existing issue?**
<!-- If Yes, please add a line of the form: `Fixes #Issue` --> 
- [ ] Yes
- [x] No

*Finally, please add a corresponding entry to CHANGELOG.adoc*
