### PR TITLE
(main) Pin mockito to 4.x.x in branch v2.2.x

### DIFF
--- a/.github/dependabot.yml
+++ b/.github/dependabot.yml
@@ -46,6 +46,9 @@ updates:
       - dependency-name: org.apache.maven.doxia:*
       - dependency-name: org.codehaus.plexus:*
       - dependency-name: commons-io:commons-io
+      - dependency-name: org.mockito:mockito-core
+        update-types:
+          - "version-update:semver-major"
       - dependency-name: org.glassfish.jaxb:jaxb-runtime
         update-types:
           - "version-update:semver-major"


### PR DESCRIPTION
Newer versions are not Java8 compatible

Thank you for opening a pull request and contributing to asciidoctor-maven-plugin!

**What kind of change does this PR introduce?** (check at least one)
<!-- Update "[ ]" to "[x]" to check a box -->

- [ ] Bugfix
- [ ] Feature
- [ ] Documentation
- [ ] Refactor
- [x] Build improvement
- [ ] Other (please describe)


**What is the goal of this pull request?**

Avoid Dependabot bumps that we know are not compatible :point_right: mockito removed Java 8 compat with v5.x.x.

**Are there any alternative ways to implement this?**

no

**Are there any implications of this pull request? Anything a user must know?**

n/a

**Is it related to an existing issue?**
<!-- If Yes, please add a line of the form: `Fixes #Issue` --> 
- [ ] Yes
- [x] No

*Finally, please add a corresponding entry to CHANGELOG.adoc*
