### PR TITLE
(main) (experimental) Test Maven 4 Beta

### DIFF
--- a/asciidoctor-maven-commons/pom.xml
+++ b/asciidoctor-maven-commons/pom.xml
@@ -36,8 +36,20 @@
         <dependency>
             <groupId>org.codehaus.plexus</groupId>
             <artifactId>plexus-utils</artifactId>
-            <version>3.5.1</version>
+            <version>4.0.2</version>
             <scope>compile</scope>
+        </dependency>
+        <dependency>
+            <groupId>org.apache.maven</groupId>
+            <artifactId>maven-api-xml</artifactId>
+            <version>${maven.version}</version>
+            <scope>provided</scope>
+        </dependency>
+        <dependency>
+            <groupId>org.apache.maven</groupId>
+            <artifactId>maven-xml-impl</artifactId>
+            <version>${maven.version}</version>
+            <scope>provided</scope>
         </dependency>
         <dependency>
             <groupId>org.apache.maven.doxia</groupId>

--- a/pom.xml
+++ b/pom.xml
@@ -70,7 +70,7 @@
     <properties>
         <project.build.sourceEncoding>UTF-8</project.build.sourceEncoding>
         <project.java.version>11</project.java.version>
-        <maven.version>3.9.9</maven.version>
+        <maven.version>4.0.0-beta-5</maven.version>
         <doxia.version>2.0.0</doxia.version>
         <doxia.sitetools.version>2.0.0</doxia.sitetools.version>
         <plexus-component-metadata.version>2.2.0</plexus-component-metadata.version>


### PR DESCRIPTION
So far, things are working fine without changes. The only things:

* Xpp3Doom no longer supports 'getParent()' https://github.com/codehaus-plexus/plexus-xml/commit/0bcfeb7a783eee7931094ee2d70f8ca086aa11dc


We also added Maven 4 to the examples to test them https://github.com/asciidoctor/asciidoctor-maven-examples/pull/234

TODO:
 - [ ] Adjust Java to minimal required: 17