### PR TITLE
Fix basic maven setup snippet.

### DIFF
--- a/docs/modules/plugin/partials/basic-maven-setup.adoc
+++ b/docs/modules/plugin/partials/basic-maven-setup.adoc
@@ -8,11 +8,13 @@ As this is a typical Maven plugin, simply declare the plugin in the `<plugins>` 
         <groupId>org.asciidoctor</groupId>
         <artifactId>asciidoctor-maven-plugin</artifactId>
         <version>{release-version}</version>
-        <dependency> <!--1-->
-            <groupId>org.asciidoctor</groupId>
-            <artifactId>asciidoctorj</artifactId>
-            <version>${asciidoctorj.version}</version>
-        </dependency>
+        <dependencies>
+            <dependency> <!--1-->
+                <groupId>org.asciidoctor</groupId>
+                <artifactId>asciidoctorj</artifactId>
+                <version>${asciidoctorj.version}</version>
+            </dependency>
+        </dependencies>
         ...
     </plugin>
 </plugins>


### PR DESCRIPTION
`<dependencies>` is missing, not a valid declaration as presented.

Thank you for opening a pull request and contributing to asciidoctor-maven-plugin!

**What kind of change does this PR introduce?** (check at least one)
<!-- Update "[ ]" to "[x]" to check a box -->

- [x] Bugfix
- [ ] Feature
- [ ] Documentation
- [ ] Refactor
- [ ] Build improvement
- [ ] Other (please describe)


**What is the goal of this pull request?**

See title, Maven snippet is invalid.

**Are there any alternative ways to implement this?**

No.

**Are there any implications of this pull request? Anything a user must know?**

The snippet can now be copied (apart from the ellipsis, but I didn't want to change that too.

**Is it related to an existing issue?**
<!-- If Yes, please add a line of the form: `Fixes #Issue` --> 
- [ ] Yes
- [x] No

*Finally, please add a corresponding entry to CHANGELOG.adoc*
