### PR TITLE
Remove use of deprecated 'parent.version' Maven property

### DIFF
--- a/CHANGELOG.adoc
+++ b/CHANGELOG.adoc
@@ -45,7 +45,8 @@ Build / Infrastructure::
   * Bump netty-codec-http to v4.1.90.Final (#628)
   * Bump plugins versions & set CI Maven to v3.9.1 (#629)
   * Add Maven matrix testing + define Maven compatibility policy (#632)
-  * Bump build related Maven plugins to the latest versions (#606)
+  * Bump build related Maven plugins to the latest versions (#635)
+  * Remove use of deprecated 'parent.version' Maven property (#606)
 
 Maintenance::
   * Replace use of reflection by direct JavaExtensionRegistry calls to register extensions (#596)

--- a/asciidoctor-converter-doxia-module/pom.xml
+++ b/asciidoctor-converter-doxia-module/pom.xml
@@ -27,7 +27,7 @@
         <dependency>
             <groupId>org.asciidoctor</groupId>
             <artifactId>asciidoctor-maven-commons</artifactId>
-            <version>${parent.version}</version>
+            <version>${project.parent.version}</version>
         </dependency>
         <dependency>
             <groupId>org.asciidoctor</groupId>

--- a/asciidoctor-maven-plugin/pom.xml
+++ b/asciidoctor-maven-plugin/pom.xml
@@ -27,7 +27,7 @@
         <dependency>
             <groupId>org.asciidoctor</groupId>
             <artifactId>asciidoctor-maven-commons</artifactId>
-            <version>${parent.version}</version>
+            <version>${project.parent.version}</version>
         </dependency>
         <dependency>
             <groupId>org.asciidoctor</groupId>

--- a/asciidoctor-parser-doxia-module/pom.xml
+++ b/asciidoctor-parser-doxia-module/pom.xml
@@ -26,7 +26,7 @@
         <dependency>
             <groupId>org.asciidoctor</groupId>
             <artifactId>asciidoctor-maven-commons</artifactId>
-            <version>${parent.version}</version>
+            <version>${project.parent.version}</version>
         </dependency>
         <dependency>
             <groupId>org.asciidoctor</groupId>


### PR DESCRIPTION

**What kind of change does this PR introduce?** (check at least one)
<!-- Update "[ ]" to "[x]" to check a box -->

- [ ] Bugfix
- [ ] Feature
- [ ] Documentation
- [ ] Refactor
- [x] Build improvement
- [ ] Other (please describe)


**What is the goal of this pull request?**
Fix the following deprecation messages that appear with Maven v3.x
This is required to build the project with Maven v4-alphas.

**Are there any alternative ways to implement this?**
No.

**Are there any implications of this pull request? Anything a user must know?**
No.

**Is it related to an existing issue?**
<!-- If Yes, please add a line of the form: `Fixes #Issue` --> 
- [ ] Yes
- [x] No

*Finally, please add a corresponding entry to CHANGELOG.adoc*
