### PR TITLE
(v2.2.x) Fix empty destination path calculation for validation

### DIFF
--- a/CHANGELOG.adoc
+++ b/CHANGELOG.adoc
@@ -16,7 +16,7 @@ For a detailed view of what has changed, refer to the {uri-repo}/commits/main[co
 Bug Fixes::
 
   * Remove Java 'requires open access' module warning in modern Java versions with JRuby v9.4.5.0 (#553)
-  * Check for both destinationDir and toDir when to avoid invalid "Duplicated destination found" messages (#728)
+  * Check for both destinationDir and toDir when to avoid invalid "Duplicated destination found" messages, and improve warning message (#728)
 
 Build / Infrastructure::
 

--- a/CHANGELOG.adoc
+++ b/CHANGELOG.adoc
@@ -16,6 +16,7 @@ For a detailed view of what has changed, refer to the {uri-repo}/commits/main[co
 Bug Fixes::
 
   * Remove Java 'requires open access' module warning in modern Java versions with JRuby v9.4.5.0 (#553)
+  * Check for both destinationDir and toDir when to avoid invalid "Duplicated destination found" messages (#728)
 
 Build / Infrastructure::
 

--- a/src/main/java/org/asciidoctor/maven/AsciidoctorMojo.java
+++ b/src/main/java/org/asciidoctor/maven/AsciidoctorMojo.java
@@ -1,5 +1,6 @@
 package org.asciidoctor.maven;
 
+import org.apache.commons.io.FilenameUtils;
 import org.apache.maven.execution.MavenSession;
 import org.apache.maven.model.Resource;
 import org.apache.maven.plugin.AbstractMojo;
@@ -243,9 +244,15 @@ public class AsciidoctorMojo extends AbstractMojo {
 
         final Set<File> uniquePaths = new HashSet<>();
         for (final File source : sourceFiles) {
-            final File destinationPath = setDestinationPaths(source, optionsBuilder, sourceDir, this);
+            final Destination destination = setDestinationPaths(source, optionsBuilder, sourceDir, this);
+            final File destinationPath = destination.path;
             if (!uniquePaths.add(destinationPath)) {
-                getLog().warn("Duplicated destination found: overwriting file: " + destinationPath.getAbsolutePath());
+                String destinationFile = destinationPath.getAbsolutePath();
+                if (!destination.isOutput) {
+                    String baseName = FilenameUtils.getBaseName(destinationPath.getName());
+                    destinationFile = destinationPath.getParentFile().getAbsolutePath() + File.separator + baseName + ".*";
+                }
+                getLog().warn("Duplicated destination found: overwriting file: " + destinationFile);
             }
 
             convertFile(asciidoctor, optionsBuilder.asMap(), source);
@@ -358,8 +365,8 @@ public class AsciidoctorMojo extends AbstractMojo {
      * @return the final destination file path.
      * @throws MojoExecutionException If output is not valid
      */
-    public File setDestinationPaths(final File sourceFile, final OptionsBuilder optionsBuilder, final File sourceDirectory,
-                                    final AsciidoctorMojo configuration) throws MojoExecutionException {
+    public Destination setDestinationPaths(final File sourceFile, final OptionsBuilder optionsBuilder, final File sourceDirectory,
+                                           final AsciidoctorMojo configuration) throws MojoExecutionException {
         try {
             if (configuration.getBaseDir() != null) {
                 optionsBuilder.baseDir(configuration.getBaseDir());
@@ -383,12 +390,25 @@ public class AsciidoctorMojo extends AbstractMojo {
             final String destinationDir = getDestinationDir(optionsBuilder);
             if (outputFile != null) {
                 optionsBuilder.toFile(outputFile);
-                return outputFile.isAbsolute() ? outputFile : new File(destinationDir, outputFile.getPath());
+                return outputFile.isAbsolute()
+                        ? new Destination(outputFile, true)
+                        : new Destination(new File(destinationDir, outputFile.getPath()), true);
             } else {
-                return new File(destinationDir, sourceFile.getName());
+                return new Destination(new File(destinationDir, sourceFile.getName()), false);
             }
         } catch (IOException e) {
             throw new MojoExecutionException("Unable to locate output directory", e);
+        }
+    }
+
+    class Destination {
+        final File path;
+        // Whether path is the actual output file or an approximation
+        final boolean isOutput;
+
+        Destination(File destination, boolean isSource) {
+            this.path = destination;
+            this.isOutput = isSource;
         }
     }
 

--- a/src/main/java/org/asciidoctor/maven/AsciidoctorMojo.java
+++ b/src/main/java/org/asciidoctor/maven/AsciidoctorMojo.java
@@ -244,8 +244,9 @@ public class AsciidoctorMojo extends AbstractMojo {
         final Set<File> uniquePaths = new HashSet<>();
         for (final File source : sourceFiles) {
             final File destinationPath = setDestinationPaths(source, optionsBuilder, sourceDir, this);
-            if (!uniquePaths.add(destinationPath))
+            if (!uniquePaths.add(destinationPath)) {
                 getLog().warn("Duplicated destination found: overwriting file: " + destinationPath.getAbsolutePath());
+            }
 
             convertFile(asciidoctor, optionsBuilder.asMap(), source);
 
@@ -379,9 +380,8 @@ public class AsciidoctorMojo extends AbstractMojo {
                 optionsBuilder.toDir(outputDir).destinationDir(outputDir);
             }
             final File outputFile = configuration.getOutputFile();
-            final String destinationDir = (String) optionsBuilder.asMap().get(Options.DESTINATION_DIR);
+            final String destinationDir = getDestinationDir(optionsBuilder);
             if (outputFile != null) {
-                // allow overriding the output file name
                 optionsBuilder.toFile(outputFile);
                 return outputFile.isAbsolute() ? outputFile : new File(destinationDir, outputFile.getPath());
             } else {
@@ -390,6 +390,12 @@ public class AsciidoctorMojo extends AbstractMojo {
         } catch (IOException e) {
             throw new MojoExecutionException("Unable to locate output directory", e);
         }
+    }
+
+    private static String getDestinationDir(OptionsBuilder optionsBuilder) {
+        final Map<String, Object> options = optionsBuilder.asMap();
+        return (String) Optional.ofNullable(options.get(Options.DESTINATION_DIR))
+                .orElse(options.get(Options.TO_DIR));
     }
 
     protected Asciidoctor getAsciidoctorInstance(String gemPath) throws MojoExecutionException {

--- a/src/test/java/org/asciidoctor/maven/AsciidoctorMojoTest.java
+++ b/src/test/java/org/asciidoctor/maven/AsciidoctorMojoTest.java
@@ -5,12 +5,17 @@ import org.apache.commons.io.FileUtils;
 import org.apache.maven.model.Resource;
 import org.apache.maven.plugin.MojoExecutionException;
 import org.apache.maven.plugin.MojoFailureException;
+import org.asciidoctor.Options;
+import org.asciidoctor.OptionsBuilder;
 import org.asciidoctor.maven.extensions.ExtensionConfiguration;
 import org.asciidoctor.maven.io.AsciidoctorFileScanner;
 import org.asciidoctor.maven.io.ConsoleHolder;
 import org.asciidoctor.maven.test.processors.RequireCheckerTreeprocessor;
 import org.assertj.core.api.Assertions;
 import org.junit.jupiter.api.Test;
+import org.junit.jupiter.params.ParameterizedTest;
+import org.junit.jupiter.params.provider.NullAndEmptySource;
+import org.junit.jupiter.params.provider.ValueSource;
 
 import java.io.*;
 import java.nio.file.Files;
@@ -1069,4 +1074,22 @@ public class AsciidoctorMojoTest {
         consoleHolder.release();
     }
 
+    @ParameterizedTest
+    @NullAndEmptySource
+    @ValueSource(strings = {"output.html"})
+    public void should_return_absolute_path_when_calculating_destination(String outputFile) throws MojoExecutionException {
+        // given
+        final AsciidoctorMojo mojo = mockAsciidoctorMojo();
+        mojo.setOutputDirectory(newOutputTestDirectory("overlapping-outputFile"));
+        if (outputFile != null) mojo.setOutputFile(outputFile);
+        final File source = new File("source.adoc");
+        final OptionsBuilder builder = Options.builder();
+        final File sourceDir = new File(".");
+
+        // when
+        File file = mojo.setDestinationPaths(source, builder, sourceDir, mojo);
+
+        // then
+        Assertions.assertThat(file).isAbsolute();
+    }
 }

--- a/src/test/java/org/asciidoctor/maven/AsciidoctorMojoTest.java
+++ b/src/test/java/org/asciidoctor/maven/AsciidoctorMojoTest.java
@@ -7,6 +7,7 @@ import org.apache.maven.plugin.MojoExecutionException;
 import org.apache.maven.plugin.MojoFailureException;
 import org.asciidoctor.Options;
 import org.asciidoctor.OptionsBuilder;
+import org.asciidoctor.maven.AsciidoctorMojo.Destination;
 import org.asciidoctor.maven.extensions.ExtensionConfiguration;
 import org.asciidoctor.maven.io.AsciidoctorFileScanner;
 import org.asciidoctor.maven.io.ConsoleHolder;
@@ -14,7 +15,7 @@ import org.asciidoctor.maven.test.processors.RequireCheckerTreeprocessor;
 import org.assertj.core.api.Assertions;
 import org.junit.jupiter.api.Test;
 import org.junit.jupiter.params.ParameterizedTest;
-import org.junit.jupiter.params.provider.NullAndEmptySource;
+import org.junit.jupiter.params.provider.NullSource;
 import org.junit.jupiter.params.provider.ValueSource;
 
 import java.io.*;
@@ -1075,7 +1076,7 @@ public class AsciidoctorMojoTest {
     }
 
     @ParameterizedTest
-    @NullAndEmptySource
+    @NullSource
     @ValueSource(strings = {"output.html"})
     public void should_return_absolute_path_when_calculating_destination(String outputFile) throws MojoExecutionException {
         // given
@@ -1087,9 +1088,10 @@ public class AsciidoctorMojoTest {
         final File sourceDir = new File(".");
 
         // when
-        File file = mojo.setDestinationPaths(source, builder, sourceDir, mojo);
+        Destination file = mojo.setDestinationPaths(source, builder, sourceDir, mojo);
 
         // then
-        Assertions.assertThat(file).isAbsolute();
+        Assertions.assertThat(file.path).isAbsolute();
+        Assertions.assertThat(file.isOutput).isEqualTo(outputFile != null);
     }
 }


### PR DESCRIPTION
**What kind of change does this PR introduce?** (check at least one)
<!-- Update "[ ]" to "[x]" to check a box -->

- [x] Bugfix
- [ ] Feature
- [ ] Documentation
- [ ] Refactor
- [ ] Build improvement
- [ ] Other (please describe)


**What is the goal of this pull request?**

Fix #728 
Also improve message. We cannot get the exact name without duplication asciidoctor core logic, but now when outputFile is not set simply wildcard will be displayed instead of the source extension to avoid confusion:
```
[warn] Duplicated destination found: overwriting file: /.../path/single-output.*
```

**Are there any alternative ways to implement this?**

We could only check for `toDir` (as done in `main` branch) but that would break builds using older AsciidoctorJ versions.

**Are there any implications of this pull request? Anything a user must know?**

no

**Is it related to an existing issue?**
<!-- If Yes, please add a line of the form: `Fixes #Issue` --> 
- [x] Yes
- [ ] No

*Finally, please add a corresponding entry to CHANGELOG.adoc*
