### PR TITLE
(v3.0.x) Remove use of destinationDir

### DIFF
--- a/CHANGELOG.adoc
+++ b/CHANGELOG.adoc
@@ -26,6 +26,7 @@ Improvements::
   * Reimplement resource copy using 'plexus.util.DirectorScanner' instead of 'maven-filtering' to reduce dependencies and build time (#597)
   * Set minimal Maven version to v3.8.5 (#629)
   * Replace deprecated 'headerFooter' by 'standalone' in configuration (#649)
+  * Remove internal use of 'destinationDir' AsciidoctorJ method (no changes for users) (#650)
 
 Build / Infrastructure::
 

--- a/asciidoctor-maven-plugin/src/main/java/org/asciidoctor/maven/AsciidoctorMojo.java
+++ b/asciidoctor-maven-plugin/src/main/java/org/asciidoctor/maven/AsciidoctorMojo.java
@@ -286,18 +286,18 @@ public class AsciidoctorMojo extends AbstractMojo {
             if (configuration.isPreserveDirectories()) {
                 final String candidatePath = sourceFile.getParentFile().getCanonicalPath().substring(sourceDirectory.getCanonicalPath().length());
                 final File relativePath = new File(outputDir.getCanonicalPath() + candidatePath);
-                optionsBuilder.toDir(relativePath).destinationDir(relativePath);
+                optionsBuilder.toDir(relativePath);
             } else {
-                optionsBuilder.toDir(outputDir).destinationDir(outputDir);
+                optionsBuilder.toDir(outputDir);
             }
             final File outputFile = configuration.getOutputFile();
-            final String destinationDir = (String) optionsBuilder.asMap().get(Options.DESTINATION_DIR);
+            final String toDir = (String) optionsBuilder.build().map().get(Options.TO_DIR);
             if (outputFile != null) {
                 // allow overriding the output file name
                 optionsBuilder.toFile(outputFile);
-                return outputFile.isAbsolute() ? outputFile : new File(destinationDir, outputFile.getPath());
+                return outputFile.isAbsolute() ? outputFile : new File(toDir, outputFile.getPath());
             } else {
-                return new File(destinationDir, sourceFile.getName());
+                return new File(toDir, sourceFile.getName());
             }
         } catch (IOException e) {
             throw new MojoExecutionException("Unable to locate output directory", e);
@@ -305,7 +305,7 @@ public class AsciidoctorMojo extends AbstractMojo {
     }
 
     protected Asciidoctor getAsciidoctorInstance(String gemPath) throws MojoExecutionException {
-        Asciidoctor asciidoctor = null;
+        Asciidoctor asciidoctor;
         if (gemPath == null) {
             asciidoctor = AsciidoctorJRuby.Factory.create();
         } else {


### PR DESCRIPTION
**What kind of change does this PR introduce?** (check at least one)
<!-- Update "[ ]" to "[x]" to check a box -->

- [ ] Bugfix
- [ ] Feature
- [ ] Documentation
- [ ] Refactor
- [ ] Build improvement
- [x] Other (please describe)
Internal change, remove the use of unnecessary calls to AsciidoctorJ's `destinationDir`.

**What is the goal of this pull request?**
Remove the use of unnecessary calls to AsciidoctorJ's `destinationDir`.

**Are there any alternative ways to implement this?**
no

**Are there any implications of this pull request? Anything a user must know?**
no

**Is it related to an existing issue?**
<!-- If Yes, please add a line of the form: `Fixes #Issue` --> 
- [x] Yes
- [ ] No

Closes #650 
