### PR TITLE
(main) Bump Asciidoctorj to v2.5.11

### DIFF
--- a/CHANGELOG.adoc
+++ b/CHANGELOG.adoc
@@ -29,6 +29,7 @@ Improvements::
   * Replace deprecated 'headerFooter' by 'standalone' in configuration (#649)
   * Remove internal use of 'destinationDir' AsciidoctorJ method (no changes for users) (#650)
   * Upgrade Asciidoctorj to v2.5.10 and jRuby to v9.4.2.0 (#647)
+  * Upgrade Asciidoctorj to v2.5.11 (#688)
 
 Build / Infrastructure::
 

--- a/asciidoctor-maven-plugin/src/it/spi-registered-log/log-handler/pom.xml
+++ b/asciidoctor-maven-plugin/src/it/spi-registered-log/log-handler/pom.xml
@@ -18,7 +18,7 @@
         <project.build.sourceEncoding>UTF-8</project.build.sourceEncoding>
         <project.java.version>1.8</project.java.version>
         <maven.compiler.plugin.version>3.8.1</maven.compiler.plugin.version>
-        <asciidoctorj.version>2.5.1</asciidoctorj.version>
+        <asciidoctorj.version>2.5.11</asciidoctorj.version>
     </properties>
 
     <build>

--- a/pom.xml
+++ b/pom.xml
@@ -76,7 +76,7 @@
         <project.build.sourceEncoding>UTF-8</project.build.sourceEncoding>
         <project.java.version>11</project.java.version>
         <project.execution.environment>JavaSE-1.8</project.execution.environment>
-        <asciidoctorj.version>2.5.10</asciidoctorj.version>
+        <asciidoctorj.version>2.5.11</asciidoctorj.version>
         <jruby.version>9.4.5.0</jruby.version>
         <maven.project.version>3.9.1</maven.project.version>
         <maven.jacoco.plugin.version>0.8.11</maven.jacoco.plugin.version>


### PR DESCRIPTION
Thank you for opening a pull request and contributing to asciidoctor-maven-plugin!

**What kind of change does this PR introduce?** (check at least one)
<!-- Update "[ ]" to "[x]" to check a box -->

- [ ] Bugfix
- [ ] Feature
- [ ] Documentation
- [ ] Refactor
- [ ] Build improvement
- [x] Other (please describe)


**What is the goal of this pull request?**

Use latest AsciidoctorJ v2.5.11.
Dependabot did not detect it :thinking: I suspect because it's set in a property?

**Are there any alternative ways to implement this?**
no

**Are there any implications of this pull request? Anything a user must know?**
n/a

**Is it related to an existing issue?**
<!-- If Yes, please add a line of the form: `Fixes #Issue` --> 
- [ ] Yes
- [x] No

*Finally, please add a corresponding entry to CHANGELOG.adoc*
