### PR TITLE
(main) Doxia parser: fix missing formattings and links in lists

### DIFF
--- a/asciidoctor-parser-doxia-module/src/it/maven-site-plugin/src/site/asciidoc/sample.adoc
+++ b/asciidoctor-parser-doxia-module/src/it/maven-site-plugin/src/site/asciidoc/sample.adoc
@@ -62,6 +62,14 @@ public class HelloWorld {
 * Walnuts
 * Almonds
 
+==== Unordered list with formatting
+
+* *Apples*
+* _Oranges_
+* ~Walnuts~
+* `Almonds`
+* https://some-link.here[link]
+
 ==== Ordered list
 
 . Protons

--- a/asciidoctor-parser-doxia-module/src/it/maven-site-plugin/validate.groovy
+++ b/asciidoctor-parser-doxia-module/src/it/maven-site-plugin/validate.groovy
@@ -32,12 +32,41 @@ new HtmlAsserter(htmlContent).with { asserter ->
     asserter.containsSectionTitle("Code blocks", 3)
 
     asserter.containsSectionTitle("Lists", 3)
+
+    asserter.containsSectionTitle("Unordered list", 4)
     asserter.containsUnorderedList("Apples", "Oranges", "Walnuts", "Almonds")
+
+    asserter.containsSectionTitle("Unordered list with formatting", 4)
+    asserter.containsUnorderedList(strong("Apples"), italics("Oranges"), subscript("Walnuts"), monospace("Almonds"), htmlLink('https://some-link.here', 'link'))
 
     asserter.containsSectionTitle("Ordered list", 4)
     asserter.containsOrderedList("Protons", "Electrons", "Neutrons")
+
 }
 
+String strong(String text) {
+    return htmlElement('strong', text)
+}
+
+String italics(String text) {
+    return htmlElement('em', text)
+}
+
+String subscript(String text) {
+    return htmlElement('sub', text)
+}
+
+String monospace(String text) {
+    return htmlElement('code', text)
+}
+
+String htmlLink(String url, String label) {
+    return "<a href=\"${url}\">${label}</a>"
+}
+
+String htmlElement(String element, String text) {
+    return "<${element}>${text}</${element}>"
+}
 
 for (String unexpectedFile : unexpectedFiles) {
     File candidate = new File(outputDir, unexpectedFile)

--- a/asciidoctor-parser-doxia-module/src/main/java/org/asciidoctor/maven/site/ast/NodesSinker.java
+++ b/asciidoctor-parser-doxia-module/src/main/java/org/asciidoctor/maven/site/ast/NodesSinker.java
@@ -8,6 +8,7 @@ import org.asciidoctor.maven.site.ast.processors.ListItemNodeProcessor;
 import org.asciidoctor.maven.site.ast.processors.ListingNodeProcessor;
 import org.asciidoctor.maven.site.ast.processors.LiteralNodeProcessor;
 import org.asciidoctor.maven.site.ast.processors.OrderedListNodeProcessor;
+import org.asciidoctor.maven.site.ast.processors.ParagraphNodeProcessor;
 import org.asciidoctor.maven.site.ast.processors.PreambleNodeProcessor;
 import org.asciidoctor.maven.site.ast.processors.SectionNodeProcessor;
 import org.asciidoctor.maven.site.ast.processors.TableNodeProcessor;
@@ -49,6 +50,7 @@ public class NodesSinker {
                 new ImageNodeProcessor(sink),
                 new ListingNodeProcessor(sink),
                 new LiteralNodeProcessor(sink),
+                new ParagraphNodeProcessor(sink),
                 new PreambleNodeProcessor(sink),
                 new SectionNodeProcessor(sink),
                 new TableNodeProcessor(sink),

--- a/asciidoctor-parser-doxia-module/src/main/java/org/asciidoctor/maven/site/ast/NodesSinker.java
+++ b/asciidoctor-parser-doxia-module/src/main/java/org/asciidoctor/maven/site/ast/NodesSinker.java
@@ -1,9 +1,5 @@
 package org.asciidoctor.maven.site.ast;
 
-import java.util.Arrays;
-import java.util.List;
-import java.util.Optional;
-
 import org.apache.maven.doxia.sink.Sink;
 import org.asciidoctor.ast.StructuralNode;
 import org.asciidoctor.maven.site.ast.processors.DocumentNodeProcessor;
@@ -12,11 +8,14 @@ import org.asciidoctor.maven.site.ast.processors.ListItemNodeProcessor;
 import org.asciidoctor.maven.site.ast.processors.ListingNodeProcessor;
 import org.asciidoctor.maven.site.ast.processors.LiteralNodeProcessor;
 import org.asciidoctor.maven.site.ast.processors.OrderedListNodeProcessor;
-import org.asciidoctor.maven.site.ast.processors.ParagraphNodeProcessor;
 import org.asciidoctor.maven.site.ast.processors.PreambleNodeProcessor;
 import org.asciidoctor.maven.site.ast.processors.SectionNodeProcessor;
 import org.asciidoctor.maven.site.ast.processors.TableNodeProcessor;
 import org.asciidoctor.maven.site.ast.processors.UnorderedListNodeProcessor;
+
+import java.util.Arrays;
+import java.util.List;
+import java.util.Optional;
 
 /**
  * Document processor.
@@ -47,15 +46,14 @@ public class NodesSinker {
 
         nodeProcessors = Arrays.asList(
                 new DocumentNodeProcessor(sink),
-                new PreambleNodeProcessor(sink),
-                new ParagraphNodeProcessor(sink),
-                new SectionNodeProcessor(sink),
-                unorderedListNodeProcessor,
-                orderedListNodeProcessor,
-                new TableNodeProcessor(sink),
-                new ListingNodeProcessor(sink),
                 new ImageNodeProcessor(sink),
-                new LiteralNodeProcessor(sink)
+                new ListingNodeProcessor(sink),
+                new LiteralNodeProcessor(sink),
+                new PreambleNodeProcessor(sink),
+                new SectionNodeProcessor(sink),
+                new TableNodeProcessor(sink),
+                orderedListNodeProcessor,
+                unorderedListNodeProcessor
         );
     }
 

--- a/asciidoctor-parser-doxia-module/src/main/java/org/asciidoctor/maven/site/ast/processors/ListItemNodeProcessor.java
+++ b/asciidoctor-parser-doxia-module/src/main/java/org/asciidoctor/maven/site/ast/processors/ListItemNodeProcessor.java
@@ -50,7 +50,7 @@ public class ListItemNodeProcessor extends AbstractSinkNodeProcessor implements 
         else
             sink.numberedListItem();
 
-        sink.text(item.getText());
+        sink.rawText(item.getText());
 
         for (StructuralNode subNode : node.getBlocks()) {
             for (NodeProcessor np : nodeProcessors) {

--- a/asciidoctor-parser-doxia-module/src/main/java/org/asciidoctor/maven/site/ast/processors/ListItemNodeProcessor.java
+++ b/asciidoctor-parser-doxia-module/src/main/java/org/asciidoctor/maven/site/ast/processors/ListItemNodeProcessor.java
@@ -50,7 +50,8 @@ public class ListItemNodeProcessor extends AbstractSinkNodeProcessor implements 
         else
             sink.numberedListItem();
 
-        sink.rawText(item.getText());
+        String text = item.getText();
+        sink.rawText(text == null ? "" : text);
 
         for (StructuralNode subNode : node.getBlocks()) {
             for (NodeProcessor np : nodeProcessors) {

--- a/asciidoctor-parser-doxia-module/src/main/java/org/asciidoctor/maven/site/ast/processors/ParagraphNodeProcessor.java
+++ b/asciidoctor-parser-doxia-module/src/main/java/org/asciidoctor/maven/site/ast/processors/ParagraphNodeProcessor.java
@@ -30,6 +30,7 @@ public class ParagraphNodeProcessor extends AbstractSinkNodeProcessor implements
     public void process(StructuralNode node) {
         getSink().paragraph();
         // content returns HTML processed including bold, italics, monospace, etc. attributes resolution
+        // TODO run convert() instead of getContent?
         String content = (String) node.getContent();
         getSink().rawText(content);
         getSink().paragraph_();

--- a/asciidoctor-parser-doxia-module/src/test/java/org/asciidoctor/maven/site/ast/AsciidoctorAstDoxiaParserTest.java
+++ b/asciidoctor-parser-doxia-module/src/test/java/org/asciidoctor/maven/site/ast/AsciidoctorAstDoxiaParserTest.java
@@ -44,11 +44,12 @@ class AsciidoctorAstDoxiaParserTest {
         String result = parse(parser, srcAsciidoc);
 
         assertThat(result)
-                .isEqualTo("<h1>Document Title</h1><p>Preamble paragraph.</p>" +
+                .isEqualTo("<h1>Document Title</h1>" +
+                        "<p>Preamble paragraph.</p>" +
                         "<h2><a name=\"Section_A\"></a>Section A</h2>" +
                         "<p><strong>Section A</strong> paragraph.</p>" +
                         "<h3><a name=\"Section_A_Subsection\"></a>Section A Subsection</h3>" +
-                        "<p><strong>Section A</strong> <em>subsection</em> paragraph.</p>" +
+                        "<p><strong>Section A</strong> 'subsection' paragraph.</p>" +
                         "<h2><a name=\"Section_B\"></a>Section B</h2>" +
                         "<p><strong>Section B</strong> paragraph.</p>" +
                         "<ul>" +

--- a/asciidoctor-parser-doxia-module/src/test/java/org/asciidoctor/maven/site/ast/processors/ListItemNodeProcessorTest.java
+++ b/asciidoctor-parser-doxia-module/src/test/java/org/asciidoctor/maven/site/ast/processors/ListItemNodeProcessorTest.java
@@ -25,7 +25,9 @@ class ListItemNodeProcessorTest {
     @ParameterizedTest
     @ValueSource(strings = {"*", "-"})
     void should_convert_list_item(String marker) {
-        String content = buildDocument(marker);
+        String content = new DocumentBuilder()
+                .listItem(marker)
+                .toString();
 
         String html = process(content);
 
@@ -35,7 +37,9 @@ class ListItemNodeProcessorTest {
 
     @Test
     void should_convert_ordered_list_item() {
-        String content = buildDocument(".");
+        String content = new DocumentBuilder()
+                .listItem(".")
+                .toString();
 
         String html = process(content);
 
@@ -43,14 +47,72 @@ class ListItemNodeProcessorTest {
                 .isEqualTo(htmlListItem());
     }
 
-    private static String htmlListItem() {
-        return "<li>unordered item</li>";
+    @ParameterizedTest
+    @ValueSource(strings = {"*", "-"})
+    void should_convert_ordered_list_item_with_formatting() {
+        String content = new DocumentBuilder()
+                .formattedListItem("*")
+                .toString();
+
+        String html = process(content);
+
+        assertThat(html)
+                .isEqualTo(htmlListItemWithFormatting());
     }
 
-    private static String buildDocument(String marker) {
-        return "= Document tile\n\n"
-                + "== Section\n\n"
-                + marker + " unordered item\n";
+    @ParameterizedTest
+    @ValueSource(strings = {"*", "-"})
+    void should_convert_ordered_list_item_with_link(String marker) {
+        String content = new DocumentBuilder()
+                .linkListItem(marker)
+                .toString();
+
+        String html = process(content);
+
+        assertThat(html)
+                .isEqualTo(htmlListItemWithLink());
+    }
+
+    private static String htmlListItem() {
+        return "<li>list item</li>";
+    }
+
+    private static String htmlListItemWithFormatting() {
+        return "<li><strong>list</strong> <em>item</em></li>";
+    }
+
+    private static String htmlListItemWithLink() {
+        return "<li>list <a href=\"https://something-random.org/\">item</a></li>";
+    }
+
+    class DocumentBuilder {
+
+        private final StringBuilder sb = new StringBuilder();
+
+        DocumentBuilder() {
+            sb.append("= Document tile\n\n");
+            sb.append("== Section\n\n");
+        }
+
+        DocumentBuilder listItem(String marker) {
+            sb.append(marker + " list item\n");
+            return this;
+        }
+
+        DocumentBuilder formattedListItem(String marker) {
+            sb.append(marker + " *list* _item_\n");
+            return this;
+        }
+
+        DocumentBuilder linkListItem(String marker) {
+            sb.append(marker + " list https://something-random.org/[item]\n");
+            return this;
+        }
+
+        @Override
+        public String toString() {
+            return sb.toString();
+        }
     }
 
     private String process(String content) {

--- a/asciidoctor-parser-doxia-module/src/test/resources/sample.asciidoc
+++ b/asciidoctor-parser-doxia-module/src/test/resources/sample.asciidoc
@@ -1,5 +1,4 @@
-Document Title
-==============
+= Document Title
 Doc Writer <thedoc@asciidoctor.org>
 :idprefix: id_
 

--- a/docs/modules/site-integration/pages/parser-module-setup-and-configuration.adoc
+++ b/docs/modules/site-integration/pages/parser-module-setup-and-configuration.adoc
@@ -177,6 +177,7 @@ This module is still under development, here is a summary of supported features:
 * Lists
 ** Unordered, for `*` and `-` markers
 ** Ordered, only arabic numerals
+** Formatted text in list items
 
 * Code blocks with source-highlighting using https://maven.apache.org/skins/maven-fluido-skin/#source-code-line-numbers[Fluido Skin Pretiffy].
 ** Support for numbered lines with `linenums`


### PR DESCRIPTION
**What kind of change does this PR introduce?** (check at least one)
<!-- Update "[ ]" to "[x]" to check a box -->

- [x] Bugfix
- [ ] Feature
- [ ] Documentation
- [ ] Refactor
- [ ] Build improvement
- [ ] Other (please describe)


**What is the goal of this pull request?**

List (ordered and unordered) dosn't convert formatting (bold, monospace, etc.) and links.

**Are there any alternative ways to implement this?**

n/a

**Are there any implications of this pull request? Anything a user must know?**

no

**Is it related to an existing issue?**
<!-- If Yes, please add a line of the form: `Fixes #Issue` --> 
- [ ] Yes
- [x] No

*Finally, please add a corresponding entry to CHANGELOG.adoc*
