### PR TITLE
(main) Pin org.codehaus.plexus:plexus-utils to use v3.x.x to avoid pulling alpha dependencies

### DIFF
--- a/.github/dependabot.yml
+++ b/.github/dependabot.yml
@@ -17,6 +17,9 @@ updates:
     target-branch: "main"
     ignore:
       - dependency-name: org.jruby:jruby
+      - dependency-name: org.codehaus.plexus:plexus-utils
+        update-types:
+          - "version-update:semver-major"
       - dependency-name: org.glassfish.jaxb:jaxb-runtime
         update-types:
           - "version-update:semver-major"


### PR DESCRIPTION
**What kind of change does this PR introduce?** (check at least one)
<!-- Update "[ ]" to "[x]" to check a box -->

- [ ] Bugfix
- [ ] Feature
- [ ] Documentation
- [ ] Refactor
- [x] Build improvement
- [ ] Other (please describe)


**What is the goal of this pull request?**

See https://github.com/asciidoctor/asciidoctor-maven-plugin/pull/721#issuecomment-1873429272

plexus-utils Maven from runtime can be overridden https://issues.apache.org/jira/browse/MNG-6965. However, using 4.0.0 means, we need to add org.codehaus.plexus:plexus-xml:jar:4.0.3 because org.codehaus.plexus.util.xml.Xpp3Dom has been extracted in a sub-module. And that pulls alpha dependencies (org.apache.maven:maven-api-xml). While it may work, we should integrate alpha dependencies in a stable release.

**Are there any alternative ways to implement this?**

no

**Are there any implications of this pull request? Anything a user must know?**

no

**Is it related to an existing issue?**
<!-- If Yes, please add a line of the form: `Fixes #Issue` --> 
- [ ] Yes
- [x] No

*Finally, please add a corresponding entry to CHANGELOG.adoc*
