### PR TITLE
Make plugin compatible with maven-site-plugin 4.0.0-M1

### DIFF
--- a/docs/modules/site-integration/pages/compatibility-matrix.adoc
+++ b/docs/modules/site-integration/pages/compatibility-matrix.adoc
@@ -8,6 +8,11 @@ Release candidate releases are not accounted.
 |===
 |Asciidoctor Maven Plugin | Maven Site Plugin | Supported
 
+// TODO uncomment on release
+//|v3.0.x
+//|v3.1x.x ~ v4.x.x
+//|Yes
+
 |v2.2.2
 |v3.1x.x
 |Yes

--- a/pom.xml
+++ b/pom.xml
@@ -76,7 +76,7 @@
         <plexus.utils.version>3.0.23</plexus.utils.version>
         <plexus.component.metadata.version>1.7</plexus.component.metadata.version>
         <netty.version>4.1.77.Final</netty.version>
-        <doxia.version>1.11.1</doxia.version>
+        <doxia.version>2.0.0-M2</doxia.version>
     </properties>
 
     <dependencyManagement>

--- a/src/it/maven-site-plugin/pom.xml
+++ b/src/it/maven-site-plugin/pom.xml
@@ -22,14 +22,14 @@
             <plugin>
                 <groupId>org.apache.maven.plugins</groupId>
                 <artifactId>maven-project-info-reports-plugin</artifactId>
-                <version>3.1.2</version>
+                <version>3.3.0</version>
             </plugin>
             <!-- tag::plugin-decl[] -->
             <plugin>
                 <groupId>org.apache.maven.plugins</groupId>
                 <artifactId>maven-site-plugin</artifactId>
                 <!-- v2.2.2 of the plugin require Maven Site Plugin 3.1x.0 alongside Doxia 1.11.1 -->
-                <version>3.12.0</version>
+                <version>4.0.0-M1</version>
                 <configuration>
                     <asciidoc>
                         <baseDir>${project.basedir}/src/site/asciidoc</baseDir>

--- a/src/it/maven-site-plugin/src/site/site.xml
+++ b/src/it/maven-site-plugin/src/site/site.xml
@@ -1,8 +1,8 @@
 <project name="Maven Site Plugin IT">
     <body>
+        <menu ref="reports"/>
         <menu name="AsciiDoc Pages">
             <item name="File with TOC" href="/file-with-toc.html"/>
         </menu>
-      ${reports}
     </body>
 </project>

--- a/src/main/java/org/asciidoctor/maven/site/AsciidoctorDoxiaParser.java
+++ b/src/main/java/org/asciidoctor/maven/site/AsciidoctorDoxiaParser.java
@@ -13,13 +13,14 @@ import org.asciidoctor.maven.log.MemoryLogHandler;
 import org.codehaus.plexus.component.annotations.Component;
 import org.codehaus.plexus.util.IOUtil;
 import org.codehaus.plexus.util.xml.Xpp3Dom;
+import org.slf4j.Logger;
+import org.slf4j.LoggerFactory;
 
 import javax.inject.Inject;
 import javax.inject.Provider;
 import java.io.File;
 import java.io.IOException;
 import java.io.Reader;
-import java.util.logging.Logger;
 
 /**
  * This class is used by <a href="https://maven.apache.org/doxia/overview.html">the Doxia framework</a>
@@ -32,6 +33,8 @@ import java.util.logging.Logger;
  */
 @Component(role = Parser.class, hint = AsciidoctorDoxiaParser.ROLE_HINT)
 public class AsciidoctorDoxiaParser extends AbstractTextParser {
+
+    private Logger logger = LoggerFactory.getLogger(AsciidoctorDoxiaParser.class);
 
     @Inject
     protected Provider<MavenProject> mavenProjectProvider;
@@ -52,7 +55,7 @@ public class AsciidoctorDoxiaParser extends AbstractTextParser {
                 source = "";
             }
         } catch (IOException ex) {
-            getLog().error("Could not read AsciiDoc source: " + ex.getLocalizedMessage());
+            logger.error("Could not read AsciiDoc source: " + ex.getLocalizedMessage());
             return;
         }
 
@@ -79,7 +82,7 @@ public class AsciidoctorDoxiaParser extends AbstractTextParser {
         String asciidocHtml = convertAsciiDoc(asciidoctor, source, conversionConfig.getOptions());
         try {
             // process log messages according to mojo configuration
-            new LogRecordsProcessors(logHandler, siteDirectory, errorMessage -> getLog().error(errorMessage))
+            new LogRecordsProcessors(logHandler, siteDirectory, errorMessage -> logger.error(errorMessage))
                     .processLogRecords(memoryLogHandler);
         } catch (Exception exception) {
             throw new ParseException(exception.getMessage(), exception);
@@ -91,10 +94,10 @@ public class AsciidoctorDoxiaParser extends AbstractTextParser {
     private MemoryLogHandler asciidoctorLoggingSetup(Asciidoctor asciidoctor, LogHandler logHandler, File siteDirectory) {
 
         final MemoryLogHandler memoryLogHandler = new MemoryLogHandler(logHandler.getOutputToConsole(), siteDirectory,
-                logRecord -> getLog().info(LogRecordFormatter.format(logRecord, siteDirectory)));
+                logRecord -> logger.info(LogRecordFormatter.format(logRecord, siteDirectory)));
         asciidoctor.registerLogHandler(memoryLogHandler);
         // disable default console output of AsciidoctorJ
-        Logger.getLogger("asciidoctor").setUseParentHandlers(false);
+        java.util.logging.Logger.getLogger("asciidoctor").setUseParentHandlers(false);
         return memoryLogHandler;
     }
 
@@ -136,7 +139,7 @@ public class AsciidoctorDoxiaParser extends AbstractTextParser {
             try {
                 asciidoctor.requireLibrary(require);
             } catch (Exception ex) {
-                getLog().error(ex.getLocalizedMessage());
+                logger.error(ex.getLocalizedMessage());
             }
         }
     }

--- a/src/main/java/org/asciidoctor/maven/site/AsciidoctorDoxiaParserModule.java
+++ b/src/main/java/org/asciidoctor/maven/site/AsciidoctorDoxiaParserModule.java
@@ -30,6 +30,6 @@ public class AsciidoctorDoxiaParserModule extends AbstractParserModule {
      * Build a new instance of {@link AsciidoctorDoxiaParserModule}.
      */
     public AsciidoctorDoxiaParserModule() {
-        super(SOURCE_DIRECTORY, FILE_EXTENSION, AsciidoctorDoxiaParser.ROLE_HINT);
+        super(SOURCE_DIRECTORY, AsciidoctorDoxiaParser.ROLE_HINT, FILE_EXTENSION);
     }
 }


### PR DESCRIPTION
* Bump Doxia to 2.0.0-M1
* Leave note in docs for release
* Use SLF4J in site module (https://github.com/apache/maven-doxia/pull/5)
* Reorder constructor args in AsciidoctorDoxiaParserModule

Fixes #578 


**What kind of change does this PR introduce?** (check at least one)
<!-- Update "[ ]" to "[x]" to check a box -->

- [ ] Bugfix
- [x] Feature
- [ ] Documentation
- [ ] Refactor
- [ ] Build improvement
- [ ] Other (please describe)


**What is the goal of this pull request?**
Make the site module compatible with latest maven-site-plugin 4.0.0-M1.

**Are there any alternative ways to implement this?**
No. Basic process is just bumping Doxia and updating required changes.

**Are there any implications of this pull request? Anything a user must know?**
maven-site-plugin v3.1x.x is still compatible. So in case of need we can still do a 2.2.3 release without breaking builds.

**Is it related to an existing issue?**
<!-- If Yes, please add a line of the form: `Fixes #Issue` --> 
- [x] Yes
- [ ] No

*Finally, please add a corresponding entry to CHANGELOG.adoc*
