### PR TITLE
(main) Limit Coverall dependencies to patch bumps

### DIFF
--- a/.github/dependabot.yml
+++ b/.github/dependabot.yml
@@ -22,6 +22,14 @@ updates:
       - dependency-name: org.apache.maven.doxia:*
       - dependency-name: org.codehaus.plexus:*
       - dependency-name: commons-io:commons-io
+      - dependency-name: org.glassfish.jaxb:jaxb-runtime
+        update-types:
+          - "version-update:semver-major"
+          - "version-update:semver-minor"
+      - dependency-name: jakarta.xml.bind:jakarta.xml.bind-api
+        update-types:
+          - "version-update:semver-major"
+          - "version-update:semver-minor"
   - package-ecosystem: "maven"
     directory: "/"
     schedule:
@@ -38,3 +46,11 @@ updates:
       - dependency-name: org.apache.maven.doxia:*
       - dependency-name: org.codehaus.plexus:*
       - dependency-name: commons-io:commons-io
+      - dependency-name: org.glassfish.jaxb:jaxb-runtime
+        update-types:
+          - "version-update:semver-major"
+          - "version-update:semver-minor"
+      - dependency-name: jakarta.xml.bind:jakarta.xml.bind-api
+        update-types:
+          - "version-update:semver-major"
+          - "version-update:semver-minor"


### PR DESCRIPTION
**What kind of change does this PR introduce?** (check at least one)
<!-- Update "[ ]" to "[x]" to check a box -->

- [ ] Bugfix
- [ ] Feature
- [ ] Documentation
- [ ] Refactor
- [x] Build improvement
- [ ] Other (please describe)


**What is the goal of this pull request?**

Limit to non-breaking version until integration is revisited

**Are there any alternative ways to implement this?**

We could ignore completely, but I'd rather at least keep things to stable versions.

**Are there any implications of this pull request? Anything a user must know?**

n/a

**Is it related to an existing issue?**
<!-- If Yes, please add a line of the form: `Fixes #Issue` --> 
- [ ] Yes
- [x] No

*Finally, please add a corresponding entry to CHANGELOG.adoc*
