### PR TITLE
Bump build plugin dependencies

### DIFF
--- a/CHANGELOG.adoc
+++ b/CHANGELOG.adoc
@@ -27,6 +27,7 @@ Build / Infrastructure::
   * Upgrade Asciidoctorj to v2.5.7 (#604)
   * Bump netty-codec-http to v4.1.90.Final (fix several CVEs)
   * Delete unused TravisCI configuration (#622)
+  * Bump Maven build plugins (#623)
 
 Documentation::
 

--- a/pom.xml
+++ b/pom.xml
@@ -14,7 +14,7 @@
         <name>Asciidoctor</name>
         <url>https://asciidoctor.org/</url>
     </organization>
-    
+
     <developers>
         <developer>
             <id>lightguard</id>
@@ -171,7 +171,7 @@
             <plugin>
                 <groupId>org.apache.maven.plugins</groupId>
                 <artifactId>maven-enforcer-plugin</artifactId>
-                <version>3.1.0</version>
+                <version>3.2.1</version>
                 <executions>
                     <execution>
                         <id>enforce-maven</id>
@@ -203,7 +203,7 @@
             <plugin>
                 <groupId>org.apache.maven.plugins</groupId>
                 <artifactId>maven-compiler-plugin</artifactId>
-                <version>3.10.1</version>
+                <version>3.11.0</version>
                 <configuration>
                     <source>${project.java.version}</source>
                     <target>${project.java.version}</target>
@@ -246,7 +246,7 @@
                 <plugin>
                     <groupId>org.apache.maven.plugins</groupId>
                     <artifactId>maven-release-plugin</artifactId>
-                    <version>3.0.0-M1</version>
+                    <version>3.0.0-M7</version>
                     <configuration>
                         <mavenExecutorId>forked-path</mavenExecutorId>
                     </configuration>
@@ -321,7 +321,7 @@
                 <plugin>
                     <groupId>org.apache.maven.plugins</groupId>
                     <artifactId>maven-javadoc-plugin</artifactId>
-                    <version>3.4.1</version>
+                    <version>3.5.0</version>
                 </plugin>
                 <plugin>
                     <groupId>org.apache.maven.plugins</groupId>
@@ -331,7 +331,7 @@
                 <plugin>
                     <groupId>org.apache.maven.plugins</groupId>
                     <artifactId>maven-surefire-plugin</artifactId>
-                    <version>3.0.0-M7</version>
+                    <version>3.0.0</version>
                 </plugin>
                 <plugin>
                     <groupId>org.apache.maven.plugins</groupId>
@@ -341,7 +341,7 @@
                 <plugin>
                     <groupId>org.apache.maven.plugins</groupId>
                     <artifactId>maven-invoker-plugin</artifactId>
-                    <version>3.2.2</version>
+                    <version>3.4.0</version>
                 </plugin>
             </plugins>
         </pluginManagement>


### PR DESCRIPTION
Thank you for opening a pull request and contributing to asciidoctor-maven-plugin!

**What kind of change does this PR introduce?** (check at least one)
<!-- Update "[ ]" to "[x]" to check a box -->

- [ ] Bugfix
- [ ] Feature
- [ ] Documentation
- [ ] Refactor
- [x] Build improvement
- [ ] Other (please describe)


**What is the goal of this pull request?**
Bump maven plugins versions for the build.
* maven-enforcer-plugin v3.2.1
* maven-compiler-plugin v3.11.0
* maven-release-plugin  3.0.0-M7
* maven-javadoc-plugin  v3.5.0
* maven-surefire-plugin v3.0.0
* maven-invoker-plugin  v3.4.0

maven-invoker-plugin v3.5.0 is failing (unable to download jruby :shrug: ). This does not impact the actual release artifact, so leaving it for now.

**Are there any alternative ways to implement this?**
no

**Are there any implications of this pull request? Anything a user must know?**
We won't know if there's an issue with maven-release-plugin until we release. But it should be fine being it a milestone bump.

**Is it related to an existing issue?**
<!-- If Yes, please add a line of the form: `Fixes #Issue` --> 
- [ ] Yes
- [x] No

*Finally, please add a corresponding entry to CHANGELOG.adoc*
