### PR TITLE
Apply 's4u/setup-maven-action' GH action

### DIFF
--- a/.github/workflows/build.yaml
+++ b/.github/workflows/build.yaml
@@ -30,7 +30,9 @@ jobs:
           - 8
           - 11
           - 17
+        # Support for 1 year old version
         maven:
+          - 3.8.5
           - 3.8.8
           - 3.9.1
     runs-on: ${{ matrix.os }}
@@ -42,5 +44,5 @@ jobs:
           maven-version: ${{ matrix.maven }}
       - name: Maven version
         run: mvn -version
-      - name: Build
+      - name: Build & Test
         run: mvn -B -Prun-its clean verify

--- a/.github/workflows/build.yaml
+++ b/.github/workflows/build.yaml
@@ -22,28 +22,25 @@ jobs:
       fail-fast: false
       max-parallel: 4
       matrix:
-        java:
-          - 8
-          - 11
-          - 17
         os:
           - ubuntu-latest
           - windows-latest
           - macos-latest
+        java:
+          - 8
+          - 11
+          - 17
+        maven:
+          - 3.8.8
+          - 3.9.1
     runs-on: ${{ matrix.os }}
     steps:
-      - uses: actions/checkout@v3
+      - uses: s4u/setup-maven-action@v1.7.0
         with:
-          fetch-depth: 1
-      - uses: actions/setup-java@v3
-        with:
-          distribution: 'temurin'
+          java-distribution: 'temurin'
           java-version: ${{ matrix.java }}
-      - name: Cache dependencies
-        uses: actions/cache@v2
-        with:
-          path: ~/.m2/repository
-          key: ${{ runner.os }}-mvn-cache-${{ hashFiles('**/pom.xml') }}
-          restore-keys: ${{ runner.os }}-mvn-cache-
+          maven-version: ${{ matrix.maven }}
+      - name: Maven version
+        run: mvn -version
       - name: Build
-        run: ./mvnw -B -V -Prun-its clean verify
+        run: mvn -B -Prun-its clean verify

--- a/README.adoc
+++ b/README.adoc
@@ -116,6 +116,11 @@ These are the minimal steps to convert your AsciiDoc documents to HTML with the 
 
 You can find examples ready to copy-paste in the {uri-examples}[Asciidoctor Maven examples] project.
 
+== Maven compatible versions
+
+// 1-year-old versions + most recent minor
+asciidoctor-maven-plugin supports Maven 3.8.5+ and 3.9.x versions.
+
 == Contributing
 
 This plugin is an open source project made possible with the help of users and enthusiasts.

--- a/docs/modules/plugin/pages/compatibility-matrix.adoc
+++ b/docs/modules/plugin/pages/compatibility-matrix.adoc
@@ -1,9 +1,18 @@
 = Compatibility Matrix
 
 Here is the list of supported versions alongside the required {uri-asciidoctorj}[AsciidoctorJ] version.
-Release candidate releases are not accounted. 
+Release candidate releases are not accounted.
 
-== Versions
+== Maven compatible versions
+
+The current policy for Maven compatibility is to support https://maven.apache.org/docs/history.html[1-year-old releases and the most recent minor].
+
+That is:
+
+* Maven v3.8.5 and higher
+* Maven v3.9.x
+
+== AsciidoctorJ compatible versions
 
 |===
 |Asciidoctor Maven Plugin | AsciidoctorJ | Supported


### PR DESCRIPTION
* Use 's4u/setup-maven-action' GH action to test Maven compatibility matrix
* Defined formal Maven compatible version (1-year-old + most recent minor)

**What kind of change does this PR introduce?** (check at least one)
<!-- Update "[ ]" to "[x]" to check a box -->

- [ ] Bugfix
- [x] Feature
- [ ] Documentation
- [ ] Refactor
- [x] Build improvement
- [ ] Other (please describe)


**What is the goal of this pull request?**
Ensure we properly support a few maven versions. There have been some breaking changes in 3.9.1 that brought this to attention.

**Are there any alternative ways to implement this?**
We could have a script step installing sdkman and setting mvn in the path.
But this is extra code we'd need to maintain.

**Are there any implications of this pull request? Anything a user must know?**
Everything is don by `s4u/setup-maven-action` so we are in theory losing some control, but in reality, nothing we really needed. We'll see how it goes.

**Is it related to an existing issue?**
<!-- If Yes, please add a line of the form: `Fixes #Issue` --> 
- [x] Yes
- [ ] No

Fixes #630 

*Finally, please add a corresponding entry to CHANGELOG.adoc*
