### PR TITLE
(main) Remove commons-io exclusion from Dependabot

### DIFF
--- a/.github/dependabot.yml
+++ b/.github/dependabot.yml
@@ -21,7 +21,6 @@ updates:
       - dependency-name: org.apache.maven.plugin-tools:*
       - dependency-name: org.apache.maven.doxia:*
       - dependency-name: org.codehaus.plexus:*
-      - dependency-name: commons-io:commons-io
       - dependency-name: org.glassfish.jaxb:jaxb-runtime
         update-types:
           - "version-update:semver-major"


### PR DESCRIPTION
**What kind of change does this PR introduce?** (check at least one)
<!-- Update "[ ]" to "[x]" to check a box -->

- [ ] Bugfix
- [ ] Feature
- [ ] Documentation
- [ ] Refactor
- [X] Build improvement
- [ ] Other (please describe)


**What is the goal of this pull request?**
`commons-io` hasn't been part of the Maven runtime for a long, long time. So we can manage ourselves as a direct plugin dependency.

**Are there any alternative ways to implement this?**

no

**Are there any implications of this pull request? Anything a user must know?**

no

**Is it related to an existing issue?**
<!-- If Yes, please add a line of the form: `Fixes #Issue` --> 
- [ ] Yes
- [X] No

*Finally, please add a corresponding entry to CHANGELOG.adoc*
