### PR TITLE
Add IT for maven-site-plugin v3.10.0

### DIFF
--- a/.github/workflows/build.yaml
+++ b/.github/workflows/build.yaml
@@ -20,7 +20,7 @@ jobs:
     name: Build
     strategy:
       fail-fast: false
-      max-parallel: 4
+      max-parallel: 16
       matrix:
         os:
           - ubuntu-latest

--- a/CHANGELOG.adoc
+++ b/CHANGELOG.adoc
@@ -15,8 +15,9 @@ For a detailed view of what has changed, refer to the {uri-repo}/commits/main[co
 
 Build / Infrastructure::
 
- * Add Maven matrix testing + define Maven compatibility policy (#632)
- * Bump Asciidoctorj to v2.5.8 and jRuby to v9.3.10.0 (#639)
+  * Add Maven matrix testing + define Maven compatibility policy (#632)
+  * Bump Asciidoctorj to v2.5.8 and jRuby to v9.3.10.0 (#639)
+  * Add maven-site-pluing v3.10.0 integration test (#641)
 
 == v2.2.3 (2023-03-18)
 

--- a/src/it/maven-site-plugin-v3.10/invoker.properties
+++ b/src/it/maven-site-plugin-v3.10/invoker.properties
@@ -1,0 +1,1 @@
+invoker.goals=clean site:site

--- a/src/it/maven-site-plugin-v3.10/pom.xml
+++ b/src/it/maven-site-plugin-v3.10/pom.xml
@@ -1,0 +1,70 @@
+<?xml version="1.0" encoding="UTF-8"?>
+<project xmlns="http://maven.apache.org/POM/4.0.0" xmlns:xsi="http://www.w3.org/2001/XMLSchema-instance"
+    xsi:schemaLocation="http://maven.apache.org/POM/4.0.0 http://maven.apache.org/xsd/maven-4.0.0.xsd">
+    <modelVersion>4.0.0</modelVersion>
+	<groupId>org.asciidoctor</groupId>
+	<artifactId>maven-site-plugin-it</artifactId>
+	<version>1.0-SNAPSHOT</version>
+    <name>Maven Site Plugin IT</name>
+    <description>Checks asciidoctor integration in Maven Site Plugin through Doxia Parser Module</description>
+
+    <properties>
+        <docs.version>v1.2.3</docs.version>
+    </properties>
+
+    <build>
+        <plugins>
+            <!--
+             Up to v2.2.1, use v2.8.1 as workaround to prevent `java.lang.ClassNotFoundException: org.apache.maven.doxia.siterenderer.DocumentContent`
+             with `maven-site-plugin` v3.6 or lower.
+             This only affects the it tests, normal executions (e.g. in asciidoctor-maven-examples) work fine.
+            -->
+            <plugin>
+                <groupId>org.apache.maven.plugins</groupId>
+                <artifactId>maven-project-info-reports-plugin</artifactId>
+                <version>3.1.2</version>
+            </plugin>
+            <!-- tag::plugin-decl[] -->
+            <plugin>
+                <groupId>org.apache.maven.plugins</groupId>
+                <artifactId>maven-site-plugin</artifactId>
+                <!-- v2.2.2 of the plugin require Maven Site Plugin 3.1x.0 alongside Doxia 1.11.1 -->
+                <version>3.10.0</version>
+                <configuration>
+                    <asciidoc>
+                        <baseDir>${project.basedir}/src/site/asciidoc</baseDir>
+                        <templateDirs>
+                            <dir>src/site/asciidoc/templates</dir>
+                        </templateDirs>
+                        <!-- or...
+                        <templateDir>src/site/asciidoc/templates</templateDir>
+                        -->
+                        <requires>
+                            <require>base64</require>
+                            <require>time</require>
+                        </requires>
+                        <!-- or...
+                        <requires>base64,time</requires>
+                        -->
+                        <attributes>
+                            <source-highlighter>coderay</source-highlighter>
+                            <coderay-css>style</coderay-css>
+                            <toclevels>2</toclevels>
+                        </attributes>
+                    </asciidoc>
+                    <moduleExcludes>
+                        <asciidoc>**/_*.adoc</asciidoc>
+                    </moduleExcludes>
+                </configuration>
+                <dependencies>
+                    <dependency><!-- add Asciidoctor Doxia Parser Module to maven-site-plugin -->
+                        <groupId>org.asciidoctor</groupId>
+                        <artifactId>asciidoctor-maven-plugin</artifactId>
+                        <version>@project.version@</version>
+                    </dependency>
+                </dependencies>
+            </plugin>
+            <!-- end::plugin-decl[] -->
+        </plugins>
+    </build>
+</project>

--- a/src/it/maven-site-plugin-v3.10/src/site/asciidoc/_include.adoc
+++ b/src/it/maven-site-plugin-v3.10/src/site/asciidoc/_include.adoc
@@ -1,0 +1,1 @@
+Content included from the file `_include.adoc`.

--- a/src/it/maven-site-plugin-v3.10/src/site/asciidoc/file-with-toc.adoc
+++ b/src/it/maven-site-plugin-v3.10/src/site/asciidoc/file-with-toc.adoc
@@ -1,0 +1,31 @@
+= File with TOC
+:toc:
+
+[.lead]
+This is an example `.adoc` file that was processed by the Doxia Parser module in the Asciidoctor Maven Plugin.
+Version {docs-version}.
+
+== First section
+
+This is the first section of the page.
+
+include::_include.adoc[]
+
+=== Sub section
+
+This is a subsection of the first section
+
+TIP: You can control the number of section levels displayed in the TOC using the `toclevels` attribute.
+
+== Second section
+
+This is the first section of the page.
+
+=== Sub section
+
+This is a subsection of the second section.
+
+[source,xml,indent=0]
+----
+include::../../../pom.xml[tag=plugin-decl]
+----

--- a/src/it/maven-site-plugin-v3.10/src/site/asciidoc/templates/paragraph.html.slim
+++ b/src/it/maven-site-plugin-v3.10/src/site/asciidoc/templates/paragraph.html.slim
@@ -1,0 +1,1 @@
+p class=role =content

--- a/src/it/maven-site-plugin-v3.10/src/site/site.xml
+++ b/src/it/maven-site-plugin-v3.10/src/site/site.xml
@@ -1,0 +1,8 @@
+<project name="Maven Site Plugin IT">
+    <body>
+        <menu name="AsciiDoc Pages">
+            <item name="File with TOC" href="/file-with-toc.html"/>
+        </menu>
+      ${reports}
+    </body>
+</project>

--- a/src/it/maven-site-plugin-v3.10/validate.bsh
+++ b/src/it/maven-site-plugin-v3.10/validate.bsh
@@ -1,0 +1,111 @@
+import java.io.*;
+import java.nio.charset.StandardCharsets;
+import java.util.ArrayList;
+import java.util.List;
+import java.util.regex.Matcher;
+import java.util.regex.Pattern;
+
+File outputDir = new File(basedir, "target/site");
+
+String[] expectedFiles = {
+	"file-with-toc.html"
+};
+
+String[] unexpectedFiles = {
+    "_include.html"
+};
+
+Pattern tocEntry = Pattern.compile("<li><a href=\"#(.*?)\">.*");
+Pattern elementIdPattern = Pattern.compile(".* id=\"(.*?)\".*");
+
+for (String expectedFile : expectedFiles) {
+    File file = new File(outputDir, expectedFile);
+    System.out.println("Checking for presence of " + file);
+    if (!file.isFile()) {
+        throw new Exception("Missing file " + file);
+    }
+
+    List lines = new ArrayList();
+    Closeable resource = null;
+    try {
+        String line = null;
+        BufferedReader bReader = new BufferedReader(resource = new FileReader(file));
+        while ((line = bReader.readLine()) != null) {
+            lines.add(line);
+        }
+    }
+    finally {
+       try {
+           resource.close();
+       }
+       catch (IOException ignore) {}
+    }
+
+    System.out.println("Ensuring IDs match TOC links");
+
+    List tocEntries = new ArrayList();
+
+    for (String line : lines) {
+        Matcher matcher = null;
+
+        matcher = tocEntry.matcher(line);
+        if (matcher.matches()) {
+            tocEntries.add(matcher.group(1));
+        }
+
+        matcher = elementIdPattern.matcher(line);
+        if (matcher.matches()) {
+            String elementId = matcher.group(1);
+            if (tocEntries.contains(elementId)) {
+                tocEntries.remove(tocEntries.indexOf(elementId));
+            }
+        }
+    }
+
+    if (tocEntries.size() != 0) {
+        throw new Exception("Couldn't find matching IDs for the following TOC entries: " + tocEntries);
+    }
+
+    boolean includeResolved = false;
+    boolean sourceHighlighted = false;
+
+    for (String line : lines) {
+        if (!includeResolved && line.contains("Content included from the file ")) {
+            includeResolved = true;
+        }
+        else if (!sourceHighlighted && line.contains("<span style=\"color:#070;font-weight:bold\">&lt;plugin&gt;</span>")) {
+            sourceHighlighted = true; 
+        }
+    }
+
+    if (!includeResolved) {
+        throw new Exception("Include file was not resolved.");
+    }
+
+    if (!sourceHighlighted) {
+        throw new Exception("Source code was not highlighted.");
+    }
+
+    // validate that maven properties are replaced same as attributes
+    boolean foundReplacement = false;
+    for (String line: lines) {
+    System.out.println(line);
+        if (line.contains("v1.2.3")) {
+            foundReplacement = true;
+            break;
+        }
+    }
+    if (!foundReplacement) {
+        throw new Exception("Maven properties not replaced.");
+    }
+}
+
+for (String unexpectedFile : unexpectedFiles) {
+    File file = new File(outputDir, unexpectedFile);
+    System.out.println("Checking for absence of " + file);
+    if (file.isFile()) {
+        throw new Exception("Unexpected file " + file);
+    }
+}
+
+return true;


### PR DESCRIPTION
**What kind of change does this PR introduce?** (check at least one)
<!-- Update "[ ]" to "[x]" to check a box -->

- [ ] Bugfix
- [ ] Feature
- [ ] Documentation
- [ ] Refactor
- [x] Build improvement
- [ ] Other (please describe)


**What is the goal of this pull request?**

This  new test validates the minimal maven-site-plugin supported version.

**Are there any alternative ways to implement this?**

We could somehow parametrize the version and run the IT's twice, but that seems a lot of work.
In the long run, I'd like to have an extension similar to what we do in the [maven examples](https://github.com/asciidoctor/asciidoctor-maven-examples/tree/main/tests/src/test/java/org/asciidoctor/maven/examples/tests) to run end-to-end tests more easily and quicker.

**Are there any implications of this pull request? Anything a user must know?**
no

**Is it related to an existing issue?**
<!-- If Yes, please add a line of the form: `Fixes #Issue` --> 
- [ ] Yes
- [x] No

*Finally, please add a corresponding entry to CHANGELOG.adoc*
