### PR TITLE
Add Dependabot for non pinned dependencies

### DIFF
--- a/.github/dependabot.yml
+++ b/.github/dependabot.yml
@@ -1,0 +1,40 @@
+version: 2
+updates:
+  - package-ecosystem: "github-actions"
+    directory: "/"
+    schedule:
+      interval: "weekly"
+    labels:
+      - "dependencies"
+  - package-ecosystem: "maven"
+    directory: "/"
+    schedule:
+      interval: "weekly"
+    labels:
+      - "dependencies"
+    commit-message:
+      prefix: "(main)"
+    target-branch: "main"
+    ignore:
+      - dependency-name: org.jruby:jruby
+      - dependency-name: org.apache.maven:*
+      - dependency-name: org.apache.maven.plugin-tools:*
+      - dependency-name: org.apache.maven.doxia:*
+      - dependency-name: org.codehaus.plexus:*
+      - dependency-name: commons-io:commons-io
+  - package-ecosystem: "maven"
+    directory: "/"
+    schedule:
+      interval: "weekly"
+    labels:
+      - "dependencies"
+    commit-message:
+      prefix: "(v2.2.x)"
+    target-branch: "v2.2.x"
+    ignore:
+      - dependency-name: org.jruby:jruby
+      - dependency-name: org.apache.maven:*
+      - dependency-name: org.apache.maven.plugin-tools:*
+      - dependency-name: org.apache.maven.doxia:*
+      - dependency-name: org.codehaus.plexus:*
+      - dependency-name: commons-io:commons-io

--- a/CHANGELOG.adoc
+++ b/CHANGELOG.adoc
@@ -37,6 +37,7 @@ Build / Infrastructure::
   * Use Maven v3.9.2 in CI and wrapper (#658)
   * Use Maven v3.9.5 in CI and wrapper (#662)
   * Add Java 21 to CI (#664)
+  * Add Dependabot to automate dependency management (#669)
 
 Documentation::
 


### PR DESCRIPTION
**What kind of change does this PR introduce?** (check at least one)

- [ ] Bugfix
- [ ] Feature
- [ ] Documentation
- [ ] Refactor
- [x] Build improvement
- [ ] Other (please describe)


**What is the goal of this pull request?**

Automate maintenance of dependencies.
Dependabot is not perfect, but having used it for some time I find it helps. Even if the bump breaks something, at least we get a notification and we see that in CI and can decide what to do. The alternative is depending on time or strength to go through bumps and hope for the best.

**Are there any alternative ways to implement this?**
There are others. I only have first-hand knowledge [Renovate](https://github.com/renovatebot/renovate), which I don't like for some companiy and data collection policies. In general, alternatives depend on extra configurations and authorizations, Dependabot being integrated in GitHub makes things easier.
Note: dependabot does text parsing, it does not really run a dependency analysis, which causes some errors, but it helps most of the times.

Pros compensate cons, but there are some:
* Changelog is not updated, we'd need to document the AsciidoctorJ & JRuby versions on the release notes.
* Maven and Java versions in CI are not covered.

**Are there any implications of this pull request? Anything a user must know?**

Not for users.

**Is it related to an existing issue?**
<!-- If Yes, please add a line of the form: `Fixes #Issue` --> 
- [ ] Yes
- [x] No

*Finally, please add a corresponding entry to CHANGELOG.adoc*
