### PR TITLE
Bump AsciidoctorJ v2.5.6 + jRuby v9.3.8.0

### DIFF
--- a/CHANGELOG.adoc
+++ b/CHANGELOG.adoc
@@ -30,6 +30,7 @@ Build / Infrastructure::
   * Bump netty-codec-http to v4.1.77.Final (fix CVE-2021-21290) (#582)
   * Upgrade Asciidoctorj to v2.5.4 and jRuby to v9.3.4.0 (#584)
   * Upgrade Asciidoctorj to v2.5.5 (#591)
+  * Upgrade Asciidoctorj to v2.5.6 and jRuby to v9.3.8.0 (#602)
 
 Maintenance::
   * Replace use of reflection by direct JavaExtensionRegistry calls to register extensions (#596)

--- a/pom.xml
+++ b/pom.xml
@@ -76,8 +76,8 @@
         <project.build.sourceEncoding>UTF-8</project.build.sourceEncoding>
         <project.java.version>1.8</project.java.version>
         <project.execution.environment>JavaSE-1.8</project.execution.environment>
-        <asciidoctorj.version>2.5.5</asciidoctorj.version>
-        <jruby.version>9.3.4.0</jruby.version>
+        <asciidoctorj.version>2.5.6</asciidoctorj.version>
+        <jruby.version>9.3.8.0</jruby.version>
         <maven.project.version>3.0.5</maven.project.version>
         <maven.jacoco.plugin.version>0.8.7</maven.jacoco.plugin.version>
     </properties>


### PR DESCRIPTION
**What kind of change does this PR introduce?** (check at least one)
<!-- Update "[ ]" to "[x]" to check a box -->

- [ ] Bugfix
- [ ] Feature
- [ ] Documentation
- [ ] Refactor
- [ ] Build improvement
- [x] Other (please describe)

chore: bumping AsciidoctorJ related versions
