### PR TITLE
(main) Implement parent support for tests in Xpp3DoomBuilder

### DIFF
--- a/asciidoctor-maven-commons/src/test/java/org/asciidoctor/maven/site/Xpp3DoomBuilder.java
+++ b/asciidoctor-maven-commons/src/test/java/org/asciidoctor/maven/site/Xpp3DoomBuilder.java
@@ -6,6 +6,7 @@ public class Xpp3DoomBuilder {
 
     private Xpp3Dom rootNode;
     private Xpp3Dom currentNode;
+    private Xpp3Dom parentNode;
 
     private Xpp3DoomBuilder(String name) {
         rootNode = currentNode = new Xpp3Dom(name);
@@ -26,6 +27,7 @@ public class Xpp3DoomBuilder {
     public Xpp3DoomBuilder addChild(String name) {
         final Xpp3Dom newNode = new Xpp3Dom(name);
         currentNode.addChild(newNode);
+        parentNode = currentNode;
         currentNode = newNode;
         return this;
     }
@@ -42,12 +44,13 @@ public class Xpp3DoomBuilder {
                 currentNode.addChild(newNode);
             }
         }
+        parentNode = currentNode;
         currentNode = newNode;
         return this;
     }
 
     public Xpp3DoomBuilder parent() {
-        currentNode = currentNode.getParent();
+        currentNode = parentNode;
         return this;
     }
 


### PR DESCRIPTION
**What kind of change does this PR introduce?** (check at least one)
<!-- Update "[ ]" to "[x]" to check a box -->

- [ ] Bugfix
- [ ] Feature
- [ ] Documentation
- [x] Refactor
- [x] Build improvement
- [ ] Other (please describe)


**What is the goal of this pull request?**

The underlying Xpp3Doom implementation removes
'getParent' support in latest version, so we need
to do keep track of the parent for our tests

Fixes #638


**Are there any alternative ways to implement this?**

Maybe, but the fix is simple enough to simply get it done.

**Are there any implications of this pull request? Anything a user must know?**

no

**Is it related to an existing issue?**
<!-- If Yes, please add a line of the form: `Fixes #Issue` --> 
- [x] Yes
- [ ] No

*Finally, please add a corresponding entry to CHANGELOG.adoc*
This is for tests only, no need to report in CHANGELOG.