### PR TITLE
(v2.2.x) Bump Asciidoctorj to v2.5.11

### DIFF
--- a/CHANGELOG.adoc
+++ b/CHANGELOG.adoc
@@ -21,6 +21,7 @@ Build / Infrastructure::
 
   * Bump AsciidoctorJ to v2.5.10 and jRuby to v9.4.2.0 (#648)
   * Use Maven v3.9.2 in CI and wrapper (#659)
+  * Upgrade Asciidoctorj to v2.5.11 (#689)
 
 == v2.2.4 (2023-05-28)
 

--- a/pom.xml
+++ b/pom.xml
@@ -74,7 +74,7 @@
         <project.build.sourceEncoding>UTF-8</project.build.sourceEncoding>
         <project.java.version>1.8</project.java.version>
         <project.execution.environment>JavaSE-1.8</project.execution.environment>
-        <asciidoctorj.version>2.5.10</asciidoctorj.version>
+        <asciidoctorj.version>2.5.11</asciidoctorj.version>
         <jruby.version>9.4.5.0</jruby.version>
         <maven.coveralls.plugin.version>4.3.0</maven.coveralls.plugin.version>
         <maven.jacoco.plugin.version>0.8.10</maven.jacoco.plugin.version>

--- a/src/it/spi-registered-log/log-handler/pom.xml
+++ b/src/it/spi-registered-log/log-handler/pom.xml
@@ -18,7 +18,7 @@
         <project.build.sourceEncoding>UTF-8</project.build.sourceEncoding>
         <project.java.version>1.8</project.java.version>
         <maven.compiler.plugin.version>3.8.1</maven.compiler.plugin.version>
-        <asciidoctorj.version>2.5.1</asciidoctorj.version>
+        <asciidoctorj.version>2.5.11</asciidoctorj.version>
     </properties>
 
     <build>


### PR DESCRIPTION
Thank you for opening a pull request and contributing to asciidoctor-maven-plugin!

**What kind of change does this PR introduce?** (check at least one)
<!-- Update "[ ]" to "[x]" to check a box -->

- [ ] Bugfix
- [ ] Feature
- [ ] Documentation
- [ ] Refactor
- [ ] Build improvement
- [x] Other (please describe)


**What is the goal of this pull request?**

Use latest AsciidoctorJ v2.5.11.
Dependabot did not detect it :thinking: I suspect because it's set in a property?

**Are there any alternative ways to implement this?**
no

**Are there any implications of this pull request? Anything a user must know?**
n/a

**Is it related to an existing issue?**
<!-- If Yes, please add a line of the form: `Fixes #Issue` --> 
- [ ] Yes
- [x] No

*Finally, please add a corresponding entry to CHANGELOG.adoc*
