### PR TITLE
Set minimal maven version to 3.9.x & bump dependencies

### DIFF
--- a/.mvn/wrapper/maven-wrapper.properties
+++ b/.mvn/wrapper/maven-wrapper.properties
@@ -14,5 +14,5 @@
 # KIND, either express or implied.  See the License for the
 # specific language governing permissions and limitations
 # under the License.
-distributionUrl=https://repo.maven.apache.org/maven2/org/apache/maven/apache-maven/3.8.6/apache-maven-3.8.6-bin.zip
+distributionUrl=https://repo.maven.apache.org/maven2/org/apache/maven/apache-maven/3.9.1/apache-maven-3.9.1-bin.zip
 wrapperUrl=https://repo.maven.apache.org/maven2/org/apache/maven/wrapper/maven-wrapper/3.1.1/maven-wrapper-3.1.1.jar

--- a/CHANGELOG.adoc
+++ b/CHANGELOG.adoc
@@ -23,6 +23,7 @@ Improvements::
   * Add 'asciidoc' as valid file extension in AsciidoctorDoxiaParserModule (#595)
   * Fix throwing an exception when registering a non Extension (#596)
   * Reimplement resource copy using 'plexus.util.DirectorScanner' instead of 'maven-filtering' to reduce dependencies and build time (#597)
+  * Set minimal Maven version to v3.9.x (#629)
 
 Documentation::
 
@@ -42,6 +43,7 @@ Build / Infrastructure::
   * Set minimal maven version to 3.8.5 (#607)
   * Bump GH 'checkout' and 'setup-java' to v3 & delete unused TravisCI configuration (#627)
   * Bump netty-codec-http to v4.1.90.Final (#628)
+  * Bump plugins versions (#629)
 
 Maintenance::
   * Replace use of reflection by direct JavaExtensionRegistry calls to register extensions (#596)

--- a/CHANGELOG.adoc
+++ b/CHANGELOG.adoc
@@ -23,7 +23,7 @@ Improvements::
   * Add 'asciidoc' as valid file extension in AsciidoctorDoxiaParserModule (#595)
   * Fix throwing an exception when registering a non Extension (#596)
   * Reimplement resource copy using 'plexus.util.DirectorScanner' instead of 'maven-filtering' to reduce dependencies and build time (#597)
-  * Set minimal Maven version to v3.9.x (#629)
+  * Set minimal Maven version to v3.8.5 (#629)
 
 Documentation::
 
@@ -43,7 +43,7 @@ Build / Infrastructure::
   * Set minimal maven version to 3.8.5 (#607)
   * Bump GH 'checkout' and 'setup-java' to v3 & delete unused TravisCI configuration (#627)
   * Bump netty-codec-http to v4.1.90.Final (#628)
-  * Bump plugins versions (#629)
+  * Bump plugins versions & set CI Maven to v3.9.1 (#629)
 
 Maintenance::
   * Replace use of reflection by direct JavaExtensionRegistry calls to register extensions (#596)

--- a/asciidoctor-converter-doxia-module/pom.xml
+++ b/asciidoctor-converter-doxia-module/pom.xml
@@ -20,7 +20,7 @@
     <properties>
         <doxia.version>1.11.1</doxia.version>
         <maven.coveralls.plugin.version>4.3.0</maven.coveralls.plugin.version>
-        <plexus.component.metadata.version>1.7</plexus.component.metadata.version>
+        <plexus.component.metadata.version>2.1.1</plexus.component.metadata.version>
     </properties>
 
     <dependencies>

--- a/asciidoctor-maven-commons/pom.xml
+++ b/asciidoctor-maven-commons/pom.xml
@@ -23,7 +23,7 @@
     <url>https://github.com/asciidoctor/asciidoctor-maven-plugin</url>
 
     <properties>
-        <plexus.utils.version>3.3.1</plexus.utils.version>
+        <plexus.utils.version>3.5.1</plexus.utils.version>
     </properties>
 
     <dependencies>

--- a/asciidoctor-maven-commons/pom.xml
+++ b/asciidoctor-maven-commons/pom.xml
@@ -42,7 +42,7 @@
             <groupId>org.codehaus.plexus</groupId>
             <artifactId>plexus-utils</artifactId>
             <version>${plexus.utils.version}</version>
-            <scope>provided</scope>
+            <scope>compile</scope>
         </dependency>
     </dependencies>
 

--- a/asciidoctor-maven-plugin/pom.xml
+++ b/asciidoctor-maven-plugin/pom.xml
@@ -18,7 +18,7 @@
     <url>https://github.com/asciidoctor/asciidoctor-maven-plugin</url>
 
     <properties>
-        <maven.plugin.plugin.version>3.7.0</maven.plugin.plugin.version>
+        <maven.plugin.plugin.version>3.8.1</maven.plugin.plugin.version>
         <netty.version>4.1.90.Final</netty.version>
         <maven.coveralls.plugin.version>4.3.0</maven.coveralls.plugin.version>
     </properties>
@@ -65,7 +65,7 @@
         <dependency>
             <groupId>commons-io</groupId>
             <artifactId>commons-io</artifactId>
-            <version>2.7</version>
+            <version>2.11.0</version>
         </dependency>
         <dependency>
             <groupId>io.netty</groupId>

--- a/asciidoctor-parser-doxia-module/pom.xml
+++ b/asciidoctor-parser-doxia-module/pom.xml
@@ -19,7 +19,7 @@
     <properties>
         <doxia.version>1.11.1</doxia.version>
         <maven.coveralls.plugin.version>4.3.0</maven.coveralls.plugin.version>
-        <plexus.component.metadata.version>1.7</plexus.component.metadata.version>
+        <plexus.component.metadata.version>2.1.1</plexus.component.metadata.version>
     </properties>
 
     <dependencies>

--- a/pom.xml
+++ b/pom.xml
@@ -135,7 +135,7 @@
                         <configuration>
                             <rules>
                                 <requireMavenVersion>
-                                    <version>3.9.0</version>
+                                    <version>3.8.5</version>
                                 </requireMavenVersion>
                             </rules>
                         </configuration>

--- a/pom.xml
+++ b/pom.xml
@@ -78,7 +78,7 @@
         <project.execution.environment>JavaSE-1.8</project.execution.environment>
         <asciidoctorj.version>2.5.7</asciidoctorj.version>
         <jruby.version>9.3.8.0</jruby.version>
-        <maven.project.version>3.8.6</maven.project.version>
+        <maven.project.version>3.9.1</maven.project.version>
         <maven.jacoco.plugin.version>0.8.8</maven.jacoco.plugin.version>
     </properties>
 
@@ -125,7 +125,7 @@
             <plugin>
                 <groupId>org.apache.maven.plugins</groupId>
                 <artifactId>maven-enforcer-plugin</artifactId>
-                <version>3.1.0</version>
+                <version>3.2.1</version>
                 <executions>
                     <execution>
                         <id>enforce-maven</id>
@@ -135,7 +135,7 @@
                         <configuration>
                             <rules>
                                 <requireMavenVersion>
-                                    <version>3.0.5</version>
+                                    <version>3.9.0</version>
                                 </requireMavenVersion>
                             </rules>
                         </configuration>
@@ -145,7 +145,7 @@
             <plugin>
                 <groupId>org.apache.maven.plugins</groupId>
                 <artifactId>maven-compiler-plugin</artifactId>
-                <version>3.10.1</version>
+                <version>3.11.0</version>
                 <configuration>
                     <source>${project.java.version}</source>
                     <target>${project.java.version}</target>
@@ -158,7 +158,7 @@
                 <plugin>
                     <groupId>org.apache.maven.plugins</groupId>
                     <artifactId>maven-release-plugin</artifactId>
-                    <version>3.0.0-M1</version>
+                    <version>3.0.0-M7</version>
                     <configuration>
                         <mavenExecutorId>forked-path</mavenExecutorId>
                     </configuration>
@@ -172,7 +172,7 @@
                 <plugin>
                     <groupId>org.apache.maven.plugins</groupId>
                     <artifactId>maven-javadoc-plugin</artifactId>
-                    <version>3.4.1</version>
+                    <version>3.5.0</version>
                 </plugin>
                 <plugin>
                     <groupId>org.apache.maven.plugins</groupId>
@@ -182,7 +182,7 @@
                 <plugin>
                     <groupId>org.apache.maven.plugins</groupId>
                     <artifactId>maven-surefire-plugin</artifactId>
-                    <version>3.0.0-M7</version>
+                    <version>3.0.0</version>
                 </plugin>
                 <plugin>
                     <groupId>org.apache.maven.plugins</groupId>
@@ -192,7 +192,7 @@
                 <plugin>
                     <groupId>org.apache.maven.plugins</groupId>
                     <artifactId>maven-invoker-plugin</artifactId>
-                    <version>3.3.0</version>
+                    <version>3.4.0</version>
                 </plugin>
                 <plugin>
                     <groupId>org.jacoco</groupId>


### PR DESCRIPTION
Bump dependencies:
* maven-core v3.9.1
* commons-io v2.11.0
* plexus-utils v3.5.1

Plugins
* maven-plugin-plugin v3.8.1
* maven-plugin-annotations v3.8.1
* plexus-component-metadata v2.1.1
* maven-enforcer-plugin v3.2.1
* maven-compiler-plugin v3.11.0
* maven-release-plugin v3.0.0-M7 (validated it works fine with 2.2.3 release)
* maven-javadoc-plugin v3.5.0
* maven-surefire-plugin v3.7.0
* maven-invoker-plugin v3.4.0 (there's a known issue preventing v3.5.0 use)