### PR TITLE
(main) Fix and test Javadoc generation

### DIFF
--- a/.github/workflows/build.yaml
+++ b/.github/workflows/build.yaml
@@ -45,3 +45,23 @@ jobs:
         run: mvn -version
       - name: Build & Test
         run: mvn -B -Prun-its clean verify
+  javadocs:
+    name: Javadocs
+    strategy:
+      fail-fast: false
+      matrix:
+        os:
+          - ubuntu-latest
+        java:
+          - 11
+        maven:
+          - 3.9.6
+    runs-on: ${{ matrix.os }}
+    steps:
+      - uses: s4u/setup-maven-action@v1.11.0
+        with:
+          java-distribution: 'temurin'
+          java-version: ${{ matrix.java }}
+          maven-version: ${{ matrix.maven }}
+      - name: Build & Test
+        run: mvn -B clean javadoc:jar

--- a/CHANGELOG.adoc
+++ b/CHANGELOG.adoc
@@ -40,6 +40,7 @@ Build / Infrastructure::
   * Add Java 21 to CI (#664)
   * Add Dependabot to automate dependency management (#669)
   * Improvements to dependency management (#690)
+  * Test Javadoc generation in CI (#690)
 
 Documentation::
 

--- a/asciidoctor-maven-plugin/src/main/java/org/asciidoctor/maven/process/CopyResourcesProcessor.java
+++ b/asciidoctor-maven-plugin/src/main/java/org/asciidoctor/maven/process/CopyResourcesProcessor.java
@@ -17,7 +17,7 @@ import static org.asciidoctor.maven.commons.StringUtils.isNotBlank;
 /**
  * {@link ResourcesProcessor} implementation that copies all valid resources from
  * a source directory to an output one.
- * <p/>
+ * <p>
  * Following resources are not valid:
  * - AsciiDoc documents: based on file extension.
  * - Asciidoctor Docinfo files.

--- a/asciidoctor-parser-doxia-module/src/main/java/org/asciidoctor/maven/site/ast/processors/AbstractSinkNodeProcessor.java
+++ b/asciidoctor-parser-doxia-module/src/main/java/org/asciidoctor/maven/site/ast/processors/AbstractSinkNodeProcessor.java
@@ -18,7 +18,10 @@ public class AbstractSinkNodeProcessor {
 
     /**
      * Tests for the presence of an attribute in current and parent nodes.
-     * Returns first match.
+     *
+     * @param name attribute name
+     * @param node node to check
+     * @return true if attribute is found
      */
     protected boolean hasAttribute(String name, ContentNode node) {
         ContentNode current = node;


### PR DESCRIPTION
**What kind of change does this PR introduce?** (check at least one)
<!-- Update "[ ]" to "[x]" to check a box -->

- [ ] Bugfix
- [ ] Feature
- [ ] Documentation
- [ ] Refactor
- [x] Build improvement
- [ ] Other (please describe)


**What is the goal of this pull request?**

Ensure we don't find Javadoc issues right when are testing a release :facepalm: To achieve it, we add a job to CI to run Javadoc generation and fail if something is wrong.
We DO accept warnings though, these are complaints about getter/setters and other that do not add value imho.

**Are there any alternative ways to implement this?**

We could enable Javadoc in the normal build, but that would slow the normal development and testing. I'd rather have it a separate CI job.

**Are there any implications of this pull request? Anything a user must know?**

Contributors would need to be aware that Javadocs are now a requirement, at least no errors.

**Is it related to an existing issue?**
<!-- If Yes, please add a line of the form: `Fixes #Issue` --> 
- [ ] Yes
- [x] No

*Finally, please add a corresponding entry to CHANGELOG.adoc*
