### PR TITLE
Fix missing maven-deploy and prerequisites Maven warnings

### DIFF
--- a/CHANGELOG.adoc
+++ b/CHANGELOG.adoc
@@ -28,6 +28,10 @@ Improvements::
   * Set minimal Maven version to v3.8.5 (#629)
   * Replace deprecated 'headerFooter' by 'standalone' in configuration (#649)
   * Remove internal use of 'destinationDir' AsciidoctorJ method (no changes for users) (#650)
+  * Upgrade Asciidoctorj to v2.5.4 and jRuby to v9.3.4.0 (#584)
+  * Upgrade Asciidoctorj to v2.5.5 (#591)
+  * Upgrade Asciidoctorj to v2.5.6 and jRuby to v9.3.8.0 (#602)
+  * Upgrade Asciidoctorj to v2.5.7 (#604)
   * Upgrade Asciidoctorj to v2.5.10 and jRuby to v9.4.2.0 (#647)
   * Upgrade Asciidoctorj to v2.5.11 (#688)
 
@@ -38,25 +42,10 @@ Build / Infrastructure::
   * Use Maven v3.9.2 in CI and wrapper (#658)
   * Use Maven v3.9.5 in CI and wrapper (#662)
   * Add Java 21 to CI (#664)
-  * Add Dependabot to automate dependency management (#669)
-  * Improvements to dependency management (#690)
-  * Test Javadoc generation in CI (#690)
-  * Fix maven-deploy-plugin and prerequisites Maven warnings (#709)
-
-Documentation::
-
-  * Add v3.x.x migration guide (#598)
-
-Build / Infrastructure::
-
   * Bump Doxia to v1.11.1 and maven-site-plugin in IT to 3.12.0 (#579)
   * Bump netty-codec-http to v4.1.77.Final (fix CVE-2021-21290) (#582)
   * Bump netty-codec-http to v4.1.87.Final (fix CVE-2022-41915) (#612)
   * Bump netty-codec-http to v4.1.89.Final (#615)
-  * Upgrade Asciidoctorj to v2.5.4 and jRuby to v9.3.4.0 (#584)
-  * Upgrade Asciidoctorj to v2.5.5 (#591)
-  * Upgrade Asciidoctorj to v2.5.6 and jRuby to v9.3.8.0 (#602)
-  * Upgrade Asciidoctorj to v2.5.7 (#604)
   * Upgrade build related Maven plugins to the latest versions (#606)
   * Set minimal maven version to 3.8.5 (#607)
   * Bump GH 'checkout' and 'setup-java' to v3 & delete unused TravisCI configuration (#627)
@@ -65,6 +54,10 @@ Build / Infrastructure::
   * Add Maven matrix testing + define Maven compatibility policy (#632)
   * Bump build related Maven plugins to the latest versions (#635)
   * Remove use of deprecated 'parent.version' Maven property (#606)
+  * Add Dependabot to automate dependency management (#669)
+  * Improvements to dependency management (#690)
+  * Test Javadoc generation in CI (#690)
+  * Fix maven-deploy-plugin and prerequisites Maven warnings (#709)
 
 Maintenance::
   * Replace use of reflection by direct JavaExtensionRegistry calls to register extensions (#596)
@@ -72,6 +65,7 @@ Maintenance::
 Documentation::
 
   * Fix absolute path in usage example and AsciiDoc references in docs (https://github.com/MarkusTiede[@MarkusTiede])(#592)
+  * Add v3.x.x migration guide (#598)
 
 == v2.2.2 (2022-01-30)
 

--- a/CHANGELOG.adoc
+++ b/CHANGELOG.adoc
@@ -41,6 +41,7 @@ Build / Infrastructure::
   * Add Dependabot to automate dependency management (#669)
   * Improvements to dependency management (#690)
   * Test Javadoc generation in CI (#690)
+  * Fix maven-deploy-plugin and prerequisites Maven warnings (#709)
 
 Documentation::
 

--- a/asciidoctor-maven-plugin/pom.xml
+++ b/asciidoctor-maven-plugin/pom.xml
@@ -17,6 +17,10 @@
     <description>Asciidoctor Maven Plugin to convert AsciiDoc documents with Asciidoctor</description>
     <url>https://github.com/asciidoctor/asciidoctor-maven-plugin</url>
 
+    <prerequisites>
+        <maven>3.8.5</maven>
+    </prerequisites>
+
     <properties>
         <maven.plugin.plugin.version>3.8.1</maven.plugin.plugin.version>
         <netty.version>4.1.104.Final</netty.version>

--- a/pom.xml
+++ b/pom.xml
@@ -68,10 +68,6 @@
         <system>GitHub Issues</system>
     </issueManagement>
 
-    <prerequisites>
-        <maven>3.8.5</maven>
-    </prerequisites>
-
     <properties>
         <project.build.sourceEncoding>UTF-8</project.build.sourceEncoding>
         <project.java.version>11</project.java.version>
@@ -152,6 +148,11 @@
 
         <pluginManagement>
             <plugins>
+                <plugin>
+                    <groupId>org.apache.maven.plugins</groupId>
+                    <artifactId>maven-deploy-plugin</artifactId>
+                    <version>3.1.1</version>
+                </plugin>
                 <plugin>
                     <groupId>org.apache.maven.plugins</groupId>
                     <artifactId>maven-release-plugin</artifactId>


### PR DESCRIPTION
Thank you for opening a pull request and contributing to asciidoctor-maven-plugin!

**What kind of change does this PR introduce?** (check at least one)
<!-- Update "[ ]" to "[x]" to check a box -->

- [x] Bugfix
- [ ] Feature
- [ ] Documentation
- [ ] Refactor
- [x] Build improvement
- [ ] Other (please describe)


**What is the goal of this pull request?**

Fix build warnings observed in my machine. In short, we needed to set the version for `maven-deploy-plugin` and place `<prerequisites>` in the actual maven plugin sub-module, not the root.

```
[WARNING] Some problems were encountered while building the effective model for org.asciidoctor:asciidoctor-maven-plugin:maven-plugin:3.0.0-SNAPSHOT
[WARNING] 'build.plugins.plugin.version' for org.apache.maven.plugins:maven-deploy-plugin is missing. @ org.apache.maven:maven-model-builder:3.8.8:super-pom, jar:file:/home/asalgadr/.sdkman/candidates/maven/3.8.8/lib/maven-model-builder-3.8.8.jar!/org/apache/maven/model/pom-4.0.0.xml, line 137, column 19
[WARNING] 
[WARNING] Some problems were encountered while building the effective model for org.asciidoctor:asciidoctor-converter-doxia-module:jar:3.0.0-SNAPSHOT
[WARNING] 'build.plugins.plugin.version' for org.apache.maven.plugins:maven-deploy-plugin is missing. @ org.apache.maven:maven-model-builder:3.8.8:super-pom, jar:file:/home/asalgadr/.sdkman/candidates/maven/3.8.8/lib/maven-model-builder-3.8.8.jar!/org/apache/maven/model/pom-4.0.0.xml, line 137, column 19
[WARNING] 
[WARNING] Some problems were encountered while building the effective model for org.asciidoctor:asciidoctor-parser-doxia-module:jar:3.0.0-SNAPSHOT
[WARNING] 'build.plugins.plugin.version' for org.apache.maven.plugins:maven-deploy-plugin is missing. @ org.apache.maven:maven-model-builder:3.8.8:super-pom, jar:file:/home/asalgadr/.sdkman/candidates/maven/3.8.8/lib/maven-model-builder-3.8.8.jar!/org/apache/maven/model/pom-4.0.0.xml, line 137, column 19
[WARNING] 
[WARNING] Some problems were encountered while building the effective model for org.asciidoctor:asciidoctor-maven-commons:jar:3.0.0-SNAPSHOT
[WARNING] 'build.plugins.plugin.version' for org.apache.maven.plugins:maven-deploy-plugin is missing. @ org.apache.maven:maven-model-builder:3.8.8:super-pom, jar:file:/home/asalgadr/.sdkman/candidates/maven/3.8.8/lib/maven-model-builder-3.8.8.jar!/org/apache/maven/model/pom-4.0.0.xml, line 137, column 19
[WARNING] 
[WARNING] Some problems were encountered while building the effective model for org.asciidoctor:asciidoctor-maven-tools:pom:3.0.0-SNAPSHOT
[WARNING] 'build.plugins.plugin.version' for org.apache.maven.plugins:maven-deploy-plugin is missing. @ org.apache.maven:maven-model-builder:3.8.8:super-pom, jar:file:/home/asalgadr/.sdkman/candidates/maven/3.8.8/lib/maven-model-builder-3.8.8.jar!/org/apache/maven/model/pom-4.0.0.xml, line 137, column 19
[WARNING] 


[WARNING] The project org.asciidoctor:asciidoctor-maven-tools:pom:3.0.0-SNAPSHOT uses prerequisites which is only intended for maven-plugin projects but not for non maven-plugin projects. For such purposes you should use the maven-enforcer-plugin. See https://maven.apache.org/enforcer/enforcer-rules/requireMavenVersion.html
```

Also, fixed CHANGELOG.

**Are there any alternative ways to implement this?**

no

**Are there any implications of this pull request? Anything a user must know?**

n/a

**Is it related to an existing issue?**
<!-- If Yes, please add a line of the form: `Fixes #Issue` --> 
- [ ] Yes
- [x] No

*Finally, please add a corresponding entry to CHANGELOG.adoc*
