### PR TITLE
Bump netty-codec-http to latest v4.1.89.Final

### DIFF
--- a/CHANGELOG.adoc
+++ b/CHANGELOG.adoc
@@ -33,7 +33,7 @@ Build / Infrastructure::
   * Bump Doxia to v1.11.1 and maven-site-plugin in IT to 3.12.0 (#579)
   * Bump netty-codec-http to v4.1.77.Final (fix CVE-2021-21290) (#582)
   * Bump netty-codec-http to v4.1.87.Final (fix CVE-2022-41915) (#612)
-  * Bump netty-codec-http to v4.1.89.Final (#TODO)
+  * Bump netty-codec-http to v4.1.89.Final (#615)
   * Upgrade Asciidoctorj to v2.5.4 and jRuby to v9.3.4.0 (#584)
   * Upgrade Asciidoctorj to v2.5.5 (#591)
   * Upgrade Asciidoctorj to v2.5.6 and jRuby to v9.3.8.0 (#602)

--- a/CHANGELOG.adoc
+++ b/CHANGELOG.adoc
@@ -33,6 +33,7 @@ Build / Infrastructure::
   * Bump Doxia to v1.11.1 and maven-site-plugin in IT to 3.12.0 (#579)
   * Bump netty-codec-http to v4.1.77.Final (fix CVE-2021-21290) (#582)
   * Bump netty-codec-http to v4.1.87.Final (fix CVE-2022-41915) (#612)
+  * Bump netty-codec-http to v4.1.89.Final (#TODO)
   * Upgrade Asciidoctorj to v2.5.4 and jRuby to v9.3.4.0 (#584)
   * Upgrade Asciidoctorj to v2.5.5 (#591)
   * Upgrade Asciidoctorj to v2.5.6 and jRuby to v9.3.8.0 (#602)

--- a/asciidoctor-maven-plugin/pom.xml
+++ b/asciidoctor-maven-plugin/pom.xml
@@ -19,7 +19,7 @@
 
     <properties>
         <maven.plugin.plugin.version>3.7.0</maven.plugin.plugin.version>
-        <netty.version>4.1.87.Final</netty.version>
+        <netty.version>4.1.89.Final</netty.version>
         <maven.coveralls.plugin.version>4.3.0</maven.coveralls.plugin.version>
     </properties>
 


### PR DESCRIPTION
Thank you for opening a pull request and contributing to asciidoctor-maven-plugin!

**What kind of change does this PR introduce?** (check at least one)
<!-- Update "[ ]" to "[x]" to check a box -->

- [ ] Bugfix
- [ ] Feature
- [ ] Documentation
- [ ] Refactor
- [ ] Build improvement
- [x] Other (please describe)


**What is the goal of this pull request?**
Update netty-codec-http to the latest patch level version for a potential patch release of the plugin.
This ONLY impacts http and auto-refresh mojos, pipelinas using the plugin for normal conversion are not impacted.

**Are there any alternative ways to implement this?**
No.

**Are there any implications of this pull request? Anything a user must know?**
No.

**Is it related to an existing issue?**
<!-- If Yes, please add a line of the form: `Fixes #Issue` --> 
- [ ] Yes
- [x] No

*Finally, please add a corresponding entry to CHANGELOG.adoc*
