### PR TITLE
(v3.0.x) Replace deprecated 'headerFooter' by 'standalone' in configuration

### DIFF
--- a/CHANGELOG.adoc
+++ b/CHANGELOG.adoc
@@ -25,6 +25,7 @@ Improvements::
   * Fix throwing an exception when registering a non Extension (#596)
   * Reimplement resource copy using 'plexus.util.DirectorScanner' instead of 'maven-filtering' to reduce dependencies and build time (#597)
   * Set minimal Maven version to v3.8.5 (#629)
+  * Replace deprecated 'headerFooter' by 'standalone' in configuration (#649)
 
 Build / Infrastructure::
 

--- a/asciidoctor-maven-plugin/src/it/thread-safe/asciidoctor-project-1/pom.xml
+++ b/asciidoctor-maven-plugin/src/it/thread-safe/asciidoctor-project-1/pom.xml
@@ -35,7 +35,7 @@
               <sourceDirectory>src/main/doc</sourceDirectory>
               <outputDirectory>target/docs</outputDirectory>
               <backend>html</backend>
-              <headerFooter>false</headerFooter>
+              <standalone>false</standalone>
             </configuration>
           </execution>
         </executions>

--- a/asciidoctor-maven-plugin/src/it/thread-safe/asciidoctor-project-2/pom.xml
+++ b/asciidoctor-maven-plugin/src/it/thread-safe/asciidoctor-project-2/pom.xml
@@ -35,7 +35,7 @@
               <sourceDirectory>src/main/doc</sourceDirectory>
               <outputDirectory>target/docs</outputDirectory>
               <backend>html</backend>
-              <headerFooter>false</headerFooter>
+              <standalone>false</standalone>
             </configuration>
           </execution>
         </executions>

--- a/asciidoctor-maven-plugin/src/it/thread-safe/asciidoctor-project-3/pom.xml
+++ b/asciidoctor-maven-plugin/src/it/thread-safe/asciidoctor-project-3/pom.xml
@@ -35,7 +35,7 @@
               <sourceDirectory>src/main/doc</sourceDirectory>
               <outputDirectory>target/docs</outputDirectory>
               <backend>html</backend>
-              <headerFooter>false</headerFooter>
+              <standalone>false</standalone>
             </configuration>
           </execution>
         </executions>

--- a/asciidoctor-maven-plugin/src/main/java/org/asciidoctor/maven/AsciidoctorMojo.java
+++ b/asciidoctor-maven-plugin/src/main/java/org/asciidoctor/maven/AsciidoctorMojo.java
@@ -10,7 +10,6 @@ import org.asciidoctor.*;
 import org.asciidoctor.jruby.AsciidoctorJRuby;
 import org.asciidoctor.jruby.internal.JRubyRuntimeContext;
 import org.asciidoctor.maven.commons.AsciidoctorHelper;
-import org.asciidoctor.maven.commons.StringUtils;
 import org.asciidoctor.maven.extensions.AsciidoctorJExtensionRegistry;
 import org.asciidoctor.maven.extensions.ExtensionConfiguration;
 import org.asciidoctor.maven.extensions.ExtensionRegistry;
@@ -31,7 +30,6 @@ import java.io.IOException;
 import java.nio.file.Path;
 import java.util.*;
 import java.util.logging.Logger;
-import java.util.stream.Collectors;
 
 import static org.asciidoctor.maven.commons.StringUtils.isBlank;
 import static org.asciidoctor.maven.process.SourceDirectoryFinder.DEFAULT_SOURCE_DIR;
@@ -91,8 +89,8 @@ public class AsciidoctorMojo extends AbstractMojo {
     @Parameter(property = AsciidoctorMaven.PREFIX + Options.ERUBY)
     protected String eruby;
 
-    @Parameter(property = AsciidoctorMaven.PREFIX + "headerFooter")
-    protected boolean headerFooter = true;
+    @Parameter(property = AsciidoctorMaven.PREFIX + "standalone", defaultValue = "true")
+    protected boolean standalone = true;
 
     @Parameter(property = AsciidoctorMaven.PREFIX + "templateDirs")
     protected List<File> templateDirs = new ArrayList<>();
@@ -389,7 +387,7 @@ public class AsciidoctorMojo extends AbstractMojo {
         final OptionsBuilder optionsBuilder = OptionsBuilder.options()
                 .backend(configuration.getBackend())
                 .safe(SafeMode.UNSAFE)
-                .headerFooter(configuration.isHeaderFooter())
+                .standalone(configuration.standalone)
                 .mkDirs(true);
 
         if (!isBlank(configuration.getEruby()))
@@ -508,14 +506,6 @@ public class AsciidoctorMojo extends AbstractMojo {
 
     public void setAttributes(Map<String, Object> attributes) {
         this.attributes = attributes;
-    }
-
-    public boolean isHeaderFooter() {
-        return headerFooter;
-    }
-
-    public void setHeaderFooter(boolean headerFooter) {
-        this.headerFooter = headerFooter;
     }
 
     public String getTemplateEngine() {

--- a/asciidoctor-maven-plugin/src/test/java/org/asciidoctor/maven/AsciidoctorIntegrationTest.java
+++ b/asciidoctor-maven-plugin/src/test/java/org/asciidoctor/maven/AsciidoctorIntegrationTest.java
@@ -357,7 +357,7 @@ public class AsciidoctorIntegrationTest {
         mojo.sourceDirectory = srcDir;
         mojo.sourceDocumentName = "book.adoc";
         mojo.outputDirectory = outputDir;
-        mojo.headerFooter = true;
+        mojo.standalone = true;
         mojo.attributes = map("linkcss", "", "copycss!", "");
         mojo.execute();
 

--- a/asciidoctor-maven-plugin/src/test/java/org/asciidoctor/maven/AsciidoctorMojoExtensionsTest.java
+++ b/asciidoctor-maven-plugin/src/test/java/org/asciidoctor/maven/AsciidoctorMojoExtensionsTest.java
@@ -42,7 +42,7 @@ public class AsciidoctorMojoExtensionsTest {
         mojo.sourceDirectory = srcDir;
         mojo.sourceDocumentName = "processors-sample.adoc";
         mojo.outputDirectory = outputDir;
-        mojo.headerFooter = true;
+        mojo.standalone = true;
         mojo.attributes = map("toc", null, "linkcss!", "");
         mojo.extensions = Arrays.asList(extensionConfiguration("non.existent.Processor"));
         Throwable throwable = Assertions.catchThrowable(mojo::execute);
@@ -66,7 +66,7 @@ public class AsciidoctorMojoExtensionsTest {
         mojo.sourceDirectory = srcDir;
         mojo.sourceDocumentName = "processors-sample.adoc";
         mojo.outputDirectory = outputDir;
-        mojo.headerFooter = true;
+        mojo.standalone = true;
         mojo.attributes = map("toc", null, "linkcss!", "");
         mojo.extensions = Arrays.asList(extensionConfiguration(FailingPreprocessor.class));
         Throwable throwable = Assertions.catchThrowable(mojo::execute);
@@ -140,7 +140,7 @@ public class AsciidoctorMojoExtensionsTest {
         mojo.sourceDirectory = srcDir;
         mojo.sourceDocumentName = "processors-sample.adoc";
         mojo.outputDirectory = outputDir;
-        mojo.headerFooter = true;
+        mojo.standalone = true;
         mojo.attributes = map("toc", null);
         mojo.extensions = singletonList(extensionConfiguration("org.asciidoctor.maven.test.processors." + extensionClassName));
         mojo.execute();
@@ -163,7 +163,7 @@ public class AsciidoctorMojoExtensionsTest {
         mojo.sourceDirectory = srcDir;
         mojo.sourceDocumentName = "processors-sample.adoc";
         mojo.outputDirectory = outputDir;
-        mojo.headerFooter = true;
+        mojo.standalone = true;
         mojo.attributes = map("toc", null);
         mojo.extensions = Arrays.asList(extensionConfiguration(ChangeAttributeValuePreprocessor.class));
         mojo.execute();
@@ -184,7 +184,7 @@ public class AsciidoctorMojoExtensionsTest {
         mojo.sourceDirectory = srcDir;
         mojo.sourceDocumentName = "processors-sample.adoc";
         mojo.outputDirectory = outputDir;
-        mojo.headerFooter = true;
+        mojo.standalone = true;
         mojo.attributes = map("toc", null);
         mojo.extensions = singletonList(extensionConfiguration(YellBlockProcessor.class, "yell"));
         mojo.execute();
@@ -205,7 +205,7 @@ public class AsciidoctorMojoExtensionsTest {
         mojo.sourceDirectory = srcDir;
         mojo.sourceDocumentName = "processors-sample.adoc";
         mojo.outputDirectory = outputDir;
-        mojo.headerFooter = true;
+        mojo.standalone = true;
         mojo.attributes = map("toc", null);
         mojo.extensions = singletonList(extensionConfiguration(MetaDocinfoProcessor.class, "yell"));
         mojo.execute();
@@ -226,7 +226,7 @@ public class AsciidoctorMojoExtensionsTest {
         mojo.sourceDirectory = srcDir;
         mojo.sourceDocumentName = "processors-sample.adoc";
         mojo.outputDirectory = outputDir;
-        mojo.headerFooter = true;
+        mojo.standalone = true;
         mojo.attributes = map("toc", null);
         mojo.extensions = singletonList(extensionConfiguration(GistBlockMacroProcessor.class, "gist"));
         mojo.execute();
@@ -247,7 +247,7 @@ public class AsciidoctorMojoExtensionsTest {
         mojo.sourceDirectory = srcDir;
         mojo.sourceDocumentName = "processors-sample.adoc";
         mojo.outputDirectory = outputDir;
-        mojo.headerFooter = true;
+        mojo.standalone = true;
         mojo.attributes = map("toc", null);
         mojo.extensions = singletonList(extensionConfiguration(ManpageInlineMacroProcessor.class, "man"));
         mojo.execute();
@@ -268,7 +268,7 @@ public class AsciidoctorMojoExtensionsTest {
         mojo.sourceDirectory = srcDir;
         mojo.sourceDocumentName = "processors-sample.adoc";
         mojo.outputDirectory = outputDir;
-        mojo.headerFooter = true;
+        mojo.standalone = true;
         mojo.attributes = map("toc", null);
         mojo.extensions = singletonList(extensionConfiguration(UriIncludeProcessor.class));
         mojo.execute();
@@ -290,7 +290,7 @@ public class AsciidoctorMojoExtensionsTest {
         mojo.sourceDirectory = srcDir;
         mojo.sourceDocumentName = "processors-sample.adoc";
         mojo.outputDirectory = outputDir;
-        mojo.headerFooter = true;
+        mojo.standalone = true;
         mojo.attributes = map("toc", null);
         mojo.extensions = Arrays.asList(
                 extensionConfiguration(ChangeAttributeValuePreprocessor.class),
@@ -320,7 +320,7 @@ public class AsciidoctorMojoExtensionsTest {
         mojo.sourceDirectory = srcDir;
         mojo.sourceDocumentName = "processors-sample.adoc";
         mojo.outputDirectory = outputDir;
-        mojo.headerFooter = true;
+        mojo.standalone = true;
         mojo.attributes = map("toc", null);
         mojo.extensions = Arrays.asList(
                 extensionConfiguration("org.asciidoctor.maven.test.processors.ChangeAttributeValuePreprocessor"),
@@ -348,7 +348,7 @@ public class AsciidoctorMojoExtensionsTest {
         mojo.sourceDirectory = srcDir;
         mojo.sourceDocumentName = "processors-sample.adoc";
         mojo.outputDirectory = outputDir;
-        mojo.headerFooter = true;
+        mojo.standalone = true;
         mojo.attributes = map("toc", "",
                 "linkcss", "",
                 "copycss!", "");
@@ -386,7 +386,7 @@ public class AsciidoctorMojoExtensionsTest {
         mojo.sourceDirectory = srcDir;
         mojo.sourceDocumentName = "processors-sample.adoc";
         mojo.outputDirectory = outputDir;
-        mojo.headerFooter = true;
+        mojo.standalone = true;
         mojo.attributes = map("toc", null, "linkcss!", "");
         mojo.execute();
         // then

--- a/asciidoctor-maven-plugin/src/test/java/org/asciidoctor/maven/AsciidoctorMojoLogHandlerTest.java
+++ b/asciidoctor-maven-plugin/src/test/java/org/asciidoctor/maven/AsciidoctorMojoLogHandlerTest.java
@@ -40,7 +40,7 @@ public class AsciidoctorMojoLogHandlerTest {
         mojo.sourceDirectory = srcDir;
         mojo.sourceDocumentName = sourceDocument;
         mojo.outputDirectory = outputDir;
-        mojo.headerFooter = true;
+        mojo.standalone = true;
         mojo.attributes = map("toc", null);
         mojo.execute();
 
@@ -64,7 +64,7 @@ public class AsciidoctorMojoLogHandlerTest {
         mojo.sourceDirectory = srcDir;
         mojo.sourceDocumentName = sourceDocument;
         mojo.outputDirectory = outputDir;
-        mojo.headerFooter = true;
+        mojo.standalone = true;
         mojo.attributes = map("toc", null);
         mojo.execute();
 
@@ -105,7 +105,7 @@ public class AsciidoctorMojoLogHandlerTest {
         mojo.sourceDirectory = srcDir;
         mojo.sourceDocumentName = sourceDocument;
         mojo.outputDirectory = outputDir;
-        mojo.headerFooter = true;
+        mojo.standalone = true;
         mojo.attributes = map("toc", null);
         mojo.execute();
 
@@ -148,7 +148,7 @@ public class AsciidoctorMojoLogHandlerTest {
         mojo.sourceDirectory = srcDir;
         mojo.sourceDocumentName = sourceDocument;
         mojo.outputDirectory = outputDir;
-        mojo.headerFooter = true;
+        mojo.standalone = true;
         mojo.attributes = map("toc", null);
         mojo.enableVerbose = true;
         mojo.execute();
@@ -188,7 +188,7 @@ public class AsciidoctorMojoLogHandlerTest {
         mojo.sourceDirectory = srcDir;
         mojo.sourceDocumentName = sourceDocument;
         mojo.outputDirectory = outputDir;
-        mojo.headerFooter = true;
+        mojo.standalone = true;
         mojo.attributes = map("toc", null);
         mojo.enableVerbose = true;
         mojo.gemPath = System.getProperty("java.io.tmpdir");
@@ -226,7 +226,7 @@ public class AsciidoctorMojoLogHandlerTest {
         mojo.sourceDirectory = srcDir;
         mojo.sourceDocumentName = sourceDocument;
         mojo.outputDirectory = outputDir;
-        mojo.headerFooter = true;
+        mojo.standalone = true;
         mojo.attributes = map("toc", null);
         Throwable throwable = catchThrowable(mojo::execute);
 
@@ -253,7 +253,7 @@ public class AsciidoctorMojoLogHandlerTest {
         mojo.sourceDirectory = srcDir;
         mojo.sourceDocumentName = sourceDocument;
         mojo.outputDirectory = outputDir;
-        mojo.headerFooter = true;
+        mojo.standalone = true;
         mojo.attributes = map("toc", null);
         Throwable throwable = catchThrowable(mojo::execute);
 
@@ -280,7 +280,7 @@ public class AsciidoctorMojoLogHandlerTest {
         mojo.sourceDirectory = srcDir;
         mojo.sourceDocumentName = sourceDocument;
         mojo.outputDirectory = outputDir;
-        mojo.headerFooter = true;
+        mojo.standalone = true;
         mojo.attributes = map("toc", null);
         mojo.execute();
 
@@ -308,7 +308,7 @@ public class AsciidoctorMojoLogHandlerTest {
         mojo.sourceDirectory = srcDir;
         mojo.sourceDocumentName = sourceDocument;
         mojo.outputDirectory = outputDir;
-        mojo.headerFooter = true;
+        mojo.standalone = true;
         mojo.attributes = map("toc", null);
         Throwable throwable = catchThrowable(mojo::execute);
 
@@ -354,7 +354,7 @@ public class AsciidoctorMojoLogHandlerTest {
         mojo.sourceDirectory = srcDir;
         mojo.sourceDocumentName = sourceDocument;
         mojo.outputDirectory = outputDir;
-        mojo.headerFooter = true;
+        mojo.standalone = true;
         mojo.attributes = map("toc", null);
         Throwable throwable = catchThrowable(mojo::execute);
 
@@ -390,7 +390,7 @@ public class AsciidoctorMojoLogHandlerTest {
         mojo.sourceDirectory = srcDir;
         mojo.sourceDocumentName = sourceDocument;
         mojo.outputDirectory = outputDir;
-        mojo.headerFooter = true;
+        mojo.standalone = true;
         mojo.attributes = map("toc", null);
         mojo.execute();
 

--- a/asciidoctor-maven-plugin/src/test/java/org/asciidoctor/maven/AsciidoctorMojoTest.java
+++ b/asciidoctor-maven-plugin/src/test/java/org/asciidoctor/maven/AsciidoctorMojoTest.java
@@ -159,7 +159,7 @@ public class AsciidoctorMojoTest {
         mojo.sourceDocumentName = "sample.asciidoc";
         mojo.resources = excludeAll();
         mojo.outputDirectory = outputDir;
-        mojo.headerFooter = true;
+        mojo.standalone = true;
         mojo.attributes = map("toc", null,
                 "linkcss!", "",
                 "source-highlighter", "coderay");

--- a/asciidoctor-maven-plugin/src/test/java/org/asciidoctor/maven/AsciidoctorRefreshMojoTest.java
+++ b/asciidoctor-maven-plugin/src/test/java/org/asciidoctor/maven/AsciidoctorRefreshMojoTest.java
@@ -351,7 +351,7 @@ public class AsciidoctorRefreshMojoTest {
 
         // when
         Thread mojoThread = runMojoAsynchronously(mojo -> {
-            mojo.headerFooter = false;
+            mojo.standalone = false;
             mojo.backend = "html5";
             mojo.sourceDirectory = srcDir;
             mojo.outputDirectory = outputDir;

--- a/docs/modules/plugin/pages/usage.adoc
+++ b/docs/modules/plugin/pages/usage.adoc
@@ -73,7 +73,7 @@ An example of this setup is below:
     </executions>
     <configuration>  <!--.-->
         <sourceDirectory>src/main/asciidoc</sourceDirectory>
-        <headerFooter>true</headerFooter>
+        <standalone>true</standalone>
     </configuration>
 </plugin>
 ----

--- a/docs/modules/plugin/pages/v3-migration-guide.adoc
+++ b/docs/modules/plugin/pages/v3-migration-guide.adoc
@@ -32,9 +32,9 @@ Note this also imposes versions on dependencies, for example:
 Support for AsciidoctorJ v1.6.x (released 14th Feb, 2019) has been totally removed and will fail when configured.
 This simplifies the current plugin code and allows for removal of Java reflection usage.
 
-*If you are setting the AsciidoctorJ dependency directly, ensure it's v2.0.0 or higher*.
+*If you are setting the AsciidoctorJ dependency directly, ensure it's v2.0.0 or higher.*
 
-[source,xml,subs=attributes+]
+[,xml,subs=attributes+]
 .invalid configuration
 ----
  <plugin>
@@ -48,5 +48,39 @@ This simplifies the current plugin code and allows for removal of Java reflectio
             <version>1.6.2</version>
         </dependency>
     </dependencies>
+</plugin>
+----
+
+=== Replace deprecated option 'headerFooter' by 'standalone'
+
+`headerFooter` option in Asciidoctor has been replaced by the easier to understand 'standalone'.
+The plugin aligns with that change replacing the option with `standalone` in the `<configuration>` block.
+The new option works exactly the same with the same semantics.
+
+*If you are using `headerFooter` option, just replace it with `standalone`.*
+
+[,xml]
+.invalid configuration
+----
+ <plugin>
+    <groupId>org.asciidoctor</groupId>
+    <artifactId>asciidoctor-maven-plugin</artifactId>
+    <version>3.0.0</version>
+    <configuration>
+      <standalone>false</standalone>
+    </configuration>
+</plugin>
+----
+
+[,xml]
+.new configuration
+----
+ <plugin>
+    <groupId>org.asciidoctor</groupId>
+    <artifactId>asciidoctor-maven-plugin</artifactId>
+    <version>3.0.0</version>
+    <configuration>
+      <standalone>false</standalone>
+    </configuration>
 </plugin>
 ----

--- a/docs/modules/plugin/partials/process-asciidoc-mojo-parameters.adoc
+++ b/docs/modules/plugin/partials/process-asciidoc-mojo-parameters.adoc
@@ -96,8 +96,8 @@ doctype:: defaults to `null` (which trigger's Asciidoctor's default of `article`
 [#configuration-eruby]
 eruby:: defaults to erb, the version used in JRuby
 
-[#configuration-headerFooter]
-headerFooter:: defaults to `true`
+[#configuration-standalone]
+standalone:: add frame around that content (i.e., the header and footer in HTML), defaults to `true`
 
 [#configuration-templateDirs]
 templateDirs:: list of directories of compatible templates to be used instead of the default built-in templates, empty by default.


### PR DESCRIPTION
**What kind of change does this PR introduce?** (check at least one)
<!-- Update "[ ]" to "[x]" to check a box -->

- [ ] Bugfix
- [ ] Feature
- [ ] Documentation
- [ ] Refactor
- [ ] Build improvement
- [x] Other (please describe)
  :point_right: Breaking change for v3

**What is the goal of this pull request?**

Also:
* Update tests
* Update docs
* Add section to v3 migration guide

**Are there any alternative ways to implement this?**

No. Using v3 to introduce breaking changes.

**Are there any implications of this pull request? Anything a user must know?**

Users will need to change `headerFooter` by `standalone`.

**Is it related to an existing issue?**
<!-- If Yes, please add a line of the form: `Fixes #Issue` --> 
- [x] Yes
- [ ] No

Closes #649 

*Finally, please add a corresponding entry to CHANGELOG.adoc*
