### PR TITLE
(v2.2.x) Bump maven to 3.9.6 for v2.2.x

### DIFF
--- a/.github/workflows/build.yaml
+++ b/.github/workflows/build.yaml
@@ -30,11 +30,11 @@ jobs:
           - 8
           - 11
           - 17
+          - 21
         # Support 1-year-old version + latest minor
         maven:
-          - 3.8.5
           - 3.8.8
-          - 3.9.2
+          - 3.9.6
     runs-on: ${{ matrix.os }}
     steps:
       - uses: s4u/setup-maven-action@v1.7.0

--- a/CHANGELOG.adoc
+++ b/CHANGELOG.adoc
@@ -50,6 +50,7 @@ Build / Infrastructure::
   * Bump Maven build plugins (#623)
   * Bump GH 'checkout' and 'setup-java' to v3 (#624)
   * Bump Doxia to v1.12.0 and maven-site-plugin in IT to 3.12.1 (#625)
+  * Support Java 21 (#684)
 
 Documentation::
 

--- a/pom.xml
+++ b/pom.xml
@@ -190,7 +190,7 @@
         <dependency>
             <groupId>org.projectlombok</groupId>
             <artifactId>lombok</artifactId>
-            <version>1.18.24</version>
+            <version>1.18.30</version>
             <scope>test</scope>
         </dependency>
     </dependencies>


### PR DESCRIPTION
* Bump lombok 1.18.24 to 1.18.30 to support Java 21

Thank you for opening a pull request and contributing to asciidoctor-maven-plugin!

**What kind of change does this PR introduce?** (check at least one)
<!-- Update "[ ]" to "[x]" to check a box -->

- [ ] Bugfix
- [ ] Feature
- [ ] Documentation
- [ ] Refactor
- [x] Build improvement
- [ ] Other (please describe)


**What is the goal of this pull request?**

* Update supported maven versions.
* Add Java 21 support to branch v2.2.x.

**Are there any alternative ways to implement this?**

n/a

**Are there any implications of this pull request? Anything a user must know?**

n/a

**Is it related to an existing issue?**
<!-- If Yes, please add a line of the form: `Fixes #Issue` --> 
- [ ] Yes
- [x] No

*Finally, please add a corresponding entry to CHANGELOG.adoc*
