### PR TITLE
Set Java 11 as minimal version

### DIFF
--- a/.github/workflows/build.yaml
+++ b/.github/workflows/build.yaml
@@ -27,7 +27,6 @@ jobs:
           - windows-latest
           - macos-latest
         java:
-          - 8
           - 11
           - 17
         # Support for 1 year old version

--- a/CHANGELOG.adoc
+++ b/CHANGELOG.adoc
@@ -29,6 +29,7 @@ Improvements::
 Build / Infrastructure::
 
   * Fix maven-source-plugin configuration for releases (#644)
+  * Set Java 11 as minimal version (remove Java8 support) (#652)
 
 Documentation::
 

--- a/docs/modules/plugin/pages/v3-migration-guide.adoc
+++ b/docs/modules/plugin/pages/v3-migration-guide.adoc
@@ -18,9 +18,18 @@ Users of the site module see xref:site-integration:v3-migration-guide.adoc[v3 mi
 
 == Changes
 
+=== Minimal Java version
+
+Minimal Java version is 11.
+
+For anyone in need of a Java 8 compatible release, v2.5.x of the plugin will be supported for some time after v3.0.x release.
+Note this also imposes versions on dependencies, for example:
+* Only AsciidoctorJ v2.5.x
+* Only asciidoctorj-diagram previous v2.2.8
+
 === Minimal AsciidoctorJ version
 
-Support for Asciidoctorj v1.6.x (released 14th Feb, 2019) has been totally removed and will fail when configured.
+Support for AsciidoctorJ v1.6.x (released 14th Feb, 2019) has been totally removed and will fail when configured.
 This simplifies the current plugin code and allows for removal of Java reflection usage.
 
 *If you are setting the AsciidoctorJ dependency directly, ensure it's v2.0.0 or higher*.

--- a/pom.xml
+++ b/pom.xml
@@ -74,7 +74,7 @@
 
     <properties>
         <project.build.sourceEncoding>UTF-8</project.build.sourceEncoding>
-        <project.java.version>1.8</project.java.version>
+        <project.java.version>11</project.java.version>
         <project.execution.environment>JavaSE-1.8</project.execution.environment>
         <asciidoctorj.version>2.5.10</asciidoctorj.version>
         <jruby.version>9.4.2.0</jruby.version>
@@ -147,8 +147,7 @@
                 <artifactId>maven-compiler-plugin</artifactId>
                 <version>3.11.0</version>
                 <configuration>
-                    <source>${project.java.version}</source>
-                    <target>${project.java.version}</target>
+                    <release>${project.java.version}</release>
                 </configuration>
             </plugin>
         </plugins>


### PR DESCRIPTION
**What kind of change does this PR introduce?** (check at least one)
<!-- Update "[ ]" to "[x]" to check a box -->

- [ ] Bugfix
- [ ] Feature
- [ ] Documentation
- [ ] Refactor
- [ ] Build improvement
- [x] Other (please describe)
  :point_right:  Breaking change


**What is the goal of this pull request?**
Set Java 11 as minimal version.
* Update maven-compiler-plugin to use 'release'
* Remove Java8 from CI
* Add info to migration guide

**Are there any alternative ways to implement this?**
no

**Are there any implications of this pull request? Anything a user must know?**

Users in need of Java8 will need to use v2.5.x of both the Maven plugin and Asciidoctor.

**Is it related to an existing issue?**
<!-- If Yes, please add a line of the form: `Fixes #Issue` --> 
- [x] Yes
- [ ] No

#652 