### PR TITLE
(main) Bump Asciidoctorj to v3.0.x

### DIFF
--- a/CHANGELOG.adoc
+++ b/CHANGELOG.adoc
@@ -16,6 +16,7 @@ For a detailed view of what has changed, refer to the {uri-repo}/commits/main[co
 Build / Infrastructure::
 
   * Fix javadoc check flake in CI (#814)
+  * Bump AsciidoctorJ to v3.0.0 (#651)
 
 == v3.0.0 (2024-01-30)
 

--- a/asciidoctor-converter-doxia-module/src/main/java/org/asciidoctor/maven/site/AsciidoctorConverterDoxiaParser.java
+++ b/asciidoctor-converter-doxia-module/src/main/java/org/asciidoctor/maven/site/AsciidoctorConverterDoxiaParser.java
@@ -13,7 +13,9 @@ import org.apache.maven.doxia.parser.Parser;
 import org.apache.maven.doxia.sink.Sink;
 import org.apache.maven.project.MavenProject;
 import org.asciidoctor.Asciidoctor;
+import org.asciidoctor.Attributes;
 import org.asciidoctor.AttributesBuilder;
+import org.asciidoctor.Options;
 import org.asciidoctor.OptionsBuilder;
 import org.asciidoctor.SafeMode;
 import org.asciidoctor.maven.log.LogHandler;
@@ -128,14 +130,14 @@ public class AsciidoctorConverterDoxiaParser extends AbstractTextParser {
     }
 
     protected OptionsBuilder defaultOptions(File siteDirectory) {
-        return OptionsBuilder.options()
+        return Options.builder()
             .backend("xhtml")
             .safe(SafeMode.UNSAFE)
-            .baseDir(new File(siteDirectory, ROLE_HINT));
+            .baseDir(new File(siteDirectory, ROLE_HINT).getAbsoluteFile());
     }
 
     protected AttributesBuilder defaultAttributes() {
-        return AttributesBuilder.attributes()
+        return Attributes.builder()
             .attribute("idprefix", "@")
             .attribute("showtitle", "@");
     }

--- a/asciidoctor-maven-commons/src/main/java/org/asciidoctor/maven/site/SiteConversionConfigurationParser.java
+++ b/asciidoctor-maven-commons/src/main/java/org/asciidoctor/maven/site/SiteConversionConfigurationParser.java
@@ -1,21 +1,21 @@
 package org.asciidoctor.maven.site;
 
-import java.io.File;
-import java.util.ArrayList;
-import java.util.Arrays;
-import java.util.Collections;
-import java.util.List;
-import java.util.Optional;
-import java.util.stream.Collectors;
-import java.util.stream.Stream;
-
 import org.apache.maven.project.MavenProject;
+import org.asciidoctor.Attributes;
 import org.asciidoctor.AttributesBuilder;
 import org.asciidoctor.Options;
 import org.asciidoctor.OptionsBuilder;
 import org.asciidoctor.maven.commons.AsciidoctorHelper;
 import org.asciidoctor.maven.commons.StringUtils;
 import org.codehaus.plexus.util.xml.Xpp3Dom;
+
+import java.io.File;
+import java.util.ArrayList;
+import java.util.Arrays;
+import java.util.Collections;
+import java.util.List;
+import java.util.stream.Collectors;
+import java.util.stream.Stream;
 
 import static org.asciidoctor.maven.commons.StringUtils.isNotBlank;
 
@@ -33,17 +33,21 @@ public class SiteConversionConfigurationParser {
 
         AsciidoctorHelper.addProperties(project.getProperties(), presetAttributes);
 
-        final Xpp3Dom siteConfiguration = Optional.ofNullable(siteConfig)
-                .map(sc -> sc.getChild("asciidoc"))
-                .orElse(null);
+        final Attributes attributes = presetAttributes.build();
 
-        if (siteConfiguration == null) {
-            final OptionsBuilder options = presetOptions.attributes(presetAttributes.build());
-            return new SiteConversionConfiguration(options.build(), Collections.emptyList());
+        if (siteConfig == null) {
+            final Options options = presetOptions.attributes(attributes).build();
+            return new SiteConversionConfiguration(options, Collections.emptyList());
+        }
+
+        final Xpp3Dom asciidocConfig = siteConfig.getChild("asciidoc");
+        if (asciidocConfig == null) {
+            final Options options = presetOptions.attributes(attributes).build();
+            return new SiteConversionConfiguration(options, Collections.emptyList());
         }
 
         final List<String> gemsToRequire = new ArrayList<>();
-        for (Xpp3Dom asciidocOpt : siteConfiguration.getChildren()) {
+        for (Xpp3Dom asciidocOpt : asciidocConfig.getChildren()) {
             String optName = asciidocOpt.getName();
 
             if ("requires".equals(optName)) {
@@ -83,12 +87,12 @@ public class SiteConversionConfigurationParser {
             }
         }
 
-        final Options options = presetOptions.attributes(presetAttributes.build()).build();
+        final Options options = presetOptions.attributes(attributes).build();
         return new SiteConversionConfiguration(options, gemsToRequire);
     }
 
     private File resolveProjectDir(MavenProject project, String path) {
         final File filePath = new File(path);
-        return !filePath.isAbsolute() ? new File(project.getBasedir(), filePath.toString()): filePath;
+        return !filePath.isAbsolute() ? new File(project.getBasedir(), filePath.toString()).getAbsoluteFile() : filePath;
     }
 }

--- a/asciidoctor-maven-plugin/src/test/java/org/asciidoctor/maven/AsciidoctorMojoExtensionsTest.java
+++ b/asciidoctor-maven-plugin/src/test/java/org/asciidoctor/maven/AsciidoctorMojoExtensionsTest.java
@@ -22,6 +22,7 @@ import org.junit.jupiter.api.Test;
 
 import static java.util.Collections.singletonList;
 import static org.asciidoctor.maven.io.TestFilesHelper.newOutputTestDirectory;
+import static org.asciidoctor.maven.test.TestUtils.ResourceBuilder.excludeAll;
 import static org.asciidoctor.maven.test.TestUtils.mockAsciidoctorMojo;
 import static org.assertj.core.api.Assertions.assertThat;
 
@@ -167,6 +168,7 @@ class AsciidoctorMojoExtensionsTest {
         mojo.backend = "html";
         mojo.sourceDirectory = srcDir;
         mojo.sourceDocumentName = "processors-sample.adoc";
+        mojo.resources = excludeAll();
         mojo.outputDirectory = outputDir;
         mojo.standalone = true;
         mojo.extensions = Arrays.asList(extensionConfiguration(ChangeAttributeValuePreprocessor.class));

--- a/asciidoctor-maven-plugin/src/test/java/org/asciidoctor/maven/io/TestFilesHelper.java
+++ b/asciidoctor-maven-plugin/src/test/java/org/asciidoctor/maven/io/TestFilesHelper.java
@@ -11,11 +11,17 @@ public class TestFilesHelper {
     public static final String TEST_OUTPUT_BASE_PATH = "target/test-outputs/";
 
     public static File newOutputTestDirectory() {
-        return createDirectory(TEST_OUTPUT_BASE_PATH + UUID.randomUUID());
+        return normalize(createDirectory(TEST_OUTPUT_BASE_PATH + UUID.randomUUID()));
     }
 
     public static File newOutputTestDirectory(String subDir) {
-        return createDirectory(TEST_OUTPUT_BASE_PATH + subDir + "/" + UUID.randomUUID());
+        return normalize(createDirectory(TEST_OUTPUT_BASE_PATH + subDir + "/" + UUID.randomUUID()));
+    }
+
+    // Since v3.0.0, path must be absolute https://github.com/asciidoctor/asciidoctorj/pull/1249.
+    // Note: in real Mojo execution, paths are always absolute.
+    private static File normalize(File file) {
+        return file.getAbsoluteFile();
     }
 
     private static File createDirectory(String path) {

--- a/asciidoctor-maven-plugin/src/test/java/org/asciidoctor/maven/test/processors/ChangeAttributeValuePreprocessor.java
+++ b/asciidoctor-maven-plugin/src/test/java/org/asciidoctor/maven/test/processors/ChangeAttributeValuePreprocessor.java
@@ -5,6 +5,7 @@ import java.util.Map;
 import org.asciidoctor.ast.Document;
 import org.asciidoctor.extension.Preprocessor;
 import org.asciidoctor.extension.PreprocessorReader;
+import org.asciidoctor.extension.Reader;
 
 public class ChangeAttributeValuePreprocessor extends Preprocessor {
 
@@ -16,9 +17,10 @@ public class ChangeAttributeValuePreprocessor extends Preprocessor {
     }
 
     @Override
-    public void process(Document document, PreprocessorReader reader) {
+    public Reader process(Document document, PreprocessorReader reader) {
         System.out.println("Processing " + this.getClass().getSimpleName());
         System.out.println("Processing: blocks found: " + document.getBlocks().size());
         document.getAttributes().put("author", AUTHOR_NAME);
+        return reader;
     }
 }

--- a/asciidoctor-maven-plugin/src/test/java/org/asciidoctor/maven/test/processors/FailingPreprocessor.java
+++ b/asciidoctor-maven-plugin/src/test/java/org/asciidoctor/maven/test/processors/FailingPreprocessor.java
@@ -5,6 +5,7 @@ import java.util.Map;
 import org.asciidoctor.ast.Document;
 import org.asciidoctor.extension.Preprocessor;
 import org.asciidoctor.extension.PreprocessorReader;
+import org.asciidoctor.extension.Reader;
 
 public class FailingPreprocessor extends Preprocessor {
 
@@ -14,7 +15,7 @@ public class FailingPreprocessor extends Preprocessor {
     }
 
     @Override
-    public void process(Document document, PreprocessorReader reader) {
+    public Reader process(Document document, PreprocessorReader reader) {
         System.out.println("Processing " + this.getClass().getSimpleName());
         System.out.println("Processing: blocks found: " + document.getBlocks().size());
         throw new RuntimeException("That's all folks");

--- a/asciidoctor-maven-plugin/src/test/java/org/asciidoctor/maven/test/processors/ManpageInlineMacroProcessor.java
+++ b/asciidoctor-maven-plugin/src/test/java/org/asciidoctor/maven/test/processors/ManpageInlineMacroProcessor.java
@@ -1,10 +1,11 @@
 package org.asciidoctor.maven.test.processors;
 
+import org.asciidoctor.ast.PhraseNode;
+import org.asciidoctor.ast.StructuralNode;
+import org.asciidoctor.extension.InlineMacroProcessor;
+
 import java.util.HashMap;
 import java.util.Map;
-
-import org.asciidoctor.ast.ContentNode;
-import org.asciidoctor.extension.InlineMacroProcessor;
 
 public class ManpageInlineMacroProcessor extends InlineMacroProcessor {
 
@@ -13,11 +14,10 @@ public class ManpageInlineMacroProcessor extends InlineMacroProcessor {
     }
 
     @Override
-    public String process(ContentNode parent, String target, Map<String, Object> attributes) {
-
+    public PhraseNode process(StructuralNode parent, String target, Map<String, Object> attributes) {
         final Map<String, Object> options = new HashMap<>();
         options.put("type", ":link");
         options.put("target", target + ".html");
-        return createPhraseNode(parent, "anchor", target, attributes, options).convert();
+        return createPhraseNode(parent, "anchor", target, attributes, options);
     }
 }

--- a/asciidoctor-maven-plugin/src/test/java/org/asciidoctor/maven/test/processors/UriIncludeProcessor.java
+++ b/asciidoctor-maven-plugin/src/test/java/org/asciidoctor/maven/test/processors/UriIncludeProcessor.java
@@ -28,7 +28,7 @@ public class UriIncludeProcessor extends IncludeProcessor {
                         Map<String, Object> attributes) {
         System.out.println("Processing " + this.getClass().getSimpleName());
         final String content = readContent(target);
-        reader.push_include(content, target, target, 1, attributes);
+        reader.pushInclude(content, target, target, 1, attributes);
     }
 
     private String readContent(String target) {

--- a/docs/modules/plugin/pages/compatibility-matrix.adoc
+++ b/docs/modules/plugin/pages/compatibility-matrix.adoc
@@ -20,11 +20,11 @@ Versions not listed below are not supported, please consider upgrading.
 |Asciidoctor Maven Plugin | AsciidoctorJ | Supported
 
 |v3.x.x
-|v2.x.x
+|v2.x.x, v3.x.x
 |Yes
 
 |v2.2.x
 |v2.x.x
-|Yes
+|Yes (EOL Dec, 2015)
 
 |===

--- a/pom.xml
+++ b/pom.xml
@@ -73,7 +73,7 @@
         <maven.version>3.9.9</maven.version>
         <doxia.version>1.12.0</doxia.version>
         <plexus-component-metadata.version>2.2.0</plexus-component-metadata.version>
-        <asciidoctorj.version>2.5.13</asciidoctorj.version>
+        <asciidoctorj.version>3.0.0</asciidoctorj.version>
         <jruby.version>9.4.6.0</jruby.version>
     </properties>
 


### PR DESCRIPTION
~Experimental branch to test changes for Asciidoctorj v3.0.x (not for merging yet).~

Bump Asciidoctorj to v3.0.x:
* Fix pathing issues related to https://github.com/asciidoctor/asciidoctorj/pull/1249. TLDR; `toDir` for `AsciidoctorMojo`  and `baseDir` for Site Converter need to be absolute.
* Tests
  * Update extensions examples used for integration testing
  * Fix pathing issues (same as above :point_up: )
  * Fix use of deprecated Options and Attributes builders in 'asciidoctor-converter-doxia-module'

:information_source: I run additional manual tests on AsciidoctorJ 2.5.13 and all is working fine since AsciidoctorJ v3 is binary compatible with 2.5.x :tada: 

NOTE: in case someone saw the previous description listing breaking changes, those no longer apply since they were already addressed in maven-plugin 3.0.0 or are internals that don't break the XML configuration of the Maven plugin :relieved: 