### PR TITLE
(main) Bump Maven to v3.9.6

### DIFF
--- a/.github/workflows/build.yaml
+++ b/.github/workflows/build.yaml
@@ -33,7 +33,7 @@ jobs:
         # Support 1-year-old version + latest minor
         maven:
           - 3.8.8
-          - 3.9.5
+          - 3.9.6
     runs-on: ${{ matrix.os }}
     steps:
       - uses: s4u/setup-maven-action@v1.11.0

--- a/.mvn/wrapper/maven-wrapper.properties
+++ b/.mvn/wrapper/maven-wrapper.properties
@@ -14,5 +14,5 @@
 # KIND, either express or implied.  See the License for the
 # specific language governing permissions and limitations
 # under the License.
-distributionUrl=https://repo.maven.apache.org/maven2/org/apache/maven/apache-maven/3.9.5/apache-maven-3.9.5-bin.zip
+distributionUrl=https://repo.maven.apache.org/maven2/org/apache/maven/apache-maven/3.9.6/apache-maven-3.9.6-bin.zip
 wrapperUrl=https://repo.maven.apache.org/maven2/org/apache/maven/wrapper/maven-wrapper/3.2.0/maven-wrapper-3.2.0.jar


### PR DESCRIPTION
**What kind of change does this PR introduce?** (check at least one)
<!-- Update "[ ]" to "[x]" to check a box -->

- [ ] Bugfix
- [ ] Feature
- [ ] Documentation
- [ ] Refactor
- [x] Build improvement
- [ ] Other (please describe)


**What is the goal of this pull request?**

Bump Maven to latest for both dev and CI.

**Are there any alternative ways to implement this?**
n/a

**Are there any implications of this pull request? Anything a user must know?**
n/a

**Is it related to an existing issue?**
<!-- If Yes, please add a line of the form: `Fixes #Issue` --> 
- [ ] Yes
- [x] No

*Finally, please add a corresponding entry to CHANGELOG.adoc*
