### PR TITLE
Add missing v2.2.x reference in README

### DIFF
--- a/CHANGELOG.adoc
+++ b/CHANGELOG.adoc
@@ -44,6 +44,7 @@ Build / Infrastructure::
   * Bump GH 'checkout' and 'setup-java' to v3 & delete unused TravisCI configuration (#627)
   * Bump netty-codec-http to v4.1.90.Final (#628)
   * Bump plugins versions & set CI Maven to v3.9.1 (#629)
+  * Add Maven matrix testing + define Maven compatibility policy (#632)
 
 Maintenance::
   * Replace use of reflection by direct JavaExtensionRegistry calls to register extensions (#596)

--- a/README.adoc
+++ b/README.adoc
@@ -62,6 +62,8 @@ ifeval::['{tag}' == 'main']
 ====
 You're viewing the documentation for the upcoming release.
 If you're looking for the documentation for an older release, please refer to one of the following tags: +
+{uri-repo}/tree/asciidoctor-maven-plugin-2.2.3#readme[2.2.3]
+&hybull;
 {uri-repo}/tree/asciidoctor-maven-plugin-2.1.0#readme[2.1.0]
 &hybull;
 {uri-repo}/tree/asciidoctor-maven-plugin-2.0.0#readme[2.0.0]


### PR DESCRIPTION
* Fix missing CHANGELOG entry for maven #632

Thank you for opening a pull request and contributing to asciidoctor-maven-plugin!

**What kind of change does this PR introduce?** (check at least one)
<!-- Update "[ ]" to "[x]" to check a box -->

- [ ] Bugfix
- [ ] Feature
- [x] Documentation
- [ ] Refactor
- [ ] Build improvement
- [ ] Other (please describe)


**What is the goal of this pull request?**
* Add missing v2.2.x readme reference in README.
* Add missing changelog entry from latest PR.

**Are there any alternative ways to implement this?**
n/a

**Are there any implications of this pull request? Anything a user must know?**
n/a

**Is it related to an existing issue?**
<!-- If Yes, please add a line of the form: `Fixes #Issue` --> 
- [ ] Yes
- [x] No

*Finally, please add a corresponding entry to CHANGELOG.adoc*
