### PR TITLE
(main) Use latest Maven version

### DIFF
--- a/.github/dependabot.yml
+++ b/.github/dependabot.yml
@@ -17,7 +17,6 @@ updates:
     target-branch: "main"
     ignore:
       - dependency-name: org.jruby:jruby
-      - dependency-name: org.apache.maven:*
       - dependency-name: org.glassfish.jaxb:jaxb-runtime
         update-types:
           - "version-update:semver-major"

--- a/CHANGELOG.adoc
+++ b/CHANGELOG.adoc
@@ -60,6 +60,7 @@ Build / Infrastructure::
   * Fix maven-deploy-plugin and prerequisites Maven warnings (#709)
   * Use latest maven-plugin-tools and remove Dependabot exclusion (CI test ensure backward compatibility) (#717)
   * Use latest Maven Doxia and remove Dependabot exclusion (CI test ensure backward compatibility) (#719)
+  * Use latest Maven and remove Dependabot exclusion (CI test ensure backward compatibility) (#722)
 
 Maintenance::
   * Replace use of reflection by direct JavaExtensionRegistry calls to register extensions (#596)

--- a/asciidoctor-converter-doxia-module/pom.xml
+++ b/asciidoctor-converter-doxia-module/pom.xml
@@ -36,7 +36,7 @@
         <dependency>
             <groupId>org.apache.maven</groupId>
             <artifactId>maven-core</artifactId>
-            <version>${maven.project.version}</version>
+            <version>${maven.version}</version>
             <scope>provided</scope>
         </dependency>
         <dependency>

--- a/asciidoctor-maven-commons/pom.xml
+++ b/asciidoctor-maven-commons/pom.xml
@@ -22,10 +22,6 @@
     </description>
     <url>https://github.com/asciidoctor/asciidoctor-maven-plugin</url>
 
-    <properties>
-        <plexus.utils.version>3.5.1</plexus.utils.version>
-    </properties>
-
     <dependencies>
         <dependency>
             <groupId>org.asciidoctor</groupId>
@@ -35,13 +31,13 @@
         <dependency>
             <groupId>org.apache.maven</groupId>
             <artifactId>maven-core</artifactId>
-            <version>${maven.project.version}</version>
+            <version>${maven.version}</version>
             <scope>provided</scope>
         </dependency>
         <dependency>
             <groupId>org.codehaus.plexus</groupId>
             <artifactId>plexus-utils</artifactId>
-            <version>${plexus.utils.version}</version>
+            <version>3.5.1</version>
             <scope>compile</scope>
         </dependency>
     </dependencies>

--- a/asciidoctor-maven-plugin/pom.xml
+++ b/asciidoctor-maven-plugin/pom.xml
@@ -23,7 +23,6 @@
 
     <properties>
         <maven-plugin-tools.version>3.10.2</maven-plugin-tools.version>
-        <netty.version>4.1.104.Final</netty.version>
     </properties>
 
     <dependencies>
@@ -44,8 +43,8 @@
         </dependency>
         <dependency>
             <groupId>org.apache.maven</groupId>
-            <artifactId>maven-plugin-api</artifactId>
-            <version>${maven.project.version}</version>
+            <artifactId>maven-core</artifactId>
+            <version>${maven.version}</version>
             <scope>provided</scope>
         </dependency>
         <dependency>
@@ -55,17 +54,6 @@
             <scope>provided</scope>
         </dependency>
         <dependency>
-            <groupId>org.apache.maven</groupId>
-            <artifactId>maven-core</artifactId>
-            <version>${maven.project.version}</version>
-            <scope>provided</scope>
-        </dependency>
-        <dependency>
-            <groupId>org.codehaus.plexus</groupId>
-            <artifactId>plexus-interpolation</artifactId>
-            <version>1.27</version>
-        </dependency>
-        <dependency>
             <groupId>commons-io</groupId>
             <artifactId>commons-io</artifactId>
             <version>2.15.1</version>
@@ -73,7 +61,7 @@
         <dependency>
             <groupId>io.netty</groupId>
             <artifactId>netty-codec-http</artifactId>
-            <version>${netty.version}</version>
+            <version>4.1.104.Final</version>
         </dependency>
     </dependencies>
 
@@ -94,32 +82,6 @@
                     <configuration>
                         <goalPrefix>asciidoctor</goalPrefix>
                         <skipErrorNoDescriptorsFound>true</skipErrorNoDescriptorsFound>
-                    </configuration>
-                </plugin>
-                <!--This plugin's configuration is used to store Eclipse m2e settings only. It has no influence on the Maven build itself.-->
-                <plugin>
-                    <groupId>org.eclipse.m2e</groupId>
-                    <artifactId>lifecycle-mapping</artifactId>
-                    <version>1.0.0</version>
-                    <configuration>
-                        <lifecycleMappingMetadata>
-                            <pluginExecutions>
-                                <pluginExecution>
-                                    <pluginExecutionFilter>
-                                        <groupId>org.apache.maven.plugins</groupId>
-                                        <artifactId>maven-plugin-plugin</artifactId>
-                                        <versionRange>[${maven.plugin.plugin.version},)</versionRange>
-                                        <goals>
-                                            <goal>descriptor</goal>
-                                            <goal>helpmojo</goal>
-                                        </goals>
-                                    </pluginExecutionFilter>
-                                    <action>
-                                        <execute/>
-                                    </action>
-                                </pluginExecution>
-                            </pluginExecutions>
-                        </lifecycleMappingMetadata>
                     </configuration>
                 </plugin>
             </plugins>

--- a/asciidoctor-parser-doxia-module/pom.xml
+++ b/asciidoctor-parser-doxia-module/pom.xml
@@ -15,6 +15,7 @@
 
     <name>Asciidoctor Parser Doxia Module</name>
     <description>Asciidoctor Doxia Module based on Asciidoctor AST processing (for Maven Site integration)</description>
+    <url>https://github.com/asciidoctor/asciidoctor-maven-plugin</url>
 
     <dependencies>
         <dependency>
@@ -35,7 +36,7 @@
         <dependency>
             <groupId>org.apache.maven</groupId>
             <artifactId>maven-core</artifactId>
-            <version>${maven.project.version}</version>
+            <version>${maven.version}</version>
             <scope>provided</scope>
         </dependency>
         <dependency>

--- a/pom.xml
+++ b/pom.xml
@@ -71,7 +71,7 @@
     <properties>
         <project.build.sourceEncoding>UTF-8</project.build.sourceEncoding>
         <project.java.version>11</project.java.version>
-        <maven.project.version>3.9.1</maven.project.version>
+        <maven.version>3.9.6</maven.version>
         <doxia.version>1.12.0</doxia.version>
         <plexus-component-metadata.version>2.2.0</plexus-component-metadata.version>
         <asciidoctorj.version>2.5.11</asciidoctorj.version>


### PR DESCRIPTION


Thank you for opening a pull request and contributing to asciidoctor-maven-plugin!

**What kind of change does this PR introduce?** (check at least one)
<!-- Update "[ ]" to "[x]" to check a box -->

- [ ] Bugfix
- [ ] Feature
- [ ] Documentation
- [ ] Refactor
- [x] Build improvement
- [ ] Other (please describe)


**What is the goal of this pull request?**

Similar to PRs #717 and #719, to ease project maintenance
    we can automate Maven (core and transitives) dependencies
    and use CI to validate backward compatibility.
    * Remove maven exclusion from Dependabot.
    * Deleted direct references to dependencies that are provided
    by maven-core: ideally we'd like to refer them if we use them,
    but ther lack of a BOM make it un-practical.
    * Rename build properties for ease of use.
    * Fix mising 'url' in 'asciidoctor-parser-doxia-module' module.

**Are there any alternative ways to implement this?**

no

**Are there any implications of this pull request? Anything a user must know?**

no

**Is it related to an existing issue?**
<!-- If Yes, please add a line of the form: `Fixes #Issue` --> 
- [ ] Yes
- [x] No

*Finally, please add a corresponding entry to CHANGELOG.adoc*
