### PR TITLE
(v2.2.x) Return maven-filtering to v3.3.0 from v3.3.1

### DIFF
--- a/pom.xml
+++ b/pom.xml
@@ -80,7 +80,7 @@
         <maven.jacoco.plugin.version>0.8.11</maven.jacoco.plugin.version>
         <maven.plugin.plugin.version>3.9.0</maven.plugin.plugin.version>
         <maven.project.version>3.8.5</maven.project.version>
-        <maven.filtering.version>3.3.1</maven.filtering.version>
+        <maven.filtering.version>3.3.0</maven.filtering.version>
         <plexus.utils.version>3.5.1</plexus.utils.version>
         <plexus.component.metadata.version>2.1.1</plexus.component.metadata.version>
         <netty.version>4.1.104.Final</netty.version>


### PR DESCRIPTION
**What kind of change does this PR introduce?** (check at least one)

- [ ] Bugfix
- [ ] Feature
- [ ] Documentation
- [ ] Refactor
- [ ] Build improvement
- [x] Other (please describe)

Avoid upstream bug.

**What is the goal of this pull request?**

v3.3.1 introduced a change that causes confusing output when using 'project.baseDir' for resources path.
See https://issues.apache.org/jira/browse/MSHARED-1175

The old message when copying resouces is fine.
```
Copying 118 resources
```

But the new, while less informative, omits the source after "from" in some cases.
```
Copying 118 resources from  to target/generated-docs
```

**Are there any alternative ways to implement this?**

No. I don't think we are loosing anything with the revert.

**Are there any implications of this pull request? Anything a user must know?**


**Is it related to an existing issue?**
<!-- If Yes, please add a line of the form: `Fixes #Issue` --> 
- [ ] Yes
- [x] No

*Finally, please add a corresponding entry to CHANGELOG.adoc*
