### PR TITLE
Remove asciidoctorj deprecated methods usage

### DIFF
--- a/CHANGELOG.adoc
+++ b/CHANGELOG.adoc
@@ -15,8 +15,8 @@ For a detailed view of what has changed, refer to the {uri-repo}/commits/main[co
 
 Bug Fixes::
 
-  * Fixed default value for eruby which caused a fail when using erb templates (#610)
-  * Upgrade Asciidoctorj to v2.5.10 and jRuby to v9.4.2.0 (#647)
+  * Fix default value for eruby which caused a fail when using erb templates (#610)
+  * Fix maven properties not being injected as attributes during site conversion (#656)
 
 Improvements::
 
@@ -27,6 +27,7 @@ Improvements::
   * Set minimal Maven version to v3.8.5 (#629)
   * Replace deprecated 'headerFooter' by 'standalone' in configuration (#649)
   * Remove internal use of 'destinationDir' AsciidoctorJ method (no changes for users) (#650)
+  * Upgrade Asciidoctorj to v2.5.10 and jRuby to v9.4.2.0 (#647)
 
 Build / Infrastructure::
 

--- a/asciidoctor-converter-doxia-module/src/main/java/org/asciidoctor/maven/site/AsciidoctorConverterDoxiaParser.java
+++ b/asciidoctor-converter-doxia-module/src/main/java/org/asciidoctor/maven/site/AsciidoctorConverterDoxiaParser.java
@@ -119,14 +119,14 @@ public class AsciidoctorConverterDoxiaParser extends AbstractTextParser {
     }
 
     protected OptionsBuilder defaultOptions(File siteDirectory) {
-        return OptionsBuilder.options()
+        return Options.builder()
                 .backend("xhtml")
                 .safe(SafeMode.UNSAFE)
                 .baseDir(new File(siteDirectory, ROLE_HINT));
     }
 
     protected AttributesBuilder defaultAttributes() {
-        return AttributesBuilder.attributes()
+        return Attributes.builder()
                 .attribute("idprefix", "@")
                 .attribute("showtitle", "@");
     }

--- a/asciidoctor-maven-commons/src/main/java/org/asciidoctor/maven/site/SiteConversionConfiguration.java
+++ b/asciidoctor-maven-commons/src/main/java/org/asciidoctor/maven/site/SiteConversionConfiguration.java
@@ -21,5 +21,4 @@ public class SiteConversionConfiguration {
     public List<String> getRequires() {
         return requires;
     }
-
 }

--- a/asciidoctor-maven-commons/src/main/java/org/asciidoctor/maven/site/SiteConversionConfigurationParser.java
+++ b/asciidoctor-maven-commons/src/main/java/org/asciidoctor/maven/site/SiteConversionConfigurationParser.java
@@ -1,7 +1,9 @@
 package org.asciidoctor.maven.site;
 
 import org.apache.maven.project.MavenProject;
+import org.asciidoctor.Attributes;
 import org.asciidoctor.AttributesBuilder;
+import org.asciidoctor.Options;
 import org.asciidoctor.OptionsBuilder;
 import org.asciidoctor.maven.commons.AsciidoctorHelper;
 import org.asciidoctor.maven.commons.StringUtils;
@@ -29,18 +31,19 @@ public class SiteConversionConfigurationParser {
                                                              OptionsBuilder presetOptions,
                                                              AttributesBuilder presetAttributes) {
 
+        AsciidoctorHelper.addProperties(project.getProperties(), presetAttributes);
+        final Attributes attributes = presetAttributes.build();
+
         if (siteConfig == null) {
-            OptionsBuilder options = presetOptions.attributes(presetAttributes);
-            return new SiteConversionConfiguration(options.get(), Collections.emptyList());
+            OptionsBuilder options = presetOptions.attributes(attributes);
+            return new SiteConversionConfiguration(options.build(), Collections.emptyList());
         }
 
         final Xpp3Dom asciidocConfig = siteConfig.getChild("asciidoc");
         if (asciidocConfig == null) {
-            OptionsBuilder options = presetOptions.attributes(presetAttributes);
-            return new SiteConversionConfiguration(options.get(), Collections.emptyList());
+            OptionsBuilder options = presetOptions.attributes(attributes);
+            return new SiteConversionConfiguration(options.build(), Collections.emptyList());
         }
-
-        AsciidoctorHelper.addProperties(project.getProperties(), presetAttributes);
 
         final List<String> gemsToRequire = new ArrayList<>();
         for (Xpp3Dom asciidocOpt : asciidocConfig.getChildren()) {
@@ -68,7 +71,7 @@ public class SiteConversionConfigurationParser {
                 }
             } else if ("attributes".equals(optName)) {
                 for (Xpp3Dom asciidocAttr : asciidocOpt.getChildren()) {
-                    AsciidoctorHelper.addAttribute(asciidocAttr.getName(), asciidocAttr.getValue(), presetAttributes);
+                    AsciidoctorHelper.addAttribute(asciidocAttr.getName(), asciidocAttr.getValue(), attributes);
                 }
             } else if ("templateDirs".equals(optName) || "template_dirs".equals(optName)) {
                 List<File> dirs = Arrays.stream(asciidocOpt.getChildren("dir"))
@@ -83,7 +86,8 @@ public class SiteConversionConfigurationParser {
             }
         }
 
-        return new SiteConversionConfiguration(presetOptions.attributes(presetAttributes).get(), gemsToRequire);
+        final Options options = presetOptions.attributes(attributes).build();
+        return new SiteConversionConfiguration(options, gemsToRequire);
     }
 
     private File resolveProjectDir(MavenProject project, String path) {

--- a/asciidoctor-maven-commons/src/test/java/org/asciidoctor/maven/site/SiteConversionConfigurationParserTest.java
+++ b/asciidoctor-maven-commons/src/test/java/org/asciidoctor/maven/site/SiteConversionConfigurationParserTest.java
@@ -160,7 +160,7 @@ public class SiteConversionConfigurationParserTest {
                 .addChild("imagesdir", "./images")
                 .parent().addChild("source-highlighter", "coderay")
                 .parent().addChild("sectnums")
-                .parent().addChild("toc", null)
+                .parent().addChild("toc")
                 .build();
 
         // when
@@ -391,7 +391,32 @@ public class SiteConversionConfigurationParserTest {
     }
 
     @Test
-    public void should_return_and_format_any_maven_project_property_as_attribute() {
+    public void should_return_and_format_any_maven_project_property_as_attribute_when_site_config_is_not_present() {
+        // given
+        final Map<String, String> projectProperties = new HashMap<>();
+        projectProperties.put("mvn.property-test1", "value-1");
+        projectProperties.put("mvn-property.test2", "value_2");
+        final MavenProject project = fakeProject(projectProperties);
+        OptionsBuilder emptyOptions = Options.builder();
+        AttributesBuilder emptyAttributes = Attributes.builder();
+
+        // when
+        SiteConversionConfiguration configuration = new SiteConversionConfigurationParser(project)
+                .processAsciiDocConfig(null, emptyOptions, emptyAttributes);
+
+        // then
+        final Map<String, Object> optionsMap = configuration.getOptions().map();
+        assertThat(optionsMap)
+                .containsOnlyKeys(ATTRIBUTES);
+        Map attributes = (Map) optionsMap.get(ATTRIBUTES);
+        assertThat(attributes).containsExactlyInAnyOrderEntriesOf(map(
+                entry("mvn-property-test1", "value-1"),
+                entry("mvn-property-test2", "value_2")
+        ));
+    }
+
+    @Test
+    public void should_return_and_format_any_maven_project_property_as_attribute_when_site_config_is_present() {
         // given
         final Map<String, String> projectProperties = new HashMap<>();
         projectProperties.put("mvn.property-test1", "value-1");

--- a/asciidoctor-maven-commons/src/test/java/org/asciidoctor/maven/site/SiteConversionConfigurationParserTest.java
+++ b/asciidoctor-maven-commons/src/test/java/org/asciidoctor/maven/site/SiteConversionConfigurationParserTest.java
@@ -2,7 +2,9 @@ package org.asciidoctor.maven.site;
 
 import org.apache.maven.model.Model;
 import org.apache.maven.project.MavenProject;
+import org.asciidoctor.Attributes;
 import org.asciidoctor.AttributesBuilder;
+import org.asciidoctor.Options;
 import org.asciidoctor.OptionsBuilder;
 import org.codehaus.plexus.util.xml.Xpp3Dom;
 import org.junit.jupiter.api.Test;
@@ -22,8 +24,8 @@ public class SiteConversionConfigurationParserTest {
     public void should_return_default_configuration_when_site_xml_is_null() {
         // given
         final MavenProject project = fakeProject();
-        OptionsBuilder emptyOptions = OptionsBuilder.options();
-        AttributesBuilder emptyAttributes = AttributesBuilder.attributes();
+        OptionsBuilder emptyOptions = Options.builder();
+        AttributesBuilder emptyAttributes = Attributes.builder();
 
         // when
         SiteConversionConfiguration configuration = new SiteConversionConfigurationParser(project)
@@ -40,8 +42,8 @@ public class SiteConversionConfigurationParserTest {
     public void should_return_default_configuration_when_asciidoc_xml_is_null() {
         // given
         final MavenProject project = fakeProject();
-        OptionsBuilder emptyOptions = OptionsBuilder.options();
-        AttributesBuilder emptyAttributes = AttributesBuilder.attributes();
+        OptionsBuilder emptyOptions = Options.builder();
+        AttributesBuilder emptyAttributes = Attributes.builder();
         Xpp3Dom siteConfig = Xpp3DoomBuilder.siteNode()
                 .build();
         // when
@@ -59,8 +61,8 @@ public class SiteConversionConfigurationParserTest {
     public void should_return_simple_single_requires() {
         // given
         final MavenProject project = fakeProject();
-        OptionsBuilder emptyOptions = OptionsBuilder.options();
-        AttributesBuilder emptyAttributes = AttributesBuilder.attributes();
+        OptionsBuilder emptyOptions = Options.builder();
+        AttributesBuilder emptyAttributes = Attributes.builder();
         Xpp3Dom siteConfig = Xpp3DoomBuilder.asciidocNode()
                 .addChild("requires")
                 .addChild("require", "gem")
@@ -82,8 +84,8 @@ public class SiteConversionConfigurationParserTest {
     public void should_return_multiple_requires() {
         // given
         final MavenProject project = fakeProject();
-        OptionsBuilder emptyOptions = OptionsBuilder.options();
-        AttributesBuilder emptyAttributes = AttributesBuilder.attributes();
+        OptionsBuilder emptyOptions = Options.builder();
+        AttributesBuilder emptyAttributes = Attributes.builder();
         Xpp3Dom siteConfig = Xpp3DoomBuilder.asciidocNode()
                 .addChild("requires")
                 .addChild("require", "gem_1", "gem_2", "gem_3")
@@ -105,8 +107,8 @@ public class SiteConversionConfigurationParserTest {
     public void should_return_multiple_requires_when_defined_in_single_element() {
         // given
         final MavenProject project = fakeProject();
-        OptionsBuilder emptyOptions = OptionsBuilder.options();
-        AttributesBuilder emptyAttributes = AttributesBuilder.attributes();
+        OptionsBuilder emptyOptions = Options.builder();
+        AttributesBuilder emptyAttributes = Attributes.builder();
         Xpp3Dom siteConfig = Xpp3DoomBuilder.asciidocNode()
                 .addChild("requires")
                 .addChild("require", "gem_1,gem_2, gem_3")
@@ -128,8 +130,8 @@ public class SiteConversionConfigurationParserTest {
     public void should_remove_empty_and_blank_requires() {
         // given
         final MavenProject project = fakeProject();
-        OptionsBuilder emptyOptions = OptionsBuilder.options();
-        AttributesBuilder emptyAttributes = AttributesBuilder.attributes();
+        OptionsBuilder emptyOptions = Options.builder();
+        AttributesBuilder emptyAttributes = Attributes.builder();
         Xpp3Dom siteConfig = Xpp3DoomBuilder.asciidocNode()
                 .addChild("requires")
                 .addChild("require", "gem_1,,gem_2", "", ",,", "gem_3")
@@ -151,8 +153,8 @@ public class SiteConversionConfigurationParserTest {
     public void should_return_attributes() {
         // given
         final MavenProject project = fakeProject();
-        OptionsBuilder emptyOptions = OptionsBuilder.options();
-        AttributesBuilder emptyAttributes = AttributesBuilder.attributes();
+        OptionsBuilder emptyOptions = Options.builder();
+        AttributesBuilder emptyAttributes = Attributes.builder();
         Xpp3Dom siteConfig = Xpp3DoomBuilder.asciidocNode()
                 .addChild("attributes")
                 .addChild("imagesdir", "./images")
@@ -182,8 +184,8 @@ public class SiteConversionConfigurationParserTest {
     public void should_map_null_attributes_as_empty_string() {
         // given
         final MavenProject project = fakeProject();
-        OptionsBuilder emptyOptions = OptionsBuilder.options();
-        AttributesBuilder emptyAttributes = AttributesBuilder.attributes();
+        OptionsBuilder emptyOptions = Options.builder();
+        AttributesBuilder emptyAttributes = Attributes.builder();
         Xpp3Dom siteConfig = Xpp3DoomBuilder.asciidocNode()
                 .addChild("attributes")
                 .addChild("toc", null)
@@ -208,8 +210,8 @@ public class SiteConversionConfigurationParserTest {
     public void should_map_true_boolean_attribute_as_empty_string_value() {
         // given
         final MavenProject project = fakeProject();
-        OptionsBuilder emptyOptions = OptionsBuilder.options();
-        AttributesBuilder emptyAttributes = AttributesBuilder.attributes();
+        OptionsBuilder emptyOptions = Options.builder();
+        AttributesBuilder emptyAttributes = Attributes.builder();
         Xpp3Dom siteConfig = Xpp3DoomBuilder.asciidocNode()
                 .addChild("attributes")
                 .addChild("toc", "true")
@@ -234,8 +236,8 @@ public class SiteConversionConfigurationParserTest {
     public void should_map_false_boolean_attribute_as_null_value() {
         // given
         final MavenProject project = fakeProject();
-        OptionsBuilder emptyOptions = OptionsBuilder.options();
-        AttributesBuilder emptyAttributes = AttributesBuilder.attributes();
+        OptionsBuilder emptyOptions = Options.builder();
+        AttributesBuilder emptyAttributes = Attributes.builder();
         Xpp3Dom siteConfig = Xpp3DoomBuilder.asciidocNode()
                 .addChild("attributes")
                 .addChild("toc", "false")
@@ -260,8 +262,8 @@ public class SiteConversionConfigurationParserTest {
     public void should_return_template_dirs_when_defined_as_templateDirs_dir() {
         // given
         final MavenProject project = fakeProject();
-        OptionsBuilder emptyOptions = OptionsBuilder.options();
-        AttributesBuilder emptyAttributes = AttributesBuilder.attributes();
+        OptionsBuilder emptyOptions = Options.builder();
+        AttributesBuilder emptyAttributes = Attributes.builder();
         Xpp3Dom siteConfig = Xpp3DoomBuilder.asciidocNode()
                 .addChild("templateDirs")
                 .addChild("dir", "path")
@@ -288,8 +290,8 @@ public class SiteConversionConfigurationParserTest {
     public void should_return_template_dirs_when_defined_as_template_dirs_dir() {
         // given
         final MavenProject project = fakeProject();
-        OptionsBuilder emptyOptions = OptionsBuilder.options();
-        AttributesBuilder emptyAttributes = AttributesBuilder.attributes();
+        OptionsBuilder emptyOptions = Options.builder();
+        AttributesBuilder emptyAttributes = Attributes.builder();
         Xpp3Dom siteConfig = Xpp3DoomBuilder.asciidocNode()
                 .addChild("template_dirs")
                 .addChild("dir", "path")
@@ -316,8 +318,8 @@ public class SiteConversionConfigurationParserTest {
     public void should_not_return_empty_template_dirs() {
         // given
         final MavenProject project = fakeProject();
-        OptionsBuilder emptyOptions = OptionsBuilder.options();
-        AttributesBuilder emptyAttributes = AttributesBuilder.attributes();
+        OptionsBuilder emptyOptions = Options.builder();
+        AttributesBuilder emptyAttributes = Attributes.builder();
         Xpp3Dom siteConfig = Xpp3DoomBuilder.asciidocNode()
                 .addChild("template_dirs")
                 .addChild("dir", "")
@@ -339,8 +341,8 @@ public class SiteConversionConfigurationParserTest {
     public void should_return_baseDir_dirs_when_defined_as_template_dirs_dir() {
         // given
         final MavenProject project = fakeProject();
-        OptionsBuilder emptyOptions = OptionsBuilder.options();
-        AttributesBuilder emptyAttributes = AttributesBuilder.attributes();
+        OptionsBuilder emptyOptions = Options.builder();
+        AttributesBuilder emptyAttributes = Attributes.builder();
         Xpp3Dom siteConfig = Xpp3DoomBuilder.asciidocNode()
                 .addChild("baseDir", "path")
                 .build();
@@ -362,8 +364,8 @@ public class SiteConversionConfigurationParserTest {
     public void should_return_any_configuration_inside_asciidoc_node_as_option() {
         // given
         final MavenProject project = fakeProject();
-        OptionsBuilder emptyOptions = OptionsBuilder.options();
-        AttributesBuilder emptyAttributes = AttributesBuilder.attributes();
+        OptionsBuilder emptyOptions = Options.builder();
+        AttributesBuilder emptyAttributes = Attributes.builder();
         Xpp3Dom siteConfig = Xpp3DoomBuilder.asciidocNode()
                 .addChild("option-1", "value-1")
                 .parent().addChild("option_2", "value-2")
@@ -395,8 +397,8 @@ public class SiteConversionConfigurationParserTest {
         projectProperties.put("mvn.property-test1", "value-1");
         projectProperties.put("mvn-property.test2", "value_2");
         final MavenProject project = fakeProject(projectProperties);
-        OptionsBuilder emptyOptions = OptionsBuilder.options();
-        AttributesBuilder emptyAttributes = AttributesBuilder.attributes();
+        OptionsBuilder emptyOptions = Options.builder();
+        AttributesBuilder emptyAttributes = Attributes.builder();
         Xpp3Dom siteConfig = Xpp3DoomBuilder.asciidocNode().build();
 
         // when

--- a/asciidoctor-maven-plugin/src/main/java/org/asciidoctor/maven/AsciidoctorMojo.java
+++ b/asciidoctor-maven-plugin/src/main/java/org/asciidoctor/maven/AsciidoctorMojo.java
@@ -411,9 +411,7 @@ public class AsciidoctorMojo extends AbstractMojo {
         if (!configuration.getTemplateDirs().isEmpty())
             optionsBuilder.templateDirs(templateDirs.toArray(new File[]{}));
 
-        if (!attributesBuilder.asMap().isEmpty())
-            optionsBuilder.attributes(attributesBuilder);
-
+        optionsBuilder.attributes(attributesBuilder.build());
         return optionsBuilder;
     }
 

--- a/asciidoctor-maven-plugin/src/main/java/org/asciidoctor/maven/AsciidoctorMojo.java
+++ b/asciidoctor-maven-plugin/src/main/java/org/asciidoctor/maven/AsciidoctorMojo.java
@@ -231,7 +231,7 @@ public class AsciidoctorMojo extends AbstractMojo {
             if (!uniquePaths.add(destinationPath))
                 getLog().warn("Duplicated destination found: overwriting file: " + destinationPath.getAbsolutePath());
 
-            convertFile(asciidoctor, optionsBuilder.asMap(), source);
+            convertFile(asciidoctor, optionsBuilder.build(), source);
 
             try {
                 // process log messages according to mojo configuration
@@ -359,7 +359,7 @@ public class AsciidoctorMojo extends AbstractMojo {
                 finder.find(sourceDirectoryPath, sourceDocumentExtensions);
     }
 
-    protected void convertFile(Asciidoctor asciidoctor, Map<String, Object> options, File f) {
+    protected void convertFile(Asciidoctor asciidoctor, Options options, File f) {
         asciidoctor.convertFile(f, options);
         logConvertedFile(f);
     }
@@ -384,7 +384,7 @@ public class AsciidoctorMojo extends AbstractMojo {
      */
     protected OptionsBuilder createOptionsBuilder(AsciidoctorMojo configuration, AttributesBuilder attributesBuilder) {
 
-        final OptionsBuilder optionsBuilder = OptionsBuilder.options()
+        final OptionsBuilder optionsBuilder = Options.builder()
                 .backend(configuration.getBackend())
                 .safe(SafeMode.UNSAFE)
                 .standalone(configuration.standalone)
@@ -417,7 +417,6 @@ public class AsciidoctorMojo extends AbstractMojo {
         return optionsBuilder;
     }
 
-
     /**
      * Creates an AttributesBuilder instance with the attributes defined in the configuration.
      *
@@ -427,7 +426,7 @@ public class AsciidoctorMojo extends AbstractMojo {
      */
     protected AttributesBuilder createAttributesBuilder(AsciidoctorMojo configuration, MavenProject mavenProject) {
 
-        final AttributesBuilder attributesBuilder = AttributesBuilder.attributes();
+        final AttributesBuilder attributesBuilder = Attributes.builder();
 
         if (configuration.isEmbedAssets()) {
             attributesBuilder.linkCss(false);

--- a/asciidoctor-maven-plugin/src/main/java/org/asciidoctor/maven/model/Resource.java
+++ b/asciidoctor-maven-plugin/src/main/java/org/asciidoctor/maven/model/Resource.java
@@ -32,7 +32,7 @@ public class Resource {
 
     public List<String> getIncludes() {
         if (this.includes == null) {
-            this.includes = new ArrayList();
+            this.includes = new ArrayList<>();
         }
 
         return this.includes;
@@ -44,7 +44,7 @@ public class Resource {
 
     public List<String> getExcludes() {
         if (this.excludes == null) {
-            this.excludes = new ArrayList();
+            this.excludes = new ArrayList<>();
         }
 
         return this.excludes;

--- a/asciidoctor-maven-plugin/src/test/java/org/asciidoctor/maven/TestUtils.java
+++ b/asciidoctor-maven-plugin/src/test/java/org/asciidoctor/maven/TestUtils.java
@@ -54,6 +54,7 @@ public class TestUtils {
     }
 
     @SneakyThrows
+    @SuppressWarnings("unchecked")
     private static <T> T mockAsciidoctorMojo(Class<T> clazz, Map<String, String> mavenProperties, LogHandler logHandler) {
         final MavenProject mavenProject = Mockito.mock(MavenProject.class);
         when(mavenProject.getBasedir()).thenReturn(new File("."));

--- a/asciidoctor-parser-doxia-module/src/main/java/org/asciidoctor/maven/site/ast/AsciidoctorAstDoxiaParser.java
+++ b/asciidoctor-parser-doxia-module/src/main/java/org/asciidoctor/maven/site/ast/AsciidoctorAstDoxiaParser.java
@@ -5,10 +5,7 @@ import org.apache.maven.doxia.parser.ParseException;
 import org.apache.maven.doxia.parser.Parser;
 import org.apache.maven.doxia.sink.Sink;
 import org.apache.maven.project.MavenProject;
-import org.asciidoctor.Asciidoctor;
-import org.asciidoctor.AttributesBuilder;
-import org.asciidoctor.OptionsBuilder;
-import org.asciidoctor.SafeMode;
+import org.asciidoctor.*;
 import org.asciidoctor.ast.Document;
 import org.asciidoctor.maven.log.LogHandler;
 import org.asciidoctor.maven.log.LogRecordFormatter;
@@ -133,14 +130,14 @@ public class AsciidoctorAstDoxiaParser extends AbstractTextParser {
     }
 
     protected OptionsBuilder defaultOptions(File siteDirectory) {
-        return OptionsBuilder.options()
+        return Options.builder()
                 .backend("xhtml")
                 .safe(SafeMode.UNSAFE)
                 .baseDir(new File(siteDirectory, ROLE_HINT));
     }
 
     protected AttributesBuilder defaultAttributes() {
-        return AttributesBuilder.attributes()
+        return Attributes.builder()
                 .attribute("idprefix", "@")
                 .attribute("showtitle", "@");
     }

--- a/pom.xml
+++ b/pom.xml
@@ -76,8 +76,7 @@
         <project.build.sourceEncoding>UTF-8</project.build.sourceEncoding>
         <project.java.version>11</project.java.version>
         <project.execution.environment>JavaSE-1.8</project.execution.environment>
-<!--        <asciidoctorj.version>2.5.10</asciidoctorj.version>-->
-        <asciidoctorj.version>3.0.0-alpha.1</asciidoctorj.version>
+        <asciidoctorj.version>2.5.10</asciidoctorj.version>
         <jruby.version>9.4.2.0</jruby.version>
         <maven.project.version>3.9.1</maven.project.version>
         <maven.jacoco.plugin.version>0.8.8</maven.jacoco.plugin.version>

--- a/pom.xml
+++ b/pom.xml
@@ -76,7 +76,8 @@
         <project.build.sourceEncoding>UTF-8</project.build.sourceEncoding>
         <project.java.version>11</project.java.version>
         <project.execution.environment>JavaSE-1.8</project.execution.environment>
-        <asciidoctorj.version>2.5.10</asciidoctorj.version>
+<!--        <asciidoctorj.version>2.5.10</asciidoctorj.version>-->
+        <asciidoctorj.version>3.0.0-alpha.1</asciidoctorj.version>
         <jruby.version>9.4.2.0</jruby.version>
         <maven.project.version>3.9.1</maven.project.version>
         <maven.jacoco.plugin.version>0.8.8</maven.jacoco.plugin.version>


### PR DESCRIPTION
**What kind of change does this PR introduce?** (check at least one)
<!-- Update "[ ]" to "[x]" to check a box -->

- [x] Bugfix
- [ ] Feature
- [ ] Documentation
- [ ] Refactor
- [x] Build improvement
- [ ] Other (please describe)


**What is the goal of this pull request?**

Started to remove the use of AsciidoctorJ methods but I also fixes a bug in the site integration found during the refactor.
In short, maven project properties were not added as Asciidoctor attributes when no site configuration was added.

**Are there any alternative ways to implement this?**
No.
For context, I bumped into AsciidoctorJ v3.0.0-alpha.1, fixed issues in API (not extensions), and then went back to v2.5.10 to ensure all was working fine.

**Are there any implications of this pull request? Anything a user must know?**
No

**Is it related to an existing issue?**
<!-- If Yes, please add a line of the form: `Fixes #Issue` --> 
- [ ] Yes
- [x] No

*Finally, please add a corresponding entry to CHANGELOG.adoc*

Only the fix will be documented, the other changes are internal.