### PR TITLE
(main) Improve warning message when destination file is going to be replaced

### DIFF
--- a/CHANGELOG.adoc
+++ b/CHANGELOG.adoc
@@ -34,6 +34,7 @@ Improvements::
   * Upgrade Asciidoctorj to v2.5.7 (#604)
   * Upgrade Asciidoctorj to v2.5.10 and jRuby to v9.4.2.0 (#647)
   * Upgrade Asciidoctorj to v2.5.11 (#688)
+  * Improve warning message when destination file is going to be replaced (#728)
 
 Build / Infrastructure::
 


### PR DESCRIPTION
**What kind of change does this PR introduce?** (check at least one)
<!-- Update "[ ]" to "[x]" to check a box -->

- [ ] Bugfix
- [ ] Feature
- [ ] Documentation
- [ ] Refactor
- [ ] Build improvement
- [ ] Other (please describe)
Improvement to user messages.

**What is the goal of this pull request?**

Add improvements from PR https://github.com/asciidoctor/asciidoctor-maven-plugin/pull/730.
See #728 

**Are there any alternative ways to implement this?**

Yes, the solution is not perfect but it would require to replicate all asciidoctor internal logic to get the target file.
In truth I wonder if we should remove the message all together :thinking: 

**Are there any implications of this pull request? Anything a user must know?**

no

**Is it related to an existing issue?**
<!-- If Yes, please add a line of the form: `Fixes #Issue` --> 
- [x] Yes
- [ ] No

*Finally, please add a corresponding entry to CHANGELOG.adoc*
