### PR TITLE
(v2.2.x): Bump org.apache.maven.shared:maven-filtering from 3.2.0 to 3.3.1

### DIFF
--- a/pom.xml
+++ b/pom.xml
@@ -80,7 +80,7 @@
         <maven.jacoco.plugin.version>0.8.10</maven.jacoco.plugin.version>
         <maven.plugin.plugin.version>3.9.0</maven.plugin.plugin.version>
         <maven.project.version>3.8.5</maven.project.version>
-        <maven.filtering.version>3.2.0</maven.filtering.version>
+        <maven.filtering.version>3.3.1</maven.filtering.version>
         <plexus.utils.version>3.5.1</plexus.utils.version>
         <plexus.component.metadata.version>2.1.1</plexus.component.metadata.version>
         <netty.version>4.1.93.Final</netty.version>

--- a/src/test/java/org/asciidoctor/maven/TestUtils.java
+++ b/src/test/java/org/asciidoctor/maven/TestUtils.java
@@ -7,8 +7,9 @@ import org.apache.maven.plugin.logging.SystemStreamLog;
 import org.apache.maven.project.MavenProject;
 import org.apache.maven.shared.filtering.DefaultMavenFileFilter;
 import org.apache.maven.shared.filtering.DefaultMavenResourcesFiltering;
+import org.apache.maven.shared.filtering.MavenFileFilter;
+import org.apache.maven.shared.filtering.MavenResourcesFiltering;
 import org.asciidoctor.maven.log.LogHandler;
-import org.codehaus.plexus.logging.console.ConsoleLogger;
 import org.mockito.Mockito;
 import org.sonatype.plexus.build.incremental.BuildContext;
 import org.sonatype.plexus.build.incremental.DefaultBuildContext;
@@ -66,17 +67,8 @@ public class TestUtils {
         }
 
         final BuildContext buildContext = new DefaultBuildContext();
-
-        final DefaultMavenFileFilter mavenFileFilter = new DefaultMavenFileFilter();
-        final ConsoleLogger plexusLogger = new ConsoleLogger();
-        mavenFileFilter.enableLogging(plexusLogger);
-        setVariableValueInObject(mavenFileFilter, "buildContext", buildContext);
-
-        final DefaultMavenResourcesFiltering resourceFilter = new DefaultMavenResourcesFiltering();
-        setVariableValueInObject(resourceFilter, "mavenFileFilter", mavenFileFilter);
-        setVariableValueInObject(resourceFilter, "buildContext", buildContext);
-        resourceFilter.initialize();
-        resourceFilter.enableLogging(plexusLogger);
+        final MavenFileFilter mavenFileFilter = new DefaultMavenFileFilter(buildContext);
+        final MavenResourcesFiltering resourceFilter = new DefaultMavenResourcesFiltering(mavenFileFilter, buildContext);
 
         final AsciidoctorMojo mojo = (AsciidoctorMojo) clazz.getConstructor(new Class[]{}).newInstance();
         setVariableValueInObject(mojo, "log", new SystemStreamLog());
@@ -160,5 +152,4 @@ public class TestUtils {
             return singletonList(new ResourceBuilder().directory(".").excludes("**/**").build());
         }
     }
-
 }


### PR DESCRIPTION
https://github.com/asciidoctor/asciidoctor-maven-plugin/pull/671 with code fixes.

As a nice extra, we could remove some nasty reflection from the mocks.