### PR TITLE
Bump build plugins and dependencies

### DIFF
--- a/pom.xml
+++ b/pom.xml
@@ -77,13 +77,13 @@
         <asciidoctorj.version>2.5.8</asciidoctorj.version>
         <jruby.version>9.3.10.0</jruby.version>
         <maven.coveralls.plugin.version>4.3.0</maven.coveralls.plugin.version>
-        <maven.jacoco.plugin.version>0.8.8</maven.jacoco.plugin.version>
-        <maven.plugin.plugin.version>3.5</maven.plugin.plugin.version>
-        <maven.project.version>3.0.5</maven.project.version>
+        <maven.jacoco.plugin.version>0.8.10</maven.jacoco.plugin.version>
+        <maven.plugin.plugin.version>3.9.0</maven.plugin.plugin.version>
+        <maven.project.version>3.8.5</maven.project.version>
         <maven.filtering.version>3.2.0</maven.filtering.version>
-        <plexus.utils.version>3.0.23</plexus.utils.version>
-        <plexus.component.metadata.version>1.7</plexus.component.metadata.version>
-        <netty.version>4.1.90.Final</netty.version>
+        <plexus.utils.version>3.5.1</plexus.utils.version>
+        <plexus.component.metadata.version>2.1.1</plexus.component.metadata.version>
+        <netty.version>4.1.93.Final</netty.version>
         <doxia.version>1.12.0</doxia.version>
     </properties>
 
@@ -92,7 +92,7 @@
             <dependency>
                 <groupId>org.junit</groupId>
                 <artifactId>junit-bom</artifactId>
-                <version>5.8.2</version>
+                <version>5.9.3</version>
                 <type>pom</type>
                 <scope>import</scope>
             </dependency>
@@ -158,7 +158,7 @@
         <dependency>
             <groupId>org.assertj</groupId>
             <artifactId>assertj-core</artifactId>
-            <version>3.23.1</version>
+            <version>3.24.2</version>
             <scope>test</scope>
         </dependency>
         <dependency>
@@ -180,7 +180,7 @@
             <plugin>
                 <groupId>org.apache.maven.plugins</groupId>
                 <artifactId>maven-enforcer-plugin</artifactId>
-                <version>3.2.1</version>
+                <version>3.3.0</version>
                 <executions>
                     <execution>
                         <id>enforce-maven</id>
@@ -255,7 +255,7 @@
                 <plugin>
                     <groupId>org.apache.maven.plugins</groupId>
                     <artifactId>maven-release-plugin</artifactId>
-                    <version>3.0.0-M7</version>
+                    <version>3.0.0</version>
                     <configuration>
                         <mavenExecutorId>forked-path</mavenExecutorId>
                     </configuration>
@@ -277,19 +277,6 @@
                     <configuration>
                         <lifecycleMappingMetadata>
                             <pluginExecutions>
-                                <pluginExecution>
-                                    <pluginExecutionFilter>
-                                        <groupId>org.codehaus.gmaven</groupId>
-                                        <artifactId>gmaven-plugin</artifactId>
-                                        <versionRange>[${gmaven.version},)</versionRange>
-                                        <goals>
-                                            <goal>testCompile</goal>
-                                        </goals>
-                                    </pluginExecutionFilter>
-                                    <action>
-                                        <execute />
-                                    </action>
-                                </pluginExecution>
                                 <pluginExecution>
                                     <pluginExecutionFilter>
                                         <groupId>org.codehaus.plexus</groupId>
@@ -325,7 +312,7 @@
                 <plugin>
                     <groupId>org.apache.maven.plugins</groupId>
                     <artifactId>maven-source-plugin</artifactId>
-                    <version>3.2.1</version>
+                    <version>3.3.0</version>
                 </plugin>
                 <plugin>
                     <groupId>org.apache.maven.plugins</groupId>
@@ -340,7 +327,7 @@
                 <plugin>
                     <groupId>org.apache.maven.plugins</groupId>
                     <artifactId>maven-surefire-plugin</artifactId>
-                    <version>3.0.0</version>
+                    <version>3.1.0</version>
                 </plugin>
                 <plugin>
                     <groupId>org.apache.maven.plugins</groupId>
@@ -350,7 +337,7 @@
                 <plugin>
                     <groupId>org.apache.maven.plugins</groupId>
                     <artifactId>maven-invoker-plugin</artifactId>
-                    <version>3.4.0</version>
+                    <version>3.5.1</version>
                 </plugin>
             </plugins>
         </pluginManagement>


### PR DESCRIPTION
**What kind of change does this PR introduce?** (check at least one)
<!-- Update "[ ]" to "[x]" to check a box -->

- [ ] Bugfix
- [ ] Feature
- [ ] Documentation
- [ ] Refactor
- [x] Build improvement
- [ ] Other (please describe)


**What is the goal of this pull request?**

A set of maintenance bumps to build plugins and dependencies
    
    Build plugins
    * jacoco-maven-plugin 0.8.10
    * maven-enforcer-plugin 3.3.0
    * maven-invoker-plugin 3.5.1
    * maven-release-plugin 3.0.0
    * maven-source-plugin 3.3.0
    * maven-surefire-plugin 3.1.0
    
    Maven dependencies
    * maven-plugin-plugin, maven-plugin-annotations 3.9.0
    * maven-core, maven-plugin-api 3.8.5
    * plexus-utils 3.8.1
    
    Plugin dependencies
    * netty-codec-http 4.1.93.Final
    
    Test dependencies
    * junit-bom 5.9.3
    * assertj-core 3.24.2


**Are there any alternative ways to implement this?**

no

**Are there any implications of this pull request? Anything a user must know?**
no

**Is it related to an existing issue?**
<!-- If Yes, please add a line of the form: `Fixes #Issue` --> 
- [ ] Yes
- [X] No


