### PR TITLE
(main) Automate release using GH Actions

### DIFF
--- a/.github/workflows/release.yaml
+++ b/.github/workflows/release.yaml
@@ -1,0 +1,44 @@
+name: Release
+
+on: workflow_dispatch
+permissions:
+  contents: write
+
+jobs:
+  release:
+    environment: release
+    env:
+      GPG_KEYNAME: ${{ secrets.GPG_KEYNAME }}
+      GPG_PASSPHRASE: ${{ secrets.GPG_PASSPHRASE }}
+      GPG_PRIVATE_KEY: ${{ secrets.GPG_PRIVATE_KEY }}
+    runs-on: ubuntu-latest
+    steps:
+      - name: Checkout repository
+        uses: actions/checkout@v4
+      - name: Setup Java
+        uses: actions/setup-java@v4
+        with:
+          distribution: 'temurin'
+          java-version: 11
+      - uses: s4u/maven-settings-action@v3.0.0
+        with:
+          servers: |
+            [{
+              "id": "ossrh",
+              "username": "${{ secrets.OSS_SONATYPE_USERNAME }}",
+              "password": "${{ secrets.OSS_SONATYPE_PASSWORD }}"
+            }]
+      - name: Configure Git user
+        run: |
+          git config user.email "actions@github.com"
+          git config user.name "GitHub Actions"
+      - name: Configure GPG key
+        run: echo -e "${{ env.GPG_PRIVATE_KEY }}" | gpg --import --batch
+      - name: Build artifacts
+        run: ./mvnw clean verify -B -Prelease -Dmaven.test.skip
+      - name: Publish artifacts
+        run: ./mvnw release:prepare release:perform -B -Darguments="-Prelease -Dmaven.test.skip"
+      - name: Close release
+        run: |
+          echo "Release completed 🎉"
+          echo "Remember to 'Close' & 'Release' at https://oss.sonatype.org"

--- a/CHANGELOG.adoc
+++ b/CHANGELOG.adoc
@@ -63,6 +63,7 @@ Build / Infrastructure::
   * Use latest Maven Doxia and remove Dependabot exclusion (CI test ensure backward compatibility) (#719)
   * Use latest Maven and remove Dependabot exclusion (CI test ensure backward compatibility) (#722)
   * Test artifact's signature with Maven in CI (#736)
+  * Automate release using GH Actions (#141)
 
 Maintenance::
   * Replace use of reflection by direct JavaExtensionRegistry calls to register extensions (#596)

--- a/asciidoctor-converter-doxia-module/pom.xml
+++ b/asciidoctor-converter-doxia-module/pom.xml
@@ -1,5 +1,4 @@
-<project xmlns="http://maven.apache.org/POM/4.0.0" xmlns:xsi="http://www.w3.org/2001/XMLSchema-instance"
-         xsi:schemaLocation="http://maven.apache.org/POM/4.0.0 http://maven.apache.org/xsd/maven-4.0.0.xsd">
+<project xmlns="http://maven.apache.org/POM/4.0.0" xmlns:xsi="http://www.w3.org/2001/XMLSchema-instance" xsi:schemaLocation="http://maven.apache.org/POM/4.0.0 http://maven.apache.org/xsd/maven-4.0.0.xsd">
     <modelVersion>4.0.0</modelVersion>
 
     <parent>

--- a/asciidoctor-maven-commons/pom.xml
+++ b/asciidoctor-maven-commons/pom.xml
@@ -1,5 +1,4 @@
-<project xmlns="http://maven.apache.org/POM/4.0.0" xmlns:xsi="http://www.w3.org/2001/XMLSchema-instance"
-         xsi:schemaLocation="http://maven.apache.org/POM/4.0.0 http://maven.apache.org/xsd/maven-4.0.0.xsd">
+<project xmlns="http://maven.apache.org/POM/4.0.0" xmlns:xsi="http://www.w3.org/2001/XMLSchema-instance" xsi:schemaLocation="http://maven.apache.org/POM/4.0.0 http://maven.apache.org/xsd/maven-4.0.0.xsd">
     <modelVersion>4.0.0</modelVersion>
 
     <parent>

--- a/asciidoctor-maven-plugin/pom.xml
+++ b/asciidoctor-maven-plugin/pom.xml
@@ -1,5 +1,4 @@
-<project xmlns="http://maven.apache.org/POM/4.0.0" xmlns:xsi="http://www.w3.org/2001/XMLSchema-instance"
-         xsi:schemaLocation="http://maven.apache.org/POM/4.0.0 http://maven.apache.org/xsd/maven-4.0.0.xsd">
+<project xmlns="http://maven.apache.org/POM/4.0.0" xmlns:xsi="http://www.w3.org/2001/XMLSchema-instance" xsi:schemaLocation="http://maven.apache.org/POM/4.0.0 http://maven.apache.org/xsd/maven-4.0.0.xsd">
     <modelVersion>4.0.0</modelVersion>
 
     <parent>

--- a/asciidoctor-parser-doxia-module/pom.xml
+++ b/asciidoctor-parser-doxia-module/pom.xml
@@ -1,5 +1,4 @@
-<project xmlns="http://maven.apache.org/POM/4.0.0" xmlns:xsi="http://www.w3.org/2001/XMLSchema-instance"
-         xsi:schemaLocation="http://maven.apache.org/POM/4.0.0 http://maven.apache.org/xsd/maven-4.0.0.xsd">
+<project xmlns="http://maven.apache.org/POM/4.0.0" xmlns:xsi="http://www.w3.org/2001/XMLSchema-instance" xsi:schemaLocation="http://maven.apache.org/POM/4.0.0 http://maven.apache.org/xsd/maven-4.0.0.xsd">
     <modelVersion>4.0.0</modelVersion>
 
     <parent>

--- a/pom.xml
+++ b/pom.xml
@@ -56,9 +56,9 @@
     </licenses>
 
     <scm>
-        <url>scm:git:git@github.com:asciidoctor/asciidoctor-maven-plugin.git</url>
-        <connection>scm:git:git@github.com:asciidoctor/asciidoctor-maven-plugin.git</connection>
-        <developerConnection>scm:git:git@github.com:asciidoctor/asciidoctor-maven-plugin.git</developerConnection>
+        <url>scm:git:https://github.com/asciidoctor/asciidoctor-maven-plugin.git</url>
+        <connection>scm:git:https://github.com/asciidoctor/asciidoctor-maven-plugin.git</connection>
+        <developerConnection>scm:git:https://github.com/asciidoctor/asciidoctor-maven-plugin.git</developerConnection>
         <tag>asciidoctor-maven-plugin-2.2.2</tag>
     </scm>
 

--- a/pom.xml
+++ b/pom.xml
@@ -1,6 +1,5 @@
 <?xml version="1.0" encoding="UTF-8"?>
-<project xmlns="http://maven.apache.org/POM/4.0.0" xmlns:xsi="http://www.w3.org/2001/XMLSchema-instance"
-         xsi:schemaLocation="http://maven.apache.org/POM/4.0.0 http://maven.apache.org/xsd/maven-4.0.0.xsd">
+<project xmlns="http://maven.apache.org/POM/4.0.0" xmlns:xsi="http://www.w3.org/2001/XMLSchema-instance" xsi:schemaLocation="http://maven.apache.org/POM/4.0.0 http://maven.apache.org/xsd/maven-4.0.0.xsd">
     <modelVersion>4.0.0</modelVersion>
 
     <groupId>org.asciidoctor</groupId>


### PR DESCRIPTION
Adds release pipeline to do relases from GitHub Action

Closes #141

Thank you for opening a pull request and contributing to asciidoctor-maven-plugin!

**What kind of change does this PR introduce?** (check at least one)
<!-- Update "[ ]" to "[x]" to check a box -->

- [ ] Bugfix
- [ ] Feature
- [ ] Documentation
- [ ] Refactor
- [x] Build improvement
- [ ] Other (please describe)


**What is the goal of this pull request?**
Automate releases to make the release process much easier, less error prone and avoid local configurations.
Note it requires:
* Configure secrets in repo
* `s4u/setup-maven-action` does not work, so under-the-hood actions are used https://github.com/s4u/setup-maven-action/issues/68
* It's still required to manually login into https://oss.sonatype.org to close and release.
I'll create a new GPG key only for CI, but the user used to upload to `oss.sonatype` is a token linked to my account.


**Are there any alternative ways to implement this?**
There's an alternative plugin https://github.com/sonatype/nexus-maven-plugins/tree/main (docs https://central.sonatype.org/publish/publish-maven/), but there hasn't been  release since 2016. Still maybe at some point we can review it it allows to close the staging repo automatically.


**Are there any implications of this pull request? Anything a user must know?**


**Is it related to an existing issue?**
<!-- If Yes, please add a line of the form: `Fixes #Issue` --> 
- [x] Yes #141 
- [ ] No

*Finally, please add a corresponding entry to CHANGELOG.adoc*
