### PR TITLE
(main) Use latest maven-plugin-tools

### DIFF
--- a/.github/dependabot.yml
+++ b/.github/dependabot.yml
@@ -18,7 +18,6 @@ updates:
     ignore:
       - dependency-name: org.jruby:jruby
       - dependency-name: org.apache.maven:*
-      - dependency-name: org.apache.maven.plugin-tools:*
       - dependency-name: org.apache.maven.doxia:*
       - dependency-name: org.codehaus.plexus:*
       - dependency-name: commons-io:commons-io

--- a/CHANGELOG.adoc
+++ b/CHANGELOG.adoc
@@ -58,6 +58,7 @@ Build / Infrastructure::
   * Improvements to dependency management (#690)
   * Test Javadoc generation in CI (#690)
   * Fix maven-deploy-plugin and prerequisites Maven warnings (#709)
+  * Use latest maven-plugin-tools and remove Dependabot exclusion (CI test ensure backward compatibility) (#717)
 
 Maintenance::
   * Replace use of reflection by direct JavaExtensionRegistry calls to register extensions (#596)

--- a/asciidoctor-maven-plugin/pom.xml
+++ b/asciidoctor-maven-plugin/pom.xml
@@ -22,7 +22,7 @@
     </prerequisites>
 
     <properties>
-        <maven.plugin.plugin.version>3.8.1</maven.plugin.plugin.version>
+        <maven-plugin-tools.version>3.10.2</maven-plugin-tools.version>
         <netty.version>4.1.104.Final</netty.version>
     </properties>
 
@@ -51,7 +51,7 @@
         <dependency>
             <groupId>org.apache.maven.plugin-tools</groupId>
             <artifactId>maven-plugin-annotations</artifactId>
-            <version>${maven.plugin.plugin.version}</version>
+            <version>${maven-plugin-tools.version}</version>
             <scope>provided</scope>
         </dependency>
         <dependency>
@@ -90,7 +90,7 @@
                 <plugin>
                     <groupId>org.apache.maven.plugins</groupId>
                     <artifactId>maven-plugin-plugin</artifactId>
-                    <version>${maven.plugin.plugin.version}</version>
+                    <version>${maven-plugin-tools.version}</version>
                     <configuration>
                         <goalPrefix>asciidoctor</goalPrefix>
                         <skipErrorNoDescriptorsFound>true</skipErrorNoDescriptorsFound>


### PR DESCRIPTION
**What kind of change does this PR introduce?** (check at least one)
<!-- Update "[ ]" to "[x]" to check a box -->

- [ ] Bugfix
- [ ] Feature
- [ ] Documentation
- [ ] Refactor
- [x] Build improvement
- [ ] Other (please describe)


**What is the goal of this pull request?**

Maven Plugin Tools is a set of tools (plugin, dependencies) to generate metadata required for the Maven plugin. As such, we can run the latest and use Dependabot to automate the management without issues.
We still have CI tests to validate backward compatibility.

**Are there any alternative ways to implement this?**

Keep using a pinned older version, however that means we cannot use Dependabot. So we depend on manual action to update from time to time.
Since we have CI to test multiple Maven versions I don't think it makes sense to keep this "use older version" policy.
There will be other similar PRs like this for other dependencies.

**Are there any implications of this pull request? Anything a user must know?**

no

**Is it related to an existing issue?**
<!-- If Yes, please add a line of the form: `Fixes #Issue` --> 
- [ ] Yes
- [x] No

*Finally, please add a corresponding entry to CHANGELOG.adoc*
