### PR TITLE
Add .editorconfig to help with formatting

### DIFF
--- a/.editorconfig
+++ b/.editorconfig
@@ -1,0 +1,14 @@
+[*]
+charset = utf-8
+end_of_line = lf
+indent_size = 4
+indent_style = space
+insert_final_newline = true
+tab_width = 4
+
+[*.java]
+ij_java_class_count_to_use_import_on_demand = 99
+ij_java_imports_layout = javax.**, java.**, |, *, |, $*
+
+[{*.yml,*.yaml}]
+indent_size = 2

--- a/CHANGELOG.adoc
+++ b/CHANGELOG.adoc
@@ -35,6 +35,7 @@ Improvements::
   * Upgrade Asciidoctorj to v2.5.10 and jRuby to v9.4.2.0 (#647)
   * Upgrade Asciidoctorj to v2.5.11 (#688)
   * Improve warning message when destination file is going to be replaced (#728)
+  * Added `.editorconfig` file to facilitate code formatting (#760)
 
 Build / Infrastructure::
 
@@ -65,7 +66,6 @@ Build / Infrastructure::
   * Test artifact's signature with Maven in CI (#736)
   * Automate release using GH Actions (#141)
   * Ensure Mojos use correct default values in unit tests (#609)
-
 
 Maintenance::
   * Replace use of reflection by direct JavaExtensionRegistry calls to register extensions (#596)

--- a/README.adoc
+++ b/README.adoc
@@ -1,8 +1,8 @@
 = Asciidoctor Maven Tools (Plugin & Site Integration)
 // Metadata
-:release-version: 2.2.2
+:release-version: 2.2.5
 :docs-version: 2.2
-:maven-site-plugin-version: 3.9.0
+:maven-site-plugin-version: 3.12.1
 // Settings
 :idprefix:
 :idseparator: -

--- a/asciidoctor-converter-doxia-module/src/test/java/org/asciidoctor/maven/site/AsciidoctorConverterDoxiaParserTest.java
+++ b/asciidoctor-converter-doxia-module/src/test/java/org/asciidoctor/maven/site/AsciidoctorConverterDoxiaParserTest.java
@@ -1,5 +1,11 @@
 package org.asciidoctor.maven.site;
 
+import java.io.File;
+import java.io.FileNotFoundException;
+import java.io.FileReader;
+import java.io.Reader;
+import java.io.StringReader;
+
 import lombok.SneakyThrows;
 import org.apache.maven.doxia.parser.ParseException;
 import org.apache.maven.doxia.sink.Sink;
@@ -8,8 +14,6 @@ import org.apache.maven.project.MavenProject;
 import org.codehaus.plexus.util.xml.Xpp3DomBuilder;
 import org.junit.jupiter.api.Test;
 import org.mockito.Mockito;
-
-import java.io.*;
 
 import static org.assertj.core.api.Assertions.assertThat;
 import static org.assertj.core.api.Assertions.catchThrowable;

--- a/asciidoctor-maven-commons/src/main/java/org/asciidoctor/maven/log/LogRecordFormatter.java
+++ b/asciidoctor-maven-commons/src/main/java/org/asciidoctor/maven/log/LogRecordFormatter.java
@@ -1,12 +1,12 @@
 package org.asciidoctor.maven.log;
 
-import org.asciidoctor.ast.Cursor;
-import org.asciidoctor.log.LogRecord;
-
 import java.io.File;
 import java.util.ArrayList;
 import java.util.List;
 import java.util.stream.Collectors;
+
+import org.asciidoctor.ast.Cursor;
+import org.asciidoctor.log.LogRecord;
 
 public class LogRecordFormatter {
 

--- a/asciidoctor-maven-commons/src/main/java/org/asciidoctor/maven/log/LogRecordsProcessors.java
+++ b/asciidoctor-maven-commons/src/main/java/org/asciidoctor/maven/log/LogRecordsProcessors.java
@@ -1,11 +1,11 @@
 package org.asciidoctor.maven.log;
 
-import org.asciidoctor.log.LogRecord;
-import org.asciidoctor.log.Severity;
-
 import java.io.File;
 import java.util.List;
 import java.util.function.Consumer;
+
+import org.asciidoctor.log.LogRecord;
+import org.asciidoctor.log.Severity;
 
 public class LogRecordsProcessors {
 

--- a/asciidoctor-maven-commons/src/main/java/org/asciidoctor/maven/log/MemoryLogHandler.java
+++ b/asciidoctor-maven-commons/src/main/java/org/asciidoctor/maven/log/MemoryLogHandler.java
@@ -1,13 +1,13 @@
 package org.asciidoctor.maven.log;
 
-import org.asciidoctor.log.LogHandler;
-import org.asciidoctor.log.LogRecord;
-import org.asciidoctor.log.Severity;
-
 import java.util.ArrayList;
 import java.util.List;
 import java.util.function.Consumer;
 import java.util.stream.Collectors;
+
+import org.asciidoctor.log.LogHandler;
+import org.asciidoctor.log.LogRecord;
+import org.asciidoctor.log.Severity;
 
 
 /**

--- a/asciidoctor-maven-commons/src/main/java/org/asciidoctor/maven/site/SiteConversionConfiguration.java
+++ b/asciidoctor-maven-commons/src/main/java/org/asciidoctor/maven/site/SiteConversionConfiguration.java
@@ -1,8 +1,8 @@
 package org.asciidoctor.maven.site;
 
-import org.asciidoctor.Options;
-
 import java.util.List;
+
+import org.asciidoctor.Options;
 
 public class SiteConversionConfiguration {
 

--- a/asciidoctor-maven-commons/src/main/java/org/asciidoctor/maven/site/SiteConversionConfigurationParser.java
+++ b/asciidoctor-maven-commons/src/main/java/org/asciidoctor/maven/site/SiteConversionConfigurationParser.java
@@ -1,5 +1,14 @@
 package org.asciidoctor.maven.site;
 
+import java.io.File;
+import java.util.ArrayList;
+import java.util.Arrays;
+import java.util.Collections;
+import java.util.List;
+import java.util.Optional;
+import java.util.stream.Collectors;
+import java.util.stream.Stream;
+
 import org.apache.maven.project.MavenProject;
 import org.asciidoctor.AttributesBuilder;
 import org.asciidoctor.Options;
@@ -7,11 +16,6 @@ import org.asciidoctor.OptionsBuilder;
 import org.asciidoctor.maven.commons.AsciidoctorHelper;
 import org.asciidoctor.maven.commons.StringUtils;
 import org.codehaus.plexus.util.xml.Xpp3Dom;
-
-import java.io.File;
-import java.util.*;
-import java.util.stream.Collectors;
-import java.util.stream.Stream;
 
 import static org.asciidoctor.maven.commons.StringUtils.isNotBlank;
 

--- a/asciidoctor-maven-commons/src/main/java/org/asciidoctor/maven/site/SiteLogHandlerDeserializer.java
+++ b/asciidoctor-maven-commons/src/main/java/org/asciidoctor/maven/site/SiteLogHandlerDeserializer.java
@@ -1,11 +1,11 @@
 package org.asciidoctor.maven.site;
 
+import java.util.Optional;
+
 import org.asciidoctor.log.Severity;
 import org.asciidoctor.maven.log.FailIf;
 import org.asciidoctor.maven.log.LogHandler;
 import org.codehaus.plexus.util.xml.Xpp3Dom;
-
-import java.util.Optional;
 
 public class SiteLogHandlerDeserializer {
 

--- a/asciidoctor-maven-commons/src/test/java/org/asciidoctor/maven/commons/AsciidoctorHelperTest.java
+++ b/asciidoctor-maven-commons/src/test/java/org/asciidoctor/maven/commons/AsciidoctorHelperTest.java
@@ -1,15 +1,15 @@
 package org.asciidoctor.maven.commons;
 
+import java.util.HashMap;
+import java.util.Map;
+import java.util.stream.Stream;
+
 import org.asciidoctor.Attributes;
 import org.asciidoctor.AttributesBuilder;
 import org.assertj.core.data.MapEntry;
 import org.junit.jupiter.params.ParameterizedTest;
 import org.junit.jupiter.params.provider.Arguments;
 import org.junit.jupiter.params.provider.MethodSource;
-
-import java.util.HashMap;
-import java.util.Map;
-import java.util.stream.Stream;
 
 import static org.asciidoctor.maven.commons.AsciidoctorHelper.addAttributes;
 import static org.assertj.core.api.Assertions.assertThat;

--- a/asciidoctor-maven-commons/src/test/java/org/asciidoctor/maven/log/LogRecordFormatterTest.java
+++ b/asciidoctor-maven-commons/src/test/java/org/asciidoctor/maven/log/LogRecordFormatterTest.java
@@ -1,13 +1,13 @@
 package org.asciidoctor.maven.log;
 
+import java.io.File;
+import java.io.IOException;
+
 import org.asciidoctor.ast.Cursor;
 import org.asciidoctor.log.LogRecord;
 import org.asciidoctor.log.Severity;
 import org.junit.jupiter.api.Test;
 import org.mockito.Mockito;
-
-import java.io.File;
-import java.io.IOException;
 
 import static java.lang.String.format;
 import static org.assertj.core.api.Assertions.assertThat;

--- a/asciidoctor-maven-commons/src/test/java/org/asciidoctor/maven/site/SiteConversionConfigurationParserTest.java
+++ b/asciidoctor-maven-commons/src/test/java/org/asciidoctor/maven/site/SiteConversionConfigurationParserTest.java
@@ -1,5 +1,11 @@
 package org.asciidoctor.maven.site;
 
+import java.io.File;
+import java.util.AbstractMap;
+import java.util.Arrays;
+import java.util.HashMap;
+import java.util.Map;
+
 import org.apache.maven.model.Model;
 import org.apache.maven.project.MavenProject;
 import org.asciidoctor.Attributes;
@@ -9,13 +15,9 @@ import org.asciidoctor.OptionsBuilder;
 import org.codehaus.plexus.util.xml.Xpp3Dom;
 import org.junit.jupiter.api.Test;
 
-import java.io.File;
-import java.util.AbstractMap;
-import java.util.Arrays;
-import java.util.HashMap;
-import java.util.Map;
-
-import static org.asciidoctor.Options.*;
+import static org.asciidoctor.Options.ATTRIBUTES;
+import static org.asciidoctor.Options.BASEDIR;
+import static org.asciidoctor.Options.TEMPLATE_DIRS;
 import static org.assertj.core.api.Assertions.assertThat;
 
 class SiteConversionConfigurationParserTest {

--- a/asciidoctor-maven-plugin/src/main/java/org/asciidoctor/maven/AsciidoctorMojo.java
+++ b/asciidoctor-maven-plugin/src/main/java/org/asciidoctor/maven/AsciidoctorMojo.java
@@ -1,5 +1,19 @@
 package org.asciidoctor.maven;
 
+import javax.inject.Inject;
+import java.io.File;
+import java.io.IOException;
+import java.nio.file.Path;
+import java.util.ArrayList;
+import java.util.Arrays;
+import java.util.HashMap;
+import java.util.HashSet;
+import java.util.List;
+import java.util.Map;
+import java.util.Optional;
+import java.util.Set;
+import java.util.logging.Logger;
+
 import org.apache.commons.io.FilenameUtils;
 import org.apache.maven.plugin.AbstractMojo;
 import org.apache.maven.plugin.MojoExecutionException;
@@ -29,20 +43,6 @@ import org.asciidoctor.maven.process.ResourcesProcessor;
 import org.asciidoctor.maven.process.SourceDirectoryFinder;
 import org.asciidoctor.maven.process.SourceDocumentFinder;
 import org.jruby.Ruby;
-
-import javax.inject.Inject;
-import java.io.File;
-import java.io.IOException;
-import java.nio.file.Path;
-import java.util.ArrayList;
-import java.util.Arrays;
-import java.util.HashMap;
-import java.util.HashSet;
-import java.util.List;
-import java.util.Map;
-import java.util.Optional;
-import java.util.Set;
-import java.util.logging.Logger;
 
 import static org.asciidoctor.maven.commons.StringUtils.isBlank;
 import static org.asciidoctor.maven.commons.StringUtils.isNotBlank;

--- a/asciidoctor-maven-plugin/src/main/java/org/asciidoctor/maven/AsciidoctorRefreshMojo.java
+++ b/asciidoctor-maven-plugin/src/main/java/org/asciidoctor/maven/AsciidoctorRefreshMojo.java
@@ -1,5 +1,13 @@
 package org.asciidoctor.maven;
 
+import java.io.File;
+import java.io.FileFilter;
+import java.util.Collection;
+import java.util.Collections;
+import java.util.Optional;
+import java.util.Scanner;
+import java.util.StringJoiner;
+
 import org.apache.commons.io.filefilter.FileFilterUtils;
 import org.apache.commons.io.filefilter.IOFileFilter;
 import org.apache.commons.io.filefilter.NameFileFilter;
@@ -16,14 +24,6 @@ import org.asciidoctor.maven.refresh.AsciidoctorConverterFileAlterationListenerA
 import org.asciidoctor.maven.refresh.ResourceCopyFileAlterationListenerAdaptor;
 import org.asciidoctor.maven.refresh.ResourcesPatternBuilder;
 import org.asciidoctor.maven.refresh.TimeCounter;
-
-import java.io.File;
-import java.io.FileFilter;
-import java.util.Collection;
-import java.util.Collections;
-import java.util.Optional;
-import java.util.Scanner;
-import java.util.StringJoiner;
 
 import static org.asciidoctor.maven.commons.StringUtils.isNotBlank;
 import static org.asciidoctor.maven.process.SourceDocumentFinder.CUSTOM_FILE_EXTENSIONS_PATTERN_PREFIX;

--- a/asciidoctor-maven-plugin/src/main/java/org/asciidoctor/maven/AsciidoctorZipMojo.java
+++ b/asciidoctor-maven-plugin/src/main/java/org/asciidoctor/maven/AsciidoctorZipMojo.java
@@ -1,5 +1,8 @@
 package org.asciidoctor.maven;
 
+import java.io.File;
+import java.io.IOException;
+
 import org.apache.maven.plugin.MojoExecutionException;
 import org.apache.maven.plugin.MojoFailureException;
 import org.apache.maven.plugins.annotations.Component;
@@ -7,9 +10,6 @@ import org.apache.maven.plugins.annotations.Mojo;
 import org.apache.maven.plugins.annotations.Parameter;
 import org.apache.maven.project.MavenProjectHelper;
 import org.asciidoctor.maven.io.Zips;
-
-import java.io.File;
-import java.io.IOException;
 
 @Mojo(name = "zip")
 public class AsciidoctorZipMojo extends AsciidoctorMojo {

--- a/asciidoctor-maven-plugin/src/main/java/org/asciidoctor/maven/http/AsciidoctorHandler.java
+++ b/asciidoctor-maven-plugin/src/main/java/org/asciidoctor/maven/http/AsciidoctorHandler.java
@@ -1,5 +1,10 @@
 package org.asciidoctor.maven.http;
 
+import java.io.ByteArrayOutputStream;
+import java.io.File;
+import java.io.FileInputStream;
+import java.nio.charset.StandardCharsets;
+
 import io.netty.buffer.ByteBuf;
 import io.netty.buffer.Unpooled;
 import io.netty.channel.ChannelFutureListener;
@@ -15,11 +20,6 @@ import io.netty.handler.codec.http.HttpVersion;
 import io.netty.util.CharsetUtil;
 import org.apache.commons.io.FileUtils;
 import org.apache.commons.io.IOUtils;
-
-import java.io.ByteArrayOutputStream;
-import java.io.File;
-import java.io.FileInputStream;
-import java.nio.charset.StandardCharsets;
 
 public class AsciidoctorHandler extends SimpleChannelInboundHandler<FullHttpRequest> {
 

--- a/asciidoctor-maven-plugin/src/main/java/org/asciidoctor/maven/http/AsciidoctorHttpServer.java
+++ b/asciidoctor-maven-plugin/src/main/java/org/asciidoctor/maven/http/AsciidoctorHttpServer.java
@@ -1,5 +1,9 @@
 package org.asciidoctor.maven.http;
 
+import java.io.File;
+import java.util.concurrent.ExecutionException;
+import java.util.concurrent.atomic.AtomicInteger;
+
 import io.netty.bootstrap.ServerBootstrap;
 import io.netty.channel.ChannelFutureListener;
 import io.netty.channel.ChannelInitializer;
@@ -13,10 +17,6 @@ import io.netty.handler.codec.http.HttpResponseEncoder;
 import io.netty.handler.stream.ChunkedWriteHandler;
 import io.netty.util.concurrent.Future;
 import org.apache.maven.plugin.logging.Log;
-
-import java.io.File;
-import java.util.concurrent.ExecutionException;
-import java.util.concurrent.atomic.AtomicInteger;
 
 /**
  * HTTP server to expose AsciiDoc converted sources.

--- a/asciidoctor-maven-plugin/src/main/java/org/asciidoctor/maven/io/Zips.java
+++ b/asciidoctor-maven-plugin/src/main/java/org/asciidoctor/maven/io/Zips.java
@@ -1,13 +1,13 @@
 package org.asciidoctor.maven.io;
 
-import org.apache.commons.io.IOUtils;
-
 import java.io.File;
 import java.io.FileInputStream;
 import java.io.FileOutputStream;
 import java.io.IOException;
 import java.util.zip.ZipEntry;
 import java.util.zip.ZipOutputStream;
+
+import org.apache.commons.io.IOUtils;
 
 public final class Zips {
 

--- a/asciidoctor-maven-plugin/src/main/java/org/asciidoctor/maven/process/CopyResourcesProcessor.java
+++ b/asciidoctor-maven-plugin/src/main/java/org/asciidoctor/maven/process/CopyResourcesProcessor.java
@@ -1,15 +1,15 @@
 package org.asciidoctor.maven.process;
 
-import org.apache.commons.io.FileUtils;
-import org.asciidoctor.maven.AsciidoctorMojo;
-import org.asciidoctor.maven.model.Resource;
-import org.codehaus.plexus.util.DirectoryScanner;
-
 import java.io.File;
 import java.io.IOException;
 import java.nio.file.Path;
 import java.util.ArrayList;
 import java.util.List;
+
+import org.apache.commons.io.FileUtils;
+import org.asciidoctor.maven.AsciidoctorMojo;
+import org.asciidoctor.maven.model.Resource;
+import org.codehaus.plexus.util.DirectoryScanner;
 
 import static org.asciidoctor.maven.commons.StringUtils.isNotBlank;
 
@@ -27,28 +27,28 @@ public class CopyResourcesProcessor implements ResourcesProcessor {
 
     // docinfo snippets should not be copied
     public static String[] IGNORED_FILE_NAMES = {
-            "docinfo.html",
-            "docinfo-header.html",
-            "docinfo-footer.html",
-            "*-docinfo.html",
-            "*-docinfo-header.html",
-            "*-docinfo-footer.html",
-            "docinfo.xml",
-            "docinfo-header.xml",
-            "docinfo-footer.xml",
-            "*-docinfo.xml",
-            "*-docinfo-header.xml",
-            "*-docinfo-footer.xml"
+        "docinfo.html",
+        "docinfo-header.html",
+        "docinfo-footer.html",
+        "*-docinfo.html",
+        "*-docinfo-header.html",
+        "*-docinfo-footer.html",
+        "docinfo.xml",
+        "docinfo-header.xml",
+        "docinfo-footer.xml",
+        "*-docinfo.xml",
+        "*-docinfo-header.xml",
+        "*-docinfo-footer.xml"
     };
 
     private static String[] DEFAULT_ASCIIDOC_EXTENSIONS = {"**/*.adoc", "**/*.ad", "**/*.asc", "**/*.asciidoc"};
 
     // Files and directories beginning with underscore are ignored
     private static String[] INTERNAL_FOLDERS_AND_FILES_PATTERNS = {
-            "**/_*.*",
-            "**/_*",
-            "**/.*",
-            "**/_*/**/*.*",
+        "**/_*.*",
+        "**/_*",
+        "**/.*",
+        "**/_*/**/*.*",
     };
 
     /*
@@ -72,8 +72,8 @@ public class CopyResourcesProcessor implements ResourcesProcessor {
      */
     private List<Resource> prepareResources(File sourceDirectory, AsciidoctorMojo configuration) {
         final List<Resource> resources = configuration.getResources() != null
-                ? configuration.getResources()
-                : new ArrayList<>();
+            ? configuration.getResources()
+            : new ArrayList<>();
         if (resources.isEmpty()) {
             // we don't want to copy files considered sources
             Resource resource = new Resource();
@@ -81,7 +81,7 @@ public class CopyResourcesProcessor implements ResourcesProcessor {
             // exclude sourceDocumentName if defined
             if (isNotBlank(configuration.getSourceDocumentName())) {
                 resource.getExcludes()
-                        .add(configuration.getSourceDocumentName());
+                    .add(configuration.getSourceDocumentName());
             }
             resources.add(resource);
         }
@@ -120,33 +120,33 @@ public class CopyResourcesProcessor implements ResourcesProcessor {
     private void copyResources(List<Resource> resources, File outputDirectory) {
 
         resources.stream()
-                .filter(resource -> new File(resource.getDirectory()).exists())
-                .forEach(resource -> {
-                    DirectoryScanner directoryScanner = new DirectoryScanner();
-                    directoryScanner.setBasedir(resource.getDirectory());
+            .filter(resource -> new File(resource.getDirectory()).exists())
+            .forEach(resource -> {
+                DirectoryScanner directoryScanner = new DirectoryScanner();
+                directoryScanner.setBasedir(resource.getDirectory());
 
-                    if (resource.getIncludes().isEmpty())
-                        directoryScanner.setIncludes(new String[]{"**/*.*", "**/*"});
-                    else
-                        directoryScanner.setIncludes(resource.getIncludes().toArray(new String[0]));
+                if (resource.getIncludes().isEmpty())
+                    directoryScanner.setIncludes(new String[]{"**/*.*", "**/*"});
+                else
+                    directoryScanner.setIncludes(resource.getIncludes().toArray(new String[0]));
 
-                    directoryScanner.setExcludes(resource.getExcludes().toArray(new String[0]));
-                    directoryScanner.setFollowSymlinks(false);
-                    directoryScanner.scan();
+                directoryScanner.setExcludes(resource.getExcludes().toArray(new String[0]));
+                directoryScanner.setFollowSymlinks(false);
+                directoryScanner.scan();
 
-                    for (String includedFile : directoryScanner.getIncludedFiles()) {
-                        File source = new File(directoryScanner.getBasedir(), includedFile);
-                        copyFileToDirectory(source, resource, outputDirectory);
-                    }
-                });
+                for (String includedFile : directoryScanner.getIncludedFiles()) {
+                    File source = new File(directoryScanner.getBasedir(), includedFile);
+                    copyFileToDirectory(source, resource, outputDirectory);
+                }
+            });
     }
 
 
     private void copyFileToDirectory(File source, Resource resource, File outputDirectory) {
         try {
             final File target = resource.getTargetPath() == null
-                    ? outputDirectory
-                    : composeTargetPath(resource, outputDirectory);
+                ? outputDirectory
+                : composeTargetPath(resource, outputDirectory);
 
             Path sourceDirectoryPath = new File(resource.getDirectory()).toPath();
             Path sourcePath = source.toPath();
@@ -168,7 +168,7 @@ public class CopyResourcesProcessor implements ResourcesProcessor {
     private static File composeTargetPath(Resource resource, File outputDirectory) {
         final File targetFile = new File(resource.getTargetPath());
         return targetFile.isAbsolute()
-                ? targetFile
-                : new File(outputDirectory, resource.getTargetPath());
+            ? targetFile
+            : new File(outputDirectory, resource.getTargetPath());
     }
 }

--- a/asciidoctor-maven-plugin/src/main/java/org/asciidoctor/maven/process/ResourcesProcessor.java
+++ b/asciidoctor-maven-plugin/src/main/java/org/asciidoctor/maven/process/ResourcesProcessor.java
@@ -1,8 +1,8 @@
 package org.asciidoctor.maven.process;
 
-import org.asciidoctor.maven.AsciidoctorMojo;
-
 import java.io.File;
+
+import org.asciidoctor.maven.AsciidoctorMojo;
 
 public interface ResourcesProcessor {
 

--- a/asciidoctor-maven-plugin/src/main/java/org/asciidoctor/maven/refresh/AbstractFileAlterationListenerAdaptor.java
+++ b/asciidoctor-maven-plugin/src/main/java/org/asciidoctor/maven/refresh/AbstractFileAlterationListenerAdaptor.java
@@ -1,10 +1,10 @@
 package org.asciidoctor.maven.refresh;
 
+import java.io.File;
+
 import org.apache.commons.io.monitor.FileAlterationListenerAdaptor;
 import org.apache.maven.plugin.logging.Log;
 import org.asciidoctor.maven.AsciidoctorRefreshMojo;
-
-import java.io.File;
 
 public abstract class AbstractFileAlterationListenerAdaptor extends FileAlterationListenerAdaptor {
 

--- a/asciidoctor-maven-plugin/src/main/java/org/asciidoctor/maven/refresh/AdditionalSourceFileAlterationListenerAdaptor.java
+++ b/asciidoctor-maven-plugin/src/main/java/org/asciidoctor/maven/refresh/AdditionalSourceFileAlterationListenerAdaptor.java
@@ -1,11 +1,11 @@
 package org.asciidoctor.maven.refresh;
 
+import java.io.File;
+
 import org.apache.maven.plugin.MojoExecutionException;
 import org.apache.maven.plugin.logging.Log;
 import org.asciidoctor.maven.AsciidoctorRefreshMojo;
 import org.asciidoctor.maven.process.ResourcesProcessor;
-
-import java.io.File;
 
 public class AdditionalSourceFileAlterationListenerAdaptor extends AbstractFileAlterationListenerAdaptor {
 

--- a/asciidoctor-maven-plugin/src/main/java/org/asciidoctor/maven/refresh/AsciidoctorConverterFileAlterationListenerAdaptor.java
+++ b/asciidoctor-maven-plugin/src/main/java/org/asciidoctor/maven/refresh/AsciidoctorConverterFileAlterationListenerAdaptor.java
@@ -1,12 +1,12 @@
 package org.asciidoctor.maven.refresh;
 
+import java.io.File;
+import java.util.Collections;
+
 import org.apache.maven.plugin.MojoExecutionException;
 import org.apache.maven.plugin.logging.Log;
 import org.asciidoctor.maven.AsciidoctorRefreshMojo;
 import org.asciidoctor.maven.process.ResourcesProcessor;
-
-import java.io.File;
-import java.util.Collections;
 
 public class AsciidoctorConverterFileAlterationListenerAdaptor extends AbstractFileAlterationListenerAdaptor {
 

--- a/asciidoctor-maven-plugin/src/main/java/org/asciidoctor/maven/refresh/ResourceCopyFileAlterationListenerAdaptor.java
+++ b/asciidoctor-maven-plugin/src/main/java/org/asciidoctor/maven/refresh/ResourceCopyFileAlterationListenerAdaptor.java
@@ -1,16 +1,16 @@
 package org.asciidoctor.maven.refresh;
 
-import org.apache.maven.plugin.logging.Log;
-import org.asciidoctor.maven.AsciidoctorRefreshMojo;
-import org.asciidoctor.maven.model.Resource;
-import org.codehaus.plexus.util.DirectoryScanner;
-import org.codehaus.plexus.util.FileUtils;
-
 import java.io.File;
 import java.io.IOException;
 import java.util.Collections;
 import java.util.List;
 import java.util.stream.Collectors;
+
+import org.apache.maven.plugin.logging.Log;
+import org.asciidoctor.maven.AsciidoctorRefreshMojo;
+import org.asciidoctor.maven.model.Resource;
+import org.codehaus.plexus.util.DirectoryScanner;
+import org.codehaus.plexus.util.FileUtils;
 
 import static org.asciidoctor.maven.commons.StringUtils.isBlank;
 

--- a/asciidoctor-maven-plugin/src/test/java/org/asciidoctor/maven/AsciidoctorAsserter.java
+++ b/asciidoctor-maven-plugin/src/test/java/org/asciidoctor/maven/AsciidoctorAsserter.java
@@ -1,12 +1,12 @@
 package org.asciidoctor.maven;
 
+import java.io.File;
+import java.nio.file.Files;
+
 import lombok.SneakyThrows;
 import org.assertj.core.api.AbstractFileAssert;
 import org.assertj.core.api.AbstractStringAssert;
 import org.assertj.core.api.Assertions;
-
-import java.io.File;
-import java.nio.file.Files;
 
 public class AsciidoctorAsserter {
 

--- a/asciidoctor-maven-plugin/src/test/java/org/asciidoctor/maven/AsciidoctorHttpMojoTest.java
+++ b/asciidoctor-maven-plugin/src/test/java/org/asciidoctor/maven/AsciidoctorHttpMojoTest.java
@@ -1,5 +1,13 @@
 package org.asciidoctor.maven;
 
+import java.io.BufferedInputStream;
+import java.io.ByteArrayOutputStream;
+import java.io.File;
+import java.io.IOException;
+import java.net.HttpURLConnection;
+import java.net.ServerSocket;
+import java.net.URL;
+
 import lombok.SneakyThrows;
 import org.apache.commons.io.FileUtils;
 import org.apache.commons.io.IOUtils;
@@ -8,14 +16,6 @@ import org.apache.maven.plugin.MojoFailureException;
 import org.asciidoctor.maven.io.TestFilesHelper;
 import org.asciidoctor.maven.io.UserInputSimulator;
 import org.junit.jupiter.api.Test;
-
-import java.io.BufferedInputStream;
-import java.io.ByteArrayOutputStream;
-import java.io.File;
-import java.io.IOException;
-import java.net.HttpURLConnection;
-import java.net.ServerSocket;
-import java.net.URL;
 
 import static java.nio.charset.StandardCharsets.UTF_8;
 import static org.asciidoctor.maven.test.TestUtils.mockAsciidoctorHttpMojo;

--- a/asciidoctor-maven-plugin/src/test/java/org/asciidoctor/maven/AsciidoctorIntegrationTest.java
+++ b/asciidoctor-maven-plugin/src/test/java/org/asciidoctor/maven/AsciidoctorIntegrationTest.java
@@ -1,18 +1,18 @@
 package org.asciidoctor.maven;
 
+import java.io.File;
+import java.util.Map;
+
 import org.apache.maven.plugin.MojoExecutionException;
 import org.apache.maven.plugin.MojoFailureException;
 import org.assertj.core.api.Assertions;
 import org.junit.jupiter.api.Disabled;
 import org.junit.jupiter.api.Test;
 
-import java.io.File;
-import java.util.Map;
-
 import static org.asciidoctor.maven.AsciidoctorAsserter.assertThat;
+import static org.asciidoctor.maven.io.TestFilesHelper.newOutputTestDirectory;
 import static org.asciidoctor.maven.test.TestUtils.ResourceBuilder.excludeAll;
 import static org.asciidoctor.maven.test.TestUtils.mockAsciidoctorMojo;
-import static org.asciidoctor.maven.io.TestFilesHelper.newOutputTestDirectory;
 
 /**
  * Opinionated tests to validate Asciidoctor behaviours in end-to-end scenarios.

--- a/asciidoctor-maven-plugin/src/test/java/org/asciidoctor/maven/AsciidoctorMojoExtensionsTest.java
+++ b/asciidoctor-maven-plugin/src/test/java/org/asciidoctor/maven/AsciidoctorMojoExtensionsTest.java
@@ -1,22 +1,28 @@
 package org.asciidoctor.maven;
 
+import java.io.File;
+import java.util.Arrays;
+import java.util.Map;
+
 import lombok.SneakyThrows;
 import org.apache.maven.plugin.MojoExecutionException;
 import org.apache.maven.plugin.MojoFailureException;
 import org.asciidoctor.maven.extensions.ExtensionConfiguration;
 import org.asciidoctor.maven.io.ConsoleHolder;
-import org.asciidoctor.maven.test.processors.*;
+import org.asciidoctor.maven.test.processors.ChangeAttributeValuePreprocessor;
+import org.asciidoctor.maven.test.processors.FailingPreprocessor;
+import org.asciidoctor.maven.test.processors.GistBlockMacroProcessor;
+import org.asciidoctor.maven.test.processors.ManpageInlineMacroProcessor;
+import org.asciidoctor.maven.test.processors.MetaDocinfoProcessor;
+import org.asciidoctor.maven.test.processors.UriIncludeProcessor;
+import org.asciidoctor.maven.test.processors.YellBlockProcessor;
 import org.assertj.core.api.Assertions;
 import org.junit.jupiter.api.Disabled;
 import org.junit.jupiter.api.Test;
 
-import java.io.File;
-import java.util.Arrays;
-import java.util.Map;
-
 import static java.util.Collections.singletonList;
-import static org.asciidoctor.maven.test.TestUtils.mockAsciidoctorMojo;
 import static org.asciidoctor.maven.io.TestFilesHelper.newOutputTestDirectory;
+import static org.asciidoctor.maven.test.TestUtils.mockAsciidoctorMojo;
 import static org.assertj.core.api.Assertions.assertThat;
 
 /**

--- a/asciidoctor-maven-plugin/src/test/java/org/asciidoctor/maven/AsciidoctorMojoLogHandlerTest.java
+++ b/asciidoctor-maven-plugin/src/test/java/org/asciidoctor/maven/AsciidoctorMojoLogHandlerTest.java
@@ -1,5 +1,11 @@
 package org.asciidoctor.maven;
 
+import java.io.File;
+import java.util.Arrays;
+import java.util.List;
+import java.util.Map;
+import java.util.stream.Collectors;
+
 import org.apache.maven.plugin.MojoExecutionException;
 import org.apache.maven.plugin.MojoFailureException;
 import org.asciidoctor.maven.io.ConsoleHolder;
@@ -8,16 +14,10 @@ import org.asciidoctor.maven.log.LogHandler;
 import org.junit.jupiter.api.Disabled;
 import org.junit.jupiter.api.Test;
 
-import java.io.File;
-import java.util.Arrays;
-import java.util.List;
-import java.util.Map;
-import java.util.stream.Collectors;
-
 import static org.asciidoctor.log.Severity.ERROR;
 import static org.asciidoctor.log.Severity.WARN;
-import static org.asciidoctor.maven.test.TestUtils.mockAsciidoctorMojo;
 import static org.asciidoctor.maven.io.TestFilesHelper.newOutputTestDirectory;
+import static org.asciidoctor.maven.test.TestUtils.mockAsciidoctorMojo;
 import static org.assertj.core.api.Assertions.assertThat;
 import static org.assertj.core.api.Assertions.catchThrowable;
 
@@ -44,7 +44,7 @@ class AsciidoctorMojoLogHandlerTest {
 
         // then: process completes but the document contains errors
         AsciidoctorAsserter.assertThat(outputDir, "document-with-missing-include.html")
-                .contains("<p>Unresolved directive in document-with-missing-include.adoc - include::unexistingdoc.adoc[]</p>");
+            .contains("<p>Unresolved directive in document-with-missing-include.adoc - include::unexistingdoc.adoc[]</p>");
     }
 
     @Test
@@ -67,19 +67,19 @@ class AsciidoctorMojoLogHandlerTest {
 
         // then
         List<String> asciidoctorMessages = Arrays.stream(consoleHolder.getOutput().split("\n"))
-                .filter(line -> line.contains("asciidoctor:"))
-                .collect(Collectors.toList());
+            .filter(line -> line.contains("asciidoctor:"))
+            .collect(Collectors.toList());
 
         assertThat(asciidoctorMessages)
-                .hasSize(4);
+            .hasSize(4);
         assertThat(asciidoctorMessages.get(0))
-                .contains(fixOsSeparator("[info] asciidoctor: ERROR: errors/document-with-missing-include.adoc: line 3: include file not found:"));
+            .contains(fixOsSeparator("[info] asciidoctor: ERROR: errors/document-with-missing-include.adoc: line 3: include file not found:"));
         assertThat(asciidoctorMessages.get(1))
-                .contains(fixOsSeparator("[info] asciidoctor: ERROR: errors/document-with-missing-include.adoc: line 5: include file not found:"));
+            .contains(fixOsSeparator("[info] asciidoctor: ERROR: errors/document-with-missing-include.adoc: line 5: include file not found:"));
         assertThat(asciidoctorMessages.get(2))
-                .contains(fixOsSeparator("[info] asciidoctor: ERROR: errors/document-with-missing-include.adoc: line 9: include file not found:"));
+            .contains(fixOsSeparator("[info] asciidoctor: ERROR: errors/document-with-missing-include.adoc: line 9: include file not found:"));
         assertThat(asciidoctorMessages.get(3))
-                .contains(fixOsSeparator("[info] asciidoctor: WARN: errors/document-with-missing-include.adoc: line 25: no callout found for <1>"));
+            .contains(fixOsSeparator("[info] asciidoctor: WARN: errors/document-with-missing-include.adoc: line 25: no callout found for <1>"));
 
         // cleanup
         consoleHolder.release();
@@ -107,20 +107,20 @@ class AsciidoctorMojoLogHandlerTest {
 
         // then: output file exists & shows include error
         AsciidoctorAsserter.assertThat(outputDir, "document-with-missing-include.html")
-                .contains("<p>Unresolved directive in document-with-missing-include.adoc - include::unexistingdoc.adoc[]</p>");
+            .contains("<p>Unresolved directive in document-with-missing-include.adoc - include::unexistingdoc.adoc[]</p>");
 
         // and: all messages (ERR & WARN) are logged as info
         List<String> outputLines = getOutputInfoLines(consoleHolder);
         assertThat(outputLines)
-                .hasSize(4);
+            .hasSize(4);
         assertThat(outputLines.get(0))
-                .startsWith(fixOsSeparator("[info] asciidoctor: ERROR: errors/document-with-missing-include.adoc: line 3: include file not found:"));
+            .startsWith(fixOsSeparator("[info] asciidoctor: ERROR: errors/document-with-missing-include.adoc: line 3: include file not found:"));
         assertThat(outputLines.get(1))
-                .startsWith(fixOsSeparator("[info] asciidoctor: ERROR: errors/document-with-missing-include.adoc: line 5: include file not found:"));
+            .startsWith(fixOsSeparator("[info] asciidoctor: ERROR: errors/document-with-missing-include.adoc: line 5: include file not found:"));
         assertThat(outputLines.get(2))
-                .startsWith(fixOsSeparator("[info] asciidoctor: ERROR: errors/document-with-missing-include.adoc: line 9: include file not found:"));
+            .startsWith(fixOsSeparator("[info] asciidoctor: ERROR: errors/document-with-missing-include.adoc: line 9: include file not found:"));
         assertThat(outputLines.get(3))
-                .startsWith(fixOsSeparator("[info] asciidoctor: WARN: errors/document-with-missing-include.adoc: line 25: no callout found for <1>"));
+            .startsWith(fixOsSeparator("[info] asciidoctor: WARN: errors/document-with-missing-include.adoc: line 25: no callout found for <1>"));
 
         // cleanup
         consoleHolder.release();
@@ -151,15 +151,15 @@ class AsciidoctorMojoLogHandlerTest {
 
         // then: output file exists & shows include error
         assertThat(new File(outputDir, "document-with-invalid-reference.html"))
-                .isNotEmpty();
+            .isNotEmpty();
 
         // and: all messages (WARN) are logged as info
         List<String> outputLines = getOutputInfoLines(consoleHolder);
         assertThat(outputLines)
-                .containsExactly(
-                        "[info] asciidoctor: WARN: invalid reference: ../path/some-file.adoc",
-                        "[info] asciidoctor: WARN: invalid reference: section-id"
-                );
+            .containsExactly(
+                "[info] asciidoctor: WARN: invalid reference: ../path/some-file.adoc",
+                "[info] asciidoctor: WARN: invalid reference: section-id"
+            );
 
         // cleanup
         consoleHolder.release();
@@ -191,14 +191,14 @@ class AsciidoctorMojoLogHandlerTest {
 
         // then: output file exists & shows include error
         assertThat(new File(outputDir, "document-with-invalid-reference.html"))
-                .isNotEmpty();
+            .isNotEmpty();
 
         // and: all messages (WARN) are logged as info
         assertThat(getOutputInfoLines(consoleHolder))
-                .containsExactly(
-                        "[info] asciidoctor: WARN: invalid reference: ../path/some-file.adoc",
-                        "[info] asciidoctor: WARN: invalid reference: section-id"
-                );
+            .containsExactly(
+                "[info] asciidoctor: WARN: invalid reference: ../path/some-file.adoc",
+                "[info] asciidoctor: WARN: invalid reference: section-id"
+            );
 
         // cleanup
         consoleHolder.release();
@@ -226,8 +226,8 @@ class AsciidoctorMojoLogHandlerTest {
 
         // then: issues with WARN and ERROR are returned
         assertThat(throwable)
-                .isInstanceOf(MojoExecutionException.class)
-                .hasMessageContaining("Found 4 issue(s) of severity WARN or higher during conversion");
+            .isInstanceOf(MojoExecutionException.class)
+            .hasMessageContaining("Found 4 issue(s) of severity WARN or higher during conversion");
     }
 
     @Test
@@ -252,8 +252,8 @@ class AsciidoctorMojoLogHandlerTest {
 
         // then
         assertThat(throwable)
-                .isInstanceOf(MojoExecutionException.class)
-                .hasMessageContaining("Found 3 issue(s) of severity ERROR or higher during conversion");
+            .isInstanceOf(MojoExecutionException.class)
+            .hasMessageContaining("Found 3 issue(s) of severity ERROR or higher during conversion");
     }
 
     @Test
@@ -278,7 +278,7 @@ class AsciidoctorMojoLogHandlerTest {
 
         // then
         AsciidoctorAsserter.assertThat(outputDir, "document-with-missing-include.html")
-                .contains("<p>Unresolved directive in document-with-missing-include.adoc - include::unexistingdoc.adoc[]</p>");
+            .contains("<p>Unresolved directive in document-with-missing-include.adoc - include::unexistingdoc.adoc[]</p>");
     }
 
     @Test
@@ -305,21 +305,21 @@ class AsciidoctorMojoLogHandlerTest {
 
         // then
         assertThat(throwable)
-                .isInstanceOf(MojoExecutionException.class)
-                .hasMessageContaining("Found 3 issue(s) containing 'include file not found'");
+            .isInstanceOf(MojoExecutionException.class)
+            .hasMessageContaining("Found 3 issue(s) containing 'include file not found'");
         assertThat(new File(outputDir, "document-with-missing-include.html"))
-                .exists();
+            .exists();
 
         // and: all messages (ERR & WARN) are logged as error
         List<String> errorLines = getErrorLines(consoleHolder);
         assertThat(errorLines)
-                .hasSize(3);
+            .hasSize(3);
         assertThat(errorLines.get(0))
-                .contains(fixOsSeparator("[error] asciidoctor: ERROR: errors/document-with-missing-include.adoc: line 3: include file not found:"));
+            .contains(fixOsSeparator("[error] asciidoctor: ERROR: errors/document-with-missing-include.adoc: line 3: include file not found:"));
         assertThat(errorLines.get(1))
-                .contains(fixOsSeparator("[error] asciidoctor: ERROR: errors/document-with-missing-include.adoc: line 5: include file not found:"));
+            .contains(fixOsSeparator("[error] asciidoctor: ERROR: errors/document-with-missing-include.adoc: line 5: include file not found:"));
         assertThat(errorLines.get(2))
-                .contains(fixOsSeparator("[error] asciidoctor: ERROR: errors/document-with-missing-include.adoc: line 9: include file not found:"));
+            .contains(fixOsSeparator("[error] asciidoctor: ERROR: errors/document-with-missing-include.adoc: line 9: include file not found:"));
 
         // cleanup
         consoleHolder.release();
@@ -350,12 +350,12 @@ class AsciidoctorMojoLogHandlerTest {
 
         // then
         assertThat(new File(outputDir, "document-with-missing-include.html"))
-                .isNotEmpty();
+            .isNotEmpty();
         assertThat(throwable)
-                .isInstanceOf(MojoExecutionException.class)
-                .hasMessageContaining("Found 4 issue(s) matching severity WARN or higher and text 'no'");
+            .isInstanceOf(MojoExecutionException.class)
+            .hasMessageContaining("Found 4 issue(s) matching severity WARN or higher and text 'no'");
         assertThat(consoleHolder.getError())
-                .contains(fixOsSeparator("[error] asciidoctor: WARN: errors/document-with-missing-include.adoc: line 25: no callout found for <1>"));
+            .contains(fixOsSeparator("[error] asciidoctor: WARN: errors/document-with-missing-include.adoc: line 25: no callout found for <1>"));
 
         // cleanup
         consoleHolder.release();
@@ -385,9 +385,9 @@ class AsciidoctorMojoLogHandlerTest {
 
         // then: output file exists & shows include error
         AsciidoctorAsserter.assertThat(new File(outputDir, "document-with-missing-include.html"))
-                .contains("<p>Unresolved directive in document-with-missing-include.adoc - include::unexistingdoc.adoc[]</p>");
+            .contains("<p>Unresolved directive in document-with-missing-include.adoc - include::unexistingdoc.adoc[]</p>");
         assertThat(consoleHolder.getError())
-                .isEmpty();
+            .isEmpty();
 
         // cleanup
         consoleHolder.release();
@@ -396,13 +396,13 @@ class AsciidoctorMojoLogHandlerTest {
     private List<String> getOutputInfoLines(ConsoleHolder consoleHolder) {
         final String lineSeparator = lineSeparator();
         return Arrays.stream(consoleHolder.getOutput().split(lineSeparator))
-                .filter(line -> line.startsWith("[info] asciidoctor"))
-                .collect(Collectors.toList());
+            .filter(line -> line.startsWith("[info] asciidoctor"))
+            .collect(Collectors.toList());
     }
 
     private List<String> getErrorLines(ConsoleHolder consoleHolder) {
         return Arrays.stream(consoleHolder.getError().split(lineSeparator()))
-                .collect(Collectors.toList());
+            .collect(Collectors.toList());
     }
 
     private String fixOsSeparator(String text) {

--- a/asciidoctor-maven-plugin/src/test/java/org/asciidoctor/maven/AsciidoctorMojoTest.java
+++ b/asciidoctor-maven-plugin/src/test/java/org/asciidoctor/maven/AsciidoctorMojoTest.java
@@ -1,15 +1,5 @@
 package org.asciidoctor.maven;
 
-import lombok.SneakyThrows;
-import org.apache.commons.io.FileUtils;
-import org.apache.maven.plugin.MojoExecutionException;
-import org.apache.maven.plugin.MojoFailureException;
-import org.asciidoctor.maven.extensions.ExtensionConfiguration;
-import org.asciidoctor.maven.io.ConsoleHolder;
-import org.asciidoctor.maven.test.processors.RequireCheckerTreeprocessor;
-import org.assertj.core.api.Assertions;
-import org.junit.jupiter.api.Test;
-
 import java.io.ByteArrayOutputStream;
 import java.io.File;
 import java.io.IOException;
@@ -23,6 +13,16 @@ import java.util.List;
 import java.util.Map;
 import java.util.UUID;
 import java.util.stream.Collectors;
+
+import lombok.SneakyThrows;
+import org.apache.commons.io.FileUtils;
+import org.apache.maven.plugin.MojoExecutionException;
+import org.apache.maven.plugin.MojoFailureException;
+import org.asciidoctor.maven.extensions.ExtensionConfiguration;
+import org.asciidoctor.maven.io.ConsoleHolder;
+import org.asciidoctor.maven.test.processors.RequireCheckerTreeprocessor;
+import org.assertj.core.api.Assertions;
+import org.junit.jupiter.api.Test;
 
 import static java.nio.file.Files.writeString;
 import static java.util.Collections.singletonList;

--- a/asciidoctor-maven-plugin/src/test/java/org/asciidoctor/maven/AsciidoctorRefreshMojoTest.java
+++ b/asciidoctor-maven-plugin/src/test/java/org/asciidoctor/maven/AsciidoctorRefreshMojoTest.java
@@ -1,14 +1,5 @@
 package org.asciidoctor.maven;
 
-import lombok.SneakyThrows;
-import org.apache.commons.io.FileUtils;
-import org.apache.maven.plugin.MojoExecutionException;
-import org.apache.maven.plugin.MojoFailureException;
-import org.asciidoctor.maven.test.TestUtils.ResourceBuilder;
-import org.asciidoctor.maven.io.ConsoleHolder;
-import org.asciidoctor.maven.model.Resource;
-import org.junit.jupiter.api.Test;
-
 import java.io.File;
 import java.io.IOException;
 import java.util.Arrays;
@@ -18,10 +9,19 @@ import java.util.function.Consumer;
 import java.util.function.Supplier;
 import java.util.stream.Collectors;
 
+import lombok.SneakyThrows;
+import org.apache.commons.io.FileUtils;
+import org.apache.maven.plugin.MojoExecutionException;
+import org.apache.maven.plugin.MojoFailureException;
+import org.asciidoctor.maven.io.ConsoleHolder;
+import org.asciidoctor.maven.model.Resource;
+import org.asciidoctor.maven.test.TestUtils.ResourceBuilder;
+import org.junit.jupiter.api.Test;
+
 import static java.nio.charset.StandardCharsets.UTF_8;
-import static org.asciidoctor.maven.test.TestUtils.newFakeRefreshMojo;
 import static org.asciidoctor.maven.io.TestFilesHelper.createFileWithContent;
 import static org.asciidoctor.maven.io.TestFilesHelper.newOutputTestDirectory;
+import static org.asciidoctor.maven.test.TestUtils.newFakeRefreshMojo;
 import static org.assertj.core.api.Assertions.assertThat;
 
 class AsciidoctorRefreshMojoTest {
@@ -113,10 +113,10 @@ class AsciidoctorRefreshMojoTest {
         final File target = new File(outputDir, sourceFile.getName().replace(fileExtension, "html"));
         consoleHolder.awaitProcessingAllSources();
         assertThat(FileUtils.readFileToString(target, UTF_8))
-                .contains("This is test, only a test");
+            .contains("This is test, only a test");
         final File ignoredTarget = new File(outputDir, ignoredFile.getName().replace(fileExtension, "html"));
         assertThat(ignoredTarget)
-                .doesNotExist();
+            .doesNotExist();
 
         // and when
         FileUtils.write(sourceFile, "= Document Title\n\nWow, this will be auto refreshed !", UTF_8);
@@ -124,9 +124,9 @@ class AsciidoctorRefreshMojoTest {
         // then
         consoleHolder.awaitProcessingSource();
         assertThat(FileUtils.readFileToString(target, UTF_8))
-                .contains("Wow, this will be auto refreshed");
+            .contains("Wow, this will be auto refreshed");
         assertThat(ignoredTarget)
-                .doesNotExist();
+            .doesNotExist();
         assertFilesNotPresentInOutput(docInfoFiles, outputDir);
 
         // cleanup
@@ -160,7 +160,7 @@ class AsciidoctorRefreshMojoTest {
         final File target = new File(outputDir, sourceFile.getName().replace(customFileExtension, "html"));
         consoleHolder.awaitProcessingAllSources();
         assertThat(FileUtils.readFileToString(target, UTF_8))
-                .contains("This is test, only a test");
+            .contains("This is test, only a test");
 
         // and when
         FileUtils.write(sourceFile, "= Document Title\n\nWow, this will be auto refreshed !", UTF_8);
@@ -168,7 +168,7 @@ class AsciidoctorRefreshMojoTest {
         // then
         consoleHolder.awaitProcessingSource();
         assertThat(FileUtils.readFileToString(target, UTF_8))
-                .contains("Wow, this will be auto refreshed");
+            .contains("Wow, this will be auto refreshed");
         assertFilesNotPresentInOutput(docInfoFiles, outputDir);
 
         // cleanup
@@ -196,7 +196,7 @@ class AsciidoctorRefreshMojoTest {
         final File target = new File(outputDir, sourceFile.getName().replace(".asciidoc", ".html"));
         consoleHolder.awaitProcessingAllSources();
         assertThat(FileUtils.readFileToString(target, UTF_8))
-                .contains("This is test, only a test");
+            .contains("This is test, only a test");
 
         // and when
         FileUtils.write(sourceFile, "= Document Title\n\nWow, this will be auto refreshed !", UTF_8);
@@ -204,7 +204,7 @@ class AsciidoctorRefreshMojoTest {
         // then
         consoleHolder.awaitProcessingSource();
         assertThat(FileUtils.readFileToString(target, UTF_8))
-                .contains("Wow, this will be auto refreshed");
+            .contains("Wow, this will be auto refreshed");
         assertFilesNotPresentInOutput(docInfoFiles, outputDir);
 
         // cleanup
@@ -232,7 +232,7 @@ class AsciidoctorRefreshMojoTest {
         File target = new File(outputDir, sourceFile.getName().replace(".asciidoc", ".html"));
         consoleHolder.awaitProcessingAllSources();
         assertThat(FileUtils.readFileToString(target, UTF_8))
-                .contains("This is test, only a test");
+            .contains("This is test, only a test");
 
         // and when
         FileUtils.write(sourceFile, "= Document Title\n\nWow, this will be auto refreshed !", UTF_8);
@@ -240,7 +240,7 @@ class AsciidoctorRefreshMojoTest {
         // then
         consoleHolder.awaitProcessingSource();
         assertThat(FileUtils.readFileToString(target, UTF_8))
-                .contains("Wow, this will be auto refreshed");
+            .contains("Wow, this will be auto refreshed");
         assertFilesNotPresentInOutput(docInfoFiles, outputDir);
 
         // cleanup
@@ -268,7 +268,7 @@ class AsciidoctorRefreshMojoTest {
         File target = new File(outputDir, sourceFile.getName().replace(".asciidoc", ".html"));
         consoleHolder.awaitProcessingAllSources();
         assertThat(FileUtils.readFileToString(target, UTF_8))
-                .contains("This is test, only a test");
+            .contains("This is test, only a test");
 
         // and when
         final File newSourceFile = new File(new File(srcDir, "sub-dir1/sub_dir2"), "sourceFile-2.asciidoc");
@@ -278,9 +278,9 @@ class AsciidoctorRefreshMojoTest {
         File newTarget = new File(outputDir, newSourceFile.getName().replace(".asciidoc", ".html"));
         consoleHolder.awaitProcessingSource();
         assertThat(FileUtils.readFileToString(newTarget, UTF_8))
-                .contains("Wow, this is NEW!!");
+            .contains("Wow, this is NEW!!");
         assertThat(FileUtils.readFileToString(target, UTF_8))
-                .contains("This is test, only a test");
+            .contains("This is test, only a test");
         assertFilesNotPresentInOutput(docInfoFiles, outputDir);
 
         // cleanup
@@ -308,7 +308,7 @@ class AsciidoctorRefreshMojoTest {
         final File target = new File(outputDir, resourceFile.getName());
         consoleHolder.awaitProcessingAllSources();
         assertThat(target)
-                .doesNotExist();
+            .doesNotExist();
 
         // and when
         FileUtils.write(resourceFile, "Supposedly image content UPDATED!", UTF_8);
@@ -316,7 +316,7 @@ class AsciidoctorRefreshMojoTest {
         // then
         consoleHolder.awaitProcessingResource();
         assertThat(FileUtils.readFileToString(target, UTF_8))
-                .isEqualTo("Supposedly image content UPDATED!");
+            .isEqualTo("Supposedly image content UPDATED!");
         assertFilesNotPresentInOutput(docInfoFiles, outputDir);
 
         // cleanup
@@ -336,17 +336,17 @@ class AsciidoctorRefreshMojoTest {
         // when
         final File sourceFile = new File(srcDir, "sourceFile.adoc");
         String sourceContent = new StringBuilder()
-                .append("= Document Title\n\n")
-                .append("This is test, only a test.\n\n")
-                .append("== Included\n\n")
-                .append("include::included.txt[]")
-                .toString();
+            .append("= Document Title\n\n")
+            .append("This is test, only a test.\n\n")
+            .append("== Included\n\n")
+            .append("include::included.txt[]")
+            .toString();
         FileUtils.write(sourceFile, sourceContent, UTF_8);
 
         final File includedFile = new File(srcDir, "included.txt");
         String includedContent = new StringBuilder()
-                .append("Original included content")
-                .toString();
+            .append("Original included content")
+            .toString();
         FileUtils.write(includedFile, includedContent, UTF_8);
 
         // when
@@ -364,9 +364,9 @@ class AsciidoctorRefreshMojoTest {
         final File target = new File(outputDir, "sourceFile.html");
         consoleHolder.awaitProcessingAllSources();
         assertThat(FileUtils.readFileToString(target, UTF_8))
-                .contains("Original included content");
+            .contains("Original included content");
         assertThat(includedContent)
-                .isNotEmpty();
+            .isNotEmpty();
 
         // and when
         FileUtils.write(includedFile, "Included content UPDATED!", UTF_8);
@@ -374,9 +374,9 @@ class AsciidoctorRefreshMojoTest {
         // then
         consoleHolder.awaitProcessingResource();
         assertThat(FileUtils.readFileToString(target, UTF_8))
-                .contains("Included content UPDATED!");
+            .contains("Included content UPDATED!");
         assertThat(includedContent)
-                .isNotEmpty();
+            .isNotEmpty();
 
         // cleanup
         consoleHolder.input("exit");
@@ -394,7 +394,7 @@ class AsciidoctorRefreshMojoTest {
         final List<File> docInfoFiles = createDocInfoFiles(srcDir);
 
         FileUtils.write(new File(srcDir, "sourceFile.asciidoc"),
-                "= Document Title\n\nThis is test, only a test.", UTF_8);
+            "= Document Title\n\nThis is test, only a test.", UTF_8);
         final String resourceFileExtension = "jpg";
         final File resourceFile = new File(srcDir, "fakeImage." + resourceFileExtension);
 
@@ -406,7 +406,7 @@ class AsciidoctorRefreshMojoTest {
         final File target = new File(outputDir, resourceFile.getName());
         consoleHolder.awaitProcessingAllSources();
         assertThat(FileUtils.readFileToString(target, UTF_8))
-                .isEqualTo("Supposedly image content");
+            .isEqualTo("Supposedly image content");
 
         // and when
         FileUtils.write(resourceFile, "Supposedly image content UPDATED!", UTF_8);
@@ -414,7 +414,7 @@ class AsciidoctorRefreshMojoTest {
         // then
         consoleHolder.awaitProcessingResource();
         assertThat(FileUtils.readFileToString(target, UTF_8))
-                .isEqualTo("Supposedly image content UPDATED!");
+            .isEqualTo("Supposedly image content UPDATED!");
         assertFilesNotPresentInOutput(docInfoFiles, outputDir);
 
         // cleanup
@@ -433,7 +433,7 @@ class AsciidoctorRefreshMojoTest {
         final List<File> docInfoFiles = createDocInfoFiles(srcDir);
 
         FileUtils.write(new File(srcDir, "sourceFile.asciidoc"),
-                "= Document Title\n\nThis is test, only a test.", UTF_8);
+            "= Document Title\n\nThis is test, only a test.", UTF_8);
         final File subDirectory = new File(srcDir, "sub-dir1/sub_dir2");
         final String resourceFileExtension = "jpg";
         final File resourceFile = new File(subDirectory, "fakeImage." + resourceFileExtension);
@@ -446,7 +446,7 @@ class AsciidoctorRefreshMojoTest {
         final File target = new File(subDirectory, resourceFile.getName());
         consoleHolder.awaitProcessingAllSources();
         assertThat(FileUtils.readFileToString(target, UTF_8))
-                .isEqualTo("Supposedly image content");
+            .isEqualTo("Supposedly image content");
 
         // and when
         FileUtils.write(resourceFile, "Supposedly image content UPDATED!", UTF_8);
@@ -454,7 +454,7 @@ class AsciidoctorRefreshMojoTest {
         // then
         consoleHolder.awaitProcessingResource();
         assertThat(FileUtils.readFileToString(target, UTF_8))
-                .isEqualTo("Supposedly image content UPDATED!");
+            .isEqualTo("Supposedly image content UPDATED!");
         assertFilesNotPresentInOutput(docInfoFiles, outputDir);
 
         // cleanup
@@ -473,7 +473,7 @@ class AsciidoctorRefreshMojoTest {
         final List<File> docInfoFiles = createDocInfoFiles(srcDir);
 
         FileUtils.write(new File(srcDir, "sourceFile.asciidoc"),
-                "= Document Title\n\nThis is test, only a test.", UTF_8);
+            "= Document Title\n\nThis is test, only a test.", UTF_8);
         final String subDirPath = "sub-dir1/sub_dir2";
         final File subDirectory = new File(srcDir, subDirPath);
         final String resourceFileExtension = "jpg";
@@ -487,17 +487,17 @@ class AsciidoctorRefreshMojoTest {
             mojo.sourceDirectory = srcDir;
             mojo.outputDirectory = outputDir;
             mojo.resources = Arrays.asList(new ResourceBuilder()
-                    .directory(subDirectory.getAbsolutePath())
-                    .includes("**/*.jpg", "**/*.gif")
-                    .targetPath(String.join(File.separator, subDirPath, customOutput))
-                    .build());
+                .directory(subDirectory.getAbsolutePath())
+                .includes("**/*.jpg", "**/*.gif")
+                .targetPath(String.join(File.separator, subDirPath, customOutput))
+                .build());
         });
 
         // then
         final File target = new File(outputDir, String.join(File.separator, subDirPath, customOutput, resourceFile.getName()));
         consoleHolder.awaitProcessingAllSources();
         assertThat(FileUtils.readFileToString(target, UTF_8))
-                .isEqualTo("Supposedly image content");
+            .isEqualTo("Supposedly image content");
 
         // and when
         FileUtils.write(resourceFile, "Supposedly image content UPDATED!", UTF_8);
@@ -505,9 +505,9 @@ class AsciidoctorRefreshMojoTest {
         // then
         consoleHolder.awaitProcessingResource();
         assertThat(FileUtils.readFileToString(target, UTF_8))
-                .isEqualTo("Supposedly image content UPDATED!");
+            .isEqualTo("Supposedly image content UPDATED!");
         assertThat(new File(outputDir, resourceFile.getName()))
-                .doesNotExist();
+            .doesNotExist();
         assertFilesNotPresentInOutput(docInfoFiles, outputDir);
 
         // cleanup
@@ -526,7 +526,7 @@ class AsciidoctorRefreshMojoTest {
         final List<File> docInfoFiles = createDocInfoFiles(srcDir);
 
         FileUtils.write(new File(srcDir, "sourceFile.asciidoc"),
-                "= Document Title\n\nThis is test, only a test.", UTF_8);
+            "= Document Title\n\nThis is test, only a test.", UTF_8);
         final String subDirPath = "sub-dir1/sub_dir2";
         final File subDirectory = new File(srcDir, subDirPath);
         final String resourceFileExtension = "jpg";
@@ -551,7 +551,7 @@ class AsciidoctorRefreshMojoTest {
         final File target = new File(outputDir, resourceFile.getName());
         consoleHolder.awaitProcessingAllSources();
         assertThat(FileUtils.readFileToString(target, UTF_8))
-                .isEqualTo("Supposedly image content");
+            .isEqualTo("Supposedly image content");
 
         // and when
         FileUtils.write(resourceFile, "Supposedly image content UPDATED!", UTF_8);
@@ -559,7 +559,7 @@ class AsciidoctorRefreshMojoTest {
         // then
         consoleHolder.awaitProcessingResource();
         assertThat(FileUtils.readFileToString(target, UTF_8))
-                .isEqualTo("Supposedly image content UPDATED!");
+            .isEqualTo("Supposedly image content UPDATED!");
         assertFilesNotPresentInOutput(docInfoFiles, outputDir);
 
         // cleanup
@@ -593,15 +593,15 @@ class AsciidoctorRefreshMojoTest {
         consoleHolder.awaitProcessingAllSources();
         final File targetSource = new File(outputDir, sourceFile.getName().replace("adoc", "html"));
         assertThat(targetSource)
-                .doesNotExist();
+            .doesNotExist();
         final File targetResource1 = new File(outputDir, resourceFile1.getName().replace("jpg", "html"));
         assertThat(FileUtils.readFileToString(targetResource1, UTF_8))
-                .contains("This is reality a Adoc source with jpg extension");
+            .contains("This is reality a Adoc source with jpg extension");
         assertThat(new File(outputDir, resourceFile1.getName()))
-                .doesNotExist();
+            .doesNotExist();
         final File targetResource2 = new File(outputDir, resourceFile2.getName());
         assertThat(targetResource2)
-                .exists();
+            .exists();
 
         // and when
         FileUtils.write(resourceFile1, "= Not an image\n\nWow, this will be auto refreshed !", UTF_8);
@@ -609,13 +609,13 @@ class AsciidoctorRefreshMojoTest {
         // then: custom file extensions is processed as source
         consoleHolder.awaitProcessingSource();
         assertThat(FileUtils.readFileToString(targetResource1, UTF_8))
-                .contains("Wow, this will be auto refreshed");
+            .contains("Wow, this will be auto refreshed");
         assertThat(new File(outputDir, resourceFile1.getName()))
-                .doesNotExist();
+            .doesNotExist();
         assertThat(targetResource2)
-                .exists();
+            .exists();
         assertThat(targetSource)
-                .doesNotExist();
+            .doesNotExist();
         assertFilesNotPresentInOutput(docInfoFiles, outputDir);
 
         // cleanup
@@ -653,15 +653,15 @@ class AsciidoctorRefreshMojoTest {
         consoleHolder.awaitProcessingAllSources();
         final File targetSource = new File(outputDir, sourceFile.getName().replace("adoc", "html"));
         assertThat(targetSource)
-                .doesNotExist();
+            .doesNotExist();
         final File targetResource1 = new File(outputDir, resourceFile1.getName().replace("jpg", "html"));
         assertThat(FileUtils.readFileToString(targetResource1, UTF_8))
-                .contains("This is reality a Adoc source with jpg extension");
+            .contains("This is reality a Adoc source with jpg extension");
         assertThat(new File(outputDir, resourceFile1.getName()))
-                .doesNotExist();
+            .doesNotExist();
         final File targetResource2 = new File(outputDir, resourceFile2.getName());
         assertThat(targetResource2)
-                .exists();
+            .exists();
 
         // and when
         FileUtils.write(resourceFile1, "= Not an image\n\nWow, this will be auto refreshed !", UTF_8);
@@ -669,13 +669,13 @@ class AsciidoctorRefreshMojoTest {
         // then: custom file extensions is processed as source
         consoleHolder.awaitProcessingSource();
         assertThat(FileUtils.readFileToString(targetResource1, UTF_8))
-                .contains("Wow, this will be auto refreshed");
+            .contains("Wow, this will be auto refreshed");
         assertThat(new File(outputDir, resourceFile1.getName()))
-                .doesNotExist();
+            .doesNotExist();
         assertThat(targetResource2)
-                .exists();
+            .exists();
         assertThat(targetSource)
-                .doesNotExist();
+            .doesNotExist();
         assertFilesNotPresentInOutput(docInfoFiles, outputDir);
 
         // cleanup
@@ -694,7 +694,7 @@ class AsciidoctorRefreshMojoTest {
 
         final List<File> docInfoFiles = createDocInfoFiles(srcDir);
         FileUtils.write(new File(srcDir, "sourceFile.asciidoc"),
-                "= Document Title\n\nThis is test, only a test.", UTF_8);
+            "= Document Title\n\nThis is test, only a test.", UTF_8);
         final File subDirectory = new File(srcDir, "sub-dir1/sub_dir2");
         final File resourceFile = new File(subDirectory, "fakeImage.jpg");
 
@@ -706,7 +706,7 @@ class AsciidoctorRefreshMojoTest {
         final File target = new File(subDirectory, resourceFile.getName());
         consoleHolder.awaitProcessingAllSources();
         assertThat(FileUtils.readFileToString(target, UTF_8))
-                .isEqualTo("Supposedly image content");
+            .isEqualTo("Supposedly image content");
 
         // and when
         final File newResourceFile = new File(subDirectory, "fakeImage-2.jpg");
@@ -715,9 +715,9 @@ class AsciidoctorRefreshMojoTest {
         // then
         consoleHolder.awaitProcessingResource();
         assertThat(FileUtils.readFileToString(newResourceFile, UTF_8))
-                .isEqualTo("Supposedly NEW image content!!");
+            .isEqualTo("Supposedly NEW image content!!");
         assertThat(resourceFile)
-                .exists();
+            .exists();
         assertFilesNotPresentInOutput(docInfoFiles, outputDir);
 
         // cleanup
@@ -791,17 +791,17 @@ class AsciidoctorRefreshMojoTest {
 
     private List<File> createDocInfoFiles(final File srcDir) {
         return Arrays.asList("docinfo.html", "docinfo-header.html", "my-docinfo-header.xml")
-                .stream()
-                .map(filename -> createFileWithContent(srcDir, filename))
-                .collect(Collectors.toList());
+            .stream()
+            .map(filename -> createFileWithContent(srcDir, filename))
+            .collect(Collectors.toList());
     }
 
     private void assertFilesNotPresentInOutput(final List<File> files, final File outputDir) {
         assertThat(files
-                .stream()
-                .map(file -> new File(outputDir, file.getName()))
-                .collect(Collectors.toList()))
-                .allMatch(file -> !file.exists());
+            .stream()
+            .map(file -> new File(outputDir, file.getName()))
+            .collect(Collectors.toList()))
+            .allMatch(file -> !file.exists());
     }
 
 }

--- a/asciidoctor-maven-plugin/src/test/java/org/asciidoctor/maven/AsciidoctorZipMojoTest.java
+++ b/asciidoctor-maven-plugin/src/test/java/org/asciidoctor/maven/AsciidoctorZipMojoTest.java
@@ -1,11 +1,5 @@
 package org.asciidoctor.maven;
 
-import org.apache.commons.io.FileUtils;
-import org.apache.maven.plugin.MojoExecutionException;
-import org.apache.maven.plugin.MojoFailureException;
-import org.asciidoctor.maven.io.TestFilesHelper;
-import org.junit.jupiter.api.Test;
-
 import java.io.File;
 import java.io.IOException;
 import java.util.ArrayList;
@@ -15,6 +9,12 @@ import java.util.List;
 import java.util.stream.Collectors;
 import java.util.zip.ZipEntry;
 import java.util.zip.ZipFile;
+
+import org.apache.commons.io.FileUtils;
+import org.apache.maven.plugin.MojoExecutionException;
+import org.apache.maven.plugin.MojoFailureException;
+import org.asciidoctor.maven.io.TestFilesHelper;
+import org.junit.jupiter.api.Test;
 
 import static java.nio.charset.StandardCharsets.UTF_8;
 import static org.asciidoctor.maven.test.TestUtils.mockAsciidoctorZipMojo;
@@ -38,7 +38,7 @@ class AsciidoctorZipMojoTest {
 
 
         FileUtils.write(new File(srcDir, "sample.adoc"),
-                "= Title\n\ntest", UTF_8);
+            "= Title\n\ntest", UTF_8);
 
         AsciidoctorZipMojo mojo = mockAsciidoctorZipMojo();
         mojo.sourceDirectory = srcDir;
@@ -52,13 +52,13 @@ class AsciidoctorZipMojoTest {
 
         ZipFile zipfile = new ZipFile(zip);
         List<String> names = getNames(zipfile.entries())
-                .stream()
-                .map(value -> normalizeOsPath(value))
-                .map(value -> value.replaceAll("/" + normalizeOsPath(outputDir.toString()), ""))
-                .collect(Collectors.toList());
+            .stream()
+            .map(value -> normalizeOsPath(value))
+            .map(value -> value.replaceAll("/" + normalizeOsPath(outputDir.toString()), ""))
+            .collect(Collectors.toList());
         assertThat(names).hasSize(1);
         assertThat(names.get(0).replaceAll("\\\\", "/"))
-                .isEqualTo("asciidoctor-zip/sample.html");
+            .isEqualTo("asciidoctor-zip/sample.html");
     }
 
     @Test
@@ -82,28 +82,28 @@ class AsciidoctorZipMojoTest {
         // then
         ZipFile zipfile = new ZipFile(zip);
         List<String> names = getNames(zipfile.entries())
-                .stream()
-                .map(value -> normalizeOsPath(value))
-                .map(value -> value.replaceAll("/" + normalizeOsPath(outputDir.toString()), ""))
-                .collect(Collectors.toList());
+            .stream()
+            .map(value -> normalizeOsPath(value))
+            .map(value -> value.replaceAll("/" + normalizeOsPath(outputDir.toString()), ""))
+            .collect(Collectors.toList());
         zipfile.close();
         // Paths are adapted for the test are do not match the real paths inside the zip
         List<String> expected = Arrays.asList(
-                "asciidoctor-zip/HelloWorld.groovy",
-                "asciidoctor-zip/HelloWorld.html",
-                "asciidoctor-zip/level-1-1/asciidoctor-icon.jpg",
-                "asciidoctor-zip/level-1-1/HelloWorld2.groovy",
-                "asciidoctor-zip/level-1-1/HelloWorld2.html",
-                "asciidoctor-zip/level-1-1/HelloWorld22.html",
-                "asciidoctor-zip/level-1-1/level-2-1/HelloWorld3.groovy",
-                "asciidoctor-zip/level-1-1/level-2-1/HelloWorld3.html",
-                "asciidoctor-zip/level-1-1/level-2-2/HelloWorld3.groovy",
-                "asciidoctor-zip/level-1-1/level-2-2/HelloWorld3.html",
-                "asciidoctor-zip/level-1-1/level-2-2/level-3-1/HelloWorld4.groovy",
-                "asciidoctor-zip/level-1-1/level-2-2/level-3-1/HelloWorld4.html"
+            "asciidoctor-zip/HelloWorld.groovy",
+            "asciidoctor-zip/HelloWorld.html",
+            "asciidoctor-zip/level-1-1/asciidoctor-icon.jpg",
+            "asciidoctor-zip/level-1-1/HelloWorld2.groovy",
+            "asciidoctor-zip/level-1-1/HelloWorld2.html",
+            "asciidoctor-zip/level-1-1/HelloWorld22.html",
+            "asciidoctor-zip/level-1-1/level-2-1/HelloWorld3.groovy",
+            "asciidoctor-zip/level-1-1/level-2-1/HelloWorld3.html",
+            "asciidoctor-zip/level-1-1/level-2-2/HelloWorld3.groovy",
+            "asciidoctor-zip/level-1-1/level-2-2/HelloWorld3.html",
+            "asciidoctor-zip/level-1-1/level-2-2/level-3-1/HelloWorld4.groovy",
+            "asciidoctor-zip/level-1-1/level-2-2/level-3-1/HelloWorld4.html"
         );
         assertThat(names)
-                .containsAll(expected);
+            .containsAll(expected);
     }
 
     @Test
@@ -125,27 +125,27 @@ class AsciidoctorZipMojoTest {
         // then
         ZipFile zipfile = new ZipFile(zip);
         List<String> names = getNames(zipfile.entries())
-                .stream()
-                .map(value -> normalizeOsPath(value))
-                .map(value -> value.replaceAll("/" + normalizeOsPath(outputDir.toString()), ""))
-                .collect(Collectors.toList());
+            .stream()
+            .map(value -> normalizeOsPath(value))
+            .map(value -> value.replaceAll("/" + normalizeOsPath(outputDir.toString()), ""))
+            .collect(Collectors.toList());
         zipfile.close();
         // Paths are adapted for the test are do not match the real paths inside the zip
         List<String> expected = Arrays.asList(
-                "asciidoctor-zip/HelloWorld.groovy",
-                "asciidoctor-zip/HelloWorld.html",
-                "asciidoctor-zip/HelloWorld2.html",
-                "asciidoctor-zip/HelloWorld22.html",
-                "asciidoctor-zip/HelloWorld3.html",
-                "asciidoctor-zip/HelloWorld4.html",
-                "asciidoctor-zip/level-1-1/asciidoctor-icon.jpg",
-                "asciidoctor-zip/level-1-1/HelloWorld2.groovy",
-                "asciidoctor-zip/level-1-1/level-2-1/HelloWorld3.groovy",
-                "asciidoctor-zip/level-1-1/level-2-2/HelloWorld3.groovy",
-                "asciidoctor-zip/level-1-1/level-2-2/level-3-1/HelloWorld4.groovy"
+            "asciidoctor-zip/HelloWorld.groovy",
+            "asciidoctor-zip/HelloWorld.html",
+            "asciidoctor-zip/HelloWorld2.html",
+            "asciidoctor-zip/HelloWorld22.html",
+            "asciidoctor-zip/HelloWorld3.html",
+            "asciidoctor-zip/HelloWorld4.html",
+            "asciidoctor-zip/level-1-1/asciidoctor-icon.jpg",
+            "asciidoctor-zip/level-1-1/HelloWorld2.groovy",
+            "asciidoctor-zip/level-1-1/level-2-1/HelloWorld3.groovy",
+            "asciidoctor-zip/level-1-1/level-2-2/HelloWorld3.groovy",
+            "asciidoctor-zip/level-1-1/level-2-2/level-3-1/HelloWorld4.groovy"
         );
         assertThat(names)
-                .containsAll(expected);
+            .containsAll(expected);
     }
 
     private List<String> getNames(Enumeration<? extends ZipEntry> entries) {

--- a/asciidoctor-maven-plugin/src/test/java/org/asciidoctor/maven/SourceDirectoryFinderTest.java
+++ b/asciidoctor-maven-plugin/src/test/java/org/asciidoctor/maven/SourceDirectoryFinderTest.java
@@ -1,13 +1,13 @@
 package org.asciidoctor.maven;
 
-import org.asciidoctor.maven.process.SourceDirectoryFinder;
-import org.junit.jupiter.api.Test;
-import org.junit.jupiter.api.io.TempDir;
-
 import java.io.File;
 import java.util.Optional;
 import java.util.concurrent.atomic.AtomicInteger;
 import java.util.function.Consumer;
+
+import org.asciidoctor.maven.process.SourceDirectoryFinder;
+import org.junit.jupiter.api.Test;
+import org.junit.jupiter.api.io.TempDir;
 
 import static org.asciidoctor.maven.process.SourceDirectoryFinder.ORDERED_CANDIDATE_PATHS;
 import static org.assertj.core.api.Assertions.assertThat;

--- a/asciidoctor-maven-plugin/src/test/java/org/asciidoctor/maven/extensions/AsciidoctorJExtensionRegistryTest.java
+++ b/asciidoctor-maven-plugin/src/test/java/org/asciidoctor/maven/extensions/AsciidoctorJExtensionRegistryTest.java
@@ -1,8 +1,23 @@
 package org.asciidoctor.maven.extensions;
 
 import org.asciidoctor.Asciidoctor;
-import org.asciidoctor.extension.*;
-import org.asciidoctor.maven.test.processors.*;
+import org.asciidoctor.extension.BlockMacroProcessor;
+import org.asciidoctor.extension.BlockProcessor;
+import org.asciidoctor.extension.DocinfoProcessor;
+import org.asciidoctor.extension.IncludeProcessor;
+import org.asciidoctor.extension.InlineMacroProcessor;
+import org.asciidoctor.extension.JavaExtensionRegistry;
+import org.asciidoctor.extension.Postprocessor;
+import org.asciidoctor.extension.Preprocessor;
+import org.asciidoctor.extension.Treeprocessor;
+import org.asciidoctor.maven.test.processors.ChangeAttributeValuePreprocessor;
+import org.asciidoctor.maven.test.processors.DummyPostprocessor;
+import org.asciidoctor.maven.test.processors.DummyTreeprocessor;
+import org.asciidoctor.maven.test.processors.GistBlockMacroProcessor;
+import org.asciidoctor.maven.test.processors.ManpageInlineMacroProcessor;
+import org.asciidoctor.maven.test.processors.MetaDocinfoProcessor;
+import org.asciidoctor.maven.test.processors.UriIncludeProcessor;
+import org.asciidoctor.maven.test.processors.YellBlockProcessor;
 import org.assertj.core.api.Assertions;
 import org.junit.jupiter.api.BeforeEach;
 import org.junit.jupiter.api.Test;
@@ -32,8 +47,8 @@ class AsciidoctorJExtensionRegistryTest {
         Exception e = Assertions.catchException(() -> pluginExtensionRegistry.register(className, null));
 
         assertThat(e)
-                .isInstanceOf(RuntimeException.class)
-                .hasMessage(String.format("'%s' is not a valid AsciidoctorJ processor class", className));
+            .isInstanceOf(RuntimeException.class)
+            .hasMessage(String.format("'%s' is not a valid AsciidoctorJ processor class", className));
     }
 
     @Test
@@ -43,8 +58,8 @@ class AsciidoctorJExtensionRegistryTest {
         Exception e = Assertions.catchException(() -> pluginExtensionRegistry.register(className, null));
 
         assertThat(e)
-                .isInstanceOf(RuntimeException.class)
-                .hasMessage(String.format("'%s' not found in classpath", className));
+            .isInstanceOf(RuntimeException.class)
+            .hasMessage(String.format("'%s' not found in classpath", className));
     }
 
     @Test

--- a/asciidoctor-maven-plugin/src/test/java/org/asciidoctor/maven/http/AsciidoctorHttpServerTest.java
+++ b/asciidoctor-maven-plugin/src/test/java/org/asciidoctor/maven/http/AsciidoctorHttpServerTest.java
@@ -1,12 +1,5 @@
 package org.asciidoctor.maven.http;
 
-import lombok.SneakyThrows;
-import lombok.Value;
-import org.apache.commons.io.IOUtils;
-import org.apache.maven.plugin.logging.Log;
-import org.junit.jupiter.api.Test;
-import org.mockito.Mockito;
-
 import java.io.File;
 import java.io.InputStream;
 import java.net.ConnectException;
@@ -16,7 +9,17 @@ import java.nio.charset.StandardCharsets;
 import java.util.Random;
 import java.util.UUID;
 
-import static io.netty.handler.codec.http.HttpResponseStatus.*;
+import lombok.SneakyThrows;
+import lombok.Value;
+import org.apache.commons.io.IOUtils;
+import org.apache.maven.plugin.logging.Log;
+import org.junit.jupiter.api.Test;
+import org.mockito.Mockito;
+
+import static io.netty.handler.codec.http.HttpResponseStatus.METHOD_NOT_ALLOWED;
+import static io.netty.handler.codec.http.HttpResponseStatus.NOT_FOUND;
+import static io.netty.handler.codec.http.HttpResponseStatus.OK;
+import static io.netty.handler.codec.http.HttpResponseStatus.RESET_CONTENT;
 import static org.asciidoctor.maven.io.TestFilesHelper.createFileWithContent;
 import static org.asciidoctor.maven.io.TestFilesHelper.newOutputTestDirectory;
 import static org.assertj.core.api.Assertions.assertThat;

--- a/asciidoctor-maven-plugin/src/test/java/org/asciidoctor/maven/io/ConsoleHolder.java
+++ b/asciidoctor-maven-plugin/src/test/java/org/asciidoctor/maven/io/ConsoleHolder.java
@@ -1,10 +1,10 @@
 package org.asciidoctor.maven.io;
 
-import lombok.SneakyThrows;
-
 import java.io.ByteArrayOutputStream;
 import java.io.InputStream;
 import java.io.PrintStream;
+
+import lombok.SneakyThrows;
 
 
 /**

--- a/asciidoctor-maven-plugin/src/test/java/org/asciidoctor/maven/io/DoubleOutputStream.java
+++ b/asciidoctor-maven-plugin/src/test/java/org/asciidoctor/maven/io/DoubleOutputStream.java
@@ -1,9 +1,9 @@
 package org.asciidoctor.maven.io;
 
-import lombok.SneakyThrows;
-
 import java.io.ByteArrayOutputStream;
 import java.io.OutputStream;
+
+import lombok.SneakyThrows;
 
 public class DoubleOutputStream extends ByteArrayOutputStream {
 

--- a/asciidoctor-maven-plugin/src/test/java/org/asciidoctor/maven/io/PrefilledInputStream.java
+++ b/asciidoctor-maven-plugin/src/test/java/org/asciidoctor/maven/io/PrefilledInputStream.java
@@ -1,9 +1,9 @@
 package org.asciidoctor.maven.io;
 
-import lombok.SneakyThrows;
-
 import java.io.ByteArrayInputStream;
 import java.util.concurrent.CountDownLatch;
+
+import lombok.SneakyThrows;
 
 public class PrefilledInputStream extends ByteArrayInputStream {
 

--- a/asciidoctor-maven-plugin/src/test/java/org/asciidoctor/maven/io/StringsCollectionsInputStream.java
+++ b/asciidoctor-maven-plugin/src/test/java/org/asciidoctor/maven/io/StringsCollectionsInputStream.java
@@ -1,13 +1,12 @@
 package org.asciidoctor.maven.io;
 
-import lombok.SneakyThrows;
-
-import java.io.IOException;
 import java.io.InputStream;
 import java.util.ArrayList;
 import java.util.List;
 import java.util.concurrent.Semaphore;
 import java.util.concurrent.atomic.AtomicInteger;
+
+import lombok.SneakyThrows;
 
 /**
  * Reads from a collection of strings to simulate command line inputs.

--- a/asciidoctor-maven-plugin/src/test/java/org/asciidoctor/maven/io/TestFilesHelper.java
+++ b/asciidoctor-maven-plugin/src/test/java/org/asciidoctor/maven/io/TestFilesHelper.java
@@ -1,10 +1,10 @@
 package org.asciidoctor.maven.io;
 
-import lombok.SneakyThrows;
-
 import java.io.File;
 import java.nio.file.Files;
 import java.util.UUID;
+
+import lombok.SneakyThrows;
 
 public class TestFilesHelper {
 

--- a/asciidoctor-maven-plugin/src/test/java/org/asciidoctor/maven/io/UserInputSimulator.java
+++ b/asciidoctor-maven-plugin/src/test/java/org/asciidoctor/maven/io/UserInputSimulator.java
@@ -1,10 +1,10 @@
 package org.asciidoctor.maven.io;
 
-import lombok.SneakyThrows;
-
 import java.io.ByteArrayOutputStream;
 import java.io.PrintStream;
 import java.util.concurrent.CountDownLatch;
+
+import lombok.SneakyThrows;
 
 public class UserInputSimulator {
 

--- a/asciidoctor-maven-plugin/src/test/java/org/asciidoctor/maven/process/CopyResourcesProcessorTest.java
+++ b/asciidoctor-maven-plugin/src/test/java/org/asciidoctor/maven/process/CopyResourcesProcessorTest.java
@@ -1,18 +1,18 @@
 package org.asciidoctor.maven.process;
 
-import org.apache.commons.io.FileUtils;
-import org.asciidoctor.maven.AsciidoctorMojo;
-import org.asciidoctor.maven.test.TestUtils.ResourceBuilder;
-import org.asciidoctor.maven.model.Resource;
-import org.junit.jupiter.api.Nested;
-import org.junit.jupiter.api.Test;
-import org.junit.jupiter.api.io.TempDir;
-
 import java.io.File;
 import java.io.IOException;
 import java.util.Arrays;
 import java.util.List;
 import java.util.UUID;
+
+import org.apache.commons.io.FileUtils;
+import org.asciidoctor.maven.AsciidoctorMojo;
+import org.asciidoctor.maven.model.Resource;
+import org.asciidoctor.maven.test.TestUtils.ResourceBuilder;
+import org.junit.jupiter.api.Nested;
+import org.junit.jupiter.api.Test;
+import org.junit.jupiter.api.io.TempDir;
 
 import static org.asciidoctor.maven.io.TestFilesHelper.createFileWithContent;
 import static org.asciidoctor.maven.process.CopyResourcesProcessor.IGNORED_FILE_NAMES;

--- a/asciidoctor-maven-plugin/src/test/java/org/asciidoctor/maven/process/SourceDocumentFinderTest.java
+++ b/asciidoctor-maven-plugin/src/test/java/org/asciidoctor/maven/process/SourceDocumentFinderTest.java
@@ -1,12 +1,12 @@
 package org.asciidoctor.maven.process;
 
-import org.junit.jupiter.api.Test;
-
 import java.io.File;
 import java.nio.file.Paths;
 import java.util.Arrays;
 import java.util.Collections;
 import java.util.List;
+
+import org.junit.jupiter.api.Test;
 
 import static org.assertj.core.api.Assertions.assertThat;
 

--- a/asciidoctor-maven-plugin/src/test/java/org/asciidoctor/maven/refresh/ResourceCopyFileAlterationListenerAdaptorTest.java
+++ b/asciidoctor-maven-plugin/src/test/java/org/asciidoctor/maven/refresh/ResourceCopyFileAlterationListenerAdaptorTest.java
@@ -1,12 +1,6 @@
 package org.asciidoctor.maven.refresh;
 
 
-import org.apache.maven.plugin.logging.Log;
-import org.asciidoctor.maven.AsciidoctorRefreshMojo;
-import org.asciidoctor.maven.model.Resource;
-import org.junit.jupiter.api.Test;
-import org.mockito.Mockito;
-
 import java.io.File;
 import java.util.Arrays;
 import java.util.List;
@@ -14,6 +8,12 @@ import java.util.UUID;
 import java.util.function.Supplier;
 import java.util.stream.Collectors;
 import java.util.stream.Stream;
+
+import org.apache.maven.plugin.logging.Log;
+import org.asciidoctor.maven.AsciidoctorRefreshMojo;
+import org.asciidoctor.maven.model.Resource;
+import org.junit.jupiter.api.Test;
+import org.mockito.Mockito;
 
 import static org.asciidoctor.maven.io.TestFilesHelper.createFileWithContent;
 import static org.asciidoctor.maven.io.TestFilesHelper.newOutputTestDirectory;

--- a/asciidoctor-maven-plugin/src/test/java/org/asciidoctor/maven/refresh/ResourcesPatternBuilderTest.java
+++ b/asciidoctor-maven-plugin/src/test/java/org/asciidoctor/maven/refresh/ResourcesPatternBuilderTest.java
@@ -1,9 +1,9 @@
 package org.asciidoctor.maven.refresh;
 
-import org.junit.jupiter.api.Test;
-
 import java.util.Arrays;
 import java.util.Collections;
+
+import org.junit.jupiter.api.Test;
 
 import static org.assertj.core.api.Assertions.assertThat;
 

--- a/asciidoctor-maven-plugin/src/test/java/org/asciidoctor/maven/test/MojoMocker.java
+++ b/asciidoctor-maven-plugin/src/test/java/org/asciidoctor/maven/test/MojoMocker.java
@@ -1,15 +1,15 @@
 package org.asciidoctor.maven.test;
 
+import java.io.File;
+import java.util.Map;
+import java.util.Properties;
+
 import lombok.SneakyThrows;
 import org.apache.maven.plugin.logging.SystemStreamLog;
 import org.apache.maven.project.MavenProject;
 import org.asciidoctor.maven.AsciidoctorMojo;
 import org.asciidoctor.maven.log.LogHandler;
 import org.mockito.Mockito;
-
-import java.io.File;
-import java.util.Map;
-import java.util.Properties;
 
 import static org.codehaus.plexus.util.ReflectionUtils.setVariableValueInObject;
 import static org.mockito.Mockito.when;

--- a/asciidoctor-maven-plugin/src/test/java/org/asciidoctor/maven/test/MojoMockerTest.java
+++ b/asciidoctor-maven-plugin/src/test/java/org/asciidoctor/maven/test/MojoMockerTest.java
@@ -1,10 +1,10 @@
 package org.asciidoctor.maven.test;
 
+import java.util.Map;
+
 import org.asciidoctor.maven.AsciidoctorMojo;
 import org.asciidoctor.maven.log.LogHandler;
 import org.junit.jupiter.api.Test;
-
-import java.util.Map;
 
 import static org.assertj.core.api.Assertions.assertThat;
 

--- a/asciidoctor-maven-plugin/src/test/java/org/asciidoctor/maven/test/TestUtils.java
+++ b/asciidoctor-maven-plugin/src/test/java/org/asciidoctor/maven/test/TestUtils.java
@@ -1,18 +1,18 @@
 package org.asciidoctor.maven.test;
 
-import org.asciidoctor.maven.AsciidoctorHttpMojo;
-import org.asciidoctor.maven.AsciidoctorMojo;
-import org.asciidoctor.maven.AsciidoctorRefreshMojo;
-import org.asciidoctor.maven.AsciidoctorZipMojo;
-import org.asciidoctor.maven.log.LogHandler;
-import org.asciidoctor.maven.model.Resource;
-
 import java.io.File;
 import java.util.ArrayList;
 import java.util.Arrays;
 import java.util.List;
 import java.util.Map;
 import java.util.stream.Collectors;
+
+import org.asciidoctor.maven.AsciidoctorHttpMojo;
+import org.asciidoctor.maven.AsciidoctorMojo;
+import org.asciidoctor.maven.AsciidoctorRefreshMojo;
+import org.asciidoctor.maven.AsciidoctorZipMojo;
+import org.asciidoctor.maven.log.LogHandler;
+import org.asciidoctor.maven.model.Resource;
 
 import static java.util.Collections.singletonList;
 import static org.asciidoctor.maven.process.SourceDocumentFinder.STANDARD_FILE_EXTENSIONS_PATTERN;

--- a/asciidoctor-maven-plugin/src/test/java/org/asciidoctor/maven/test/processors/AutoregisteredProcessor.java
+++ b/asciidoctor-maven-plugin/src/test/java/org/asciidoctor/maven/test/processors/AutoregisteredProcessor.java
@@ -1,7 +1,6 @@
 package org.asciidoctor.maven.test.processors;
 
 import org.asciidoctor.Asciidoctor;
-import org.asciidoctor.extension.JavaExtensionRegistry;
 import org.asciidoctor.jruby.extension.spi.ExtensionRegistry;
 
 public class AutoregisteredProcessor implements ExtensionRegistry {

--- a/asciidoctor-maven-plugin/src/test/java/org/asciidoctor/maven/test/processors/ChangeAttributeValuePreprocessor.java
+++ b/asciidoctor-maven-plugin/src/test/java/org/asciidoctor/maven/test/processors/ChangeAttributeValuePreprocessor.java
@@ -1,10 +1,10 @@
 package org.asciidoctor.maven.test.processors;
 
+import java.util.Map;
+
 import org.asciidoctor.ast.Document;
 import org.asciidoctor.extension.Preprocessor;
 import org.asciidoctor.extension.PreprocessorReader;
-
-import java.util.Map;
 
 public class ChangeAttributeValuePreprocessor extends Preprocessor {
 

--- a/asciidoctor-maven-plugin/src/test/java/org/asciidoctor/maven/test/processors/DummyPostprocessor.java
+++ b/asciidoctor-maven-plugin/src/test/java/org/asciidoctor/maven/test/processors/DummyPostprocessor.java
@@ -1,9 +1,9 @@
 package org.asciidoctor.maven.test.processors;
 
+import java.util.Map;
+
 import org.asciidoctor.ast.Document;
 import org.asciidoctor.extension.Postprocessor;
-
-import java.util.Map;
 
 public class DummyPostprocessor extends Postprocessor {
 

--- a/asciidoctor-maven-plugin/src/test/java/org/asciidoctor/maven/test/processors/DummyTreeprocessor.java
+++ b/asciidoctor-maven-plugin/src/test/java/org/asciidoctor/maven/test/processors/DummyTreeprocessor.java
@@ -1,10 +1,10 @@
 package org.asciidoctor.maven.test.processors;
 
-import org.asciidoctor.ast.Document;
-import org.asciidoctor.extension.Treeprocessor;
-
 import java.util.HashMap;
 import java.util.Map;
+
+import org.asciidoctor.ast.Document;
+import org.asciidoctor.extension.Treeprocessor;
 
 public class DummyTreeprocessor extends Treeprocessor {
 

--- a/asciidoctor-maven-plugin/src/test/java/org/asciidoctor/maven/test/processors/FailingPreprocessor.java
+++ b/asciidoctor-maven-plugin/src/test/java/org/asciidoctor/maven/test/processors/FailingPreprocessor.java
@@ -1,10 +1,10 @@
 package org.asciidoctor.maven.test.processors;
 
+import java.util.Map;
+
 import org.asciidoctor.ast.Document;
 import org.asciidoctor.extension.Preprocessor;
 import org.asciidoctor.extension.PreprocessorReader;
-
-import java.util.Map;
 
 public class FailingPreprocessor extends Preprocessor {
 

--- a/asciidoctor-maven-plugin/src/test/java/org/asciidoctor/maven/test/processors/GistBlockMacroProcessor.java
+++ b/asciidoctor-maven-plugin/src/test/java/org/asciidoctor/maven/test/processors/GistBlockMacroProcessor.java
@@ -1,11 +1,11 @@
 package org.asciidoctor.maven.test.processors;
 
+import java.util.List;
+import java.util.Map;
+
 import org.asciidoctor.ast.Block;
 import org.asciidoctor.ast.StructuralNode;
 import org.asciidoctor.extension.BlockMacroProcessor;
-
-import java.util.List;
-import java.util.Map;
 
 public class GistBlockMacroProcessor extends BlockMacroProcessor {
 

--- a/asciidoctor-maven-plugin/src/test/java/org/asciidoctor/maven/test/processors/ManpageInlineMacroProcessor.java
+++ b/asciidoctor-maven-plugin/src/test/java/org/asciidoctor/maven/test/processors/ManpageInlineMacroProcessor.java
@@ -1,10 +1,10 @@
 package org.asciidoctor.maven.test.processors;
 
-import org.asciidoctor.ast.ContentNode;
-import org.asciidoctor.extension.InlineMacroProcessor;
-
 import java.util.HashMap;
 import java.util.Map;
+
+import org.asciidoctor.ast.ContentNode;
+import org.asciidoctor.extension.InlineMacroProcessor;
 
 public class ManpageInlineMacroProcessor extends InlineMacroProcessor {
 

--- a/asciidoctor-maven-plugin/src/test/java/org/asciidoctor/maven/test/processors/MetaDocinfoProcessor.java
+++ b/asciidoctor-maven-plugin/src/test/java/org/asciidoctor/maven/test/processors/MetaDocinfoProcessor.java
@@ -1,9 +1,9 @@
 package org.asciidoctor.maven.test.processors;
 
+import java.util.Map;
+
 import org.asciidoctor.ast.Document;
 import org.asciidoctor.extension.DocinfoProcessor;
-
-import java.util.Map;
 
 public class MetaDocinfoProcessor extends DocinfoProcessor {
 

--- a/asciidoctor-maven-plugin/src/test/java/org/asciidoctor/maven/test/processors/UriIncludeProcessor.java
+++ b/asciidoctor-maven-plugin/src/test/java/org/asciidoctor/maven/test/processors/UriIncludeProcessor.java
@@ -1,15 +1,15 @@
 package org.asciidoctor.maven.test.processors;
 
-import org.asciidoctor.ast.Document;
-import org.asciidoctor.extension.IncludeProcessor;
-import org.asciidoctor.extension.PreprocessorReader;
-
 import java.io.BufferedReader;
 import java.io.IOException;
 import java.io.InputStreamReader;
 import java.net.URL;
 import java.util.Map;
 import java.util.stream.Collectors;
+
+import org.asciidoctor.ast.Document;
+import org.asciidoctor.extension.IncludeProcessor;
+import org.asciidoctor.extension.PreprocessorReader;
 
 public class UriIncludeProcessor extends IncludeProcessor {
 

--- a/asciidoctor-maven-plugin/src/test/java/org/asciidoctor/maven/test/processors/YellBlockProcessor.java
+++ b/asciidoctor-maven-plugin/src/test/java/org/asciidoctor/maven/test/processors/YellBlockProcessor.java
@@ -1,13 +1,13 @@
 package org.asciidoctor.maven.test.processors;
 
-import org.asciidoctor.ast.StructuralNode;
-import org.asciidoctor.extension.BlockProcessor;
-import org.asciidoctor.extension.Reader;
-
 import java.util.HashMap;
 import java.util.List;
 import java.util.Map;
 import java.util.stream.Collectors;
+
+import org.asciidoctor.ast.StructuralNode;
+import org.asciidoctor.extension.BlockProcessor;
+import org.asciidoctor.extension.Reader;
 
 public class YellBlockProcessor extends BlockProcessor {
 

--- a/asciidoctor-parser-doxia-module/src/main/java/org/asciidoctor/maven/site/ast/AsciidoctorAstDoxiaParser.java
+++ b/asciidoctor-parser-doxia-module/src/main/java/org/asciidoctor/maven/site/ast/AsciidoctorAstDoxiaParser.java
@@ -1,5 +1,12 @@
 package org.asciidoctor.maven.site.ast;
 
+import javax.inject.Inject;
+import javax.inject.Provider;
+import java.io.File;
+import java.io.IOException;
+import java.io.Reader;
+import java.util.logging.Logger;
+
 import org.apache.maven.doxia.parser.AbstractTextParser;
 import org.apache.maven.doxia.parser.ParseException;
 import org.apache.maven.doxia.parser.Parser;
@@ -22,13 +29,6 @@ import org.asciidoctor.maven.site.SiteLogHandlerDeserializer;
 import org.codehaus.plexus.component.annotations.Component;
 import org.codehaus.plexus.util.IOUtil;
 import org.codehaus.plexus.util.xml.Xpp3Dom;
-
-import javax.inject.Inject;
-import javax.inject.Provider;
-import java.io.File;
-import java.io.IOException;
-import java.io.Reader;
-import java.util.logging.Logger;
 
 import static org.asciidoctor.maven.commons.StringUtils.isNotBlank;
 

--- a/asciidoctor-parser-doxia-module/src/main/java/org/asciidoctor/maven/site/ast/NodesSinker.java
+++ b/asciidoctor-parser-doxia-module/src/main/java/org/asciidoctor/maven/site/ast/NodesSinker.java
@@ -1,5 +1,9 @@
 package org.asciidoctor.maven.site.ast;
 
+import java.util.Arrays;
+import java.util.List;
+import java.util.Optional;
+
 import org.apache.maven.doxia.sink.Sink;
 import org.asciidoctor.ast.StructuralNode;
 import org.asciidoctor.maven.site.ast.processors.DocumentNodeProcessor;
@@ -13,10 +17,6 @@ import org.asciidoctor.maven.site.ast.processors.PreambleNodeProcessor;
 import org.asciidoctor.maven.site.ast.processors.SectionNodeProcessor;
 import org.asciidoctor.maven.site.ast.processors.TableNodeProcessor;
 import org.asciidoctor.maven.site.ast.processors.UnorderedListNodeProcessor;
-
-import java.util.Arrays;
-import java.util.List;
-import java.util.Optional;
 
 /**
  * Document processor.

--- a/asciidoctor-parser-doxia-module/src/main/java/org/asciidoctor/maven/site/ast/processors/ImageNodeProcessor.java
+++ b/asciidoctor-parser-doxia-module/src/main/java/org/asciidoctor/maven/site/ast/processors/ImageNodeProcessor.java
@@ -1,10 +1,10 @@
 package org.asciidoctor.maven.site.ast.processors;
 
+import java.nio.file.FileSystems;
+
 import org.apache.maven.doxia.sink.Sink;
 import org.asciidoctor.ast.StructuralNode;
 import org.asciidoctor.maven.site.ast.NodeProcessor;
-
-import java.nio.file.FileSystems;
 
 import static org.asciidoctor.maven.commons.StringUtils.isBlank;
 

--- a/asciidoctor-parser-doxia-module/src/main/java/org/asciidoctor/maven/site/ast/processors/ListItemNodeProcessor.java
+++ b/asciidoctor-parser-doxia-module/src/main/java/org/asciidoctor/maven/site/ast/processors/ListItemNodeProcessor.java
@@ -1,11 +1,11 @@
 package org.asciidoctor.maven.site.ast.processors;
 
+import java.util.List;
+
 import org.apache.maven.doxia.sink.Sink;
 import org.asciidoctor.ast.ListItem;
 import org.asciidoctor.ast.StructuralNode;
 import org.asciidoctor.maven.site.ast.NodeProcessor;
-
-import java.util.List;
 
 /**
  * List items processor, including numbered and unnumbered.

--- a/asciidoctor-parser-doxia-module/src/main/java/org/asciidoctor/maven/site/ast/processors/OrderedListNodeProcessor.java
+++ b/asciidoctor-parser-doxia-module/src/main/java/org/asciidoctor/maven/site/ast/processors/OrderedListNodeProcessor.java
@@ -1,10 +1,10 @@
 package org.asciidoctor.maven.site.ast.processors;
 
+import java.util.List;
+
 import org.apache.maven.doxia.sink.Sink;
 import org.asciidoctor.ast.StructuralNode;
 import org.asciidoctor.maven.site.ast.NodeProcessor;
-
-import java.util.List;
 
 /**
  * Ordered list processor.

--- a/asciidoctor-parser-doxia-module/src/main/java/org/asciidoctor/maven/site/ast/processors/TableNodeProcessor.java
+++ b/asciidoctor-parser-doxia-module/src/main/java/org/asciidoctor/maven/site/ast/processors/TableNodeProcessor.java
@@ -1,13 +1,13 @@
 package org.asciidoctor.maven.site.ast.processors;
 
+import java.util.List;
+
 import org.apache.maven.doxia.sink.Sink;
 import org.asciidoctor.ast.Cell;
 import org.asciidoctor.ast.Row;
 import org.asciidoctor.ast.StructuralNode;
 import org.asciidoctor.jruby.ast.impl.TableImpl;
 import org.asciidoctor.maven.site.ast.NodeProcessor;
-
-import java.util.List;
 
 import static org.apache.maven.doxia.sink.Sink.JUSTIFY_LEFT;
 import static org.asciidoctor.maven.commons.StringUtils.isBlank;

--- a/asciidoctor-parser-doxia-module/src/main/java/org/asciidoctor/maven/site/ast/processors/UnorderedListNodeProcessor.java
+++ b/asciidoctor-parser-doxia-module/src/main/java/org/asciidoctor/maven/site/ast/processors/UnorderedListNodeProcessor.java
@@ -1,10 +1,10 @@
 package org.asciidoctor.maven.site.ast.processors;
 
+import java.util.List;
+
 import org.apache.maven.doxia.sink.Sink;
 import org.asciidoctor.ast.StructuralNode;
 import org.asciidoctor.maven.site.ast.NodeProcessor;
-
-import java.util.List;
 
 /**
  * Unordered list processor.

--- a/asciidoctor-parser-doxia-module/src/test/java/org/asciidoctor/maven/site/ast/processors/ImageNodeProcessorTest.java
+++ b/asciidoctor-parser-doxia-module/src/test/java/org/asciidoctor/maven/site/ast/processors/ImageNodeProcessorTest.java
@@ -1,17 +1,17 @@
 package org.asciidoctor.maven.site.ast.processors;
 
+import java.io.StringWriter;
+import java.nio.file.FileSystems;
+import java.util.Collections;
+import java.util.Map;
+import java.util.stream.Collectors;
+
 import org.asciidoctor.Asciidoctor;
 import org.asciidoctor.Options;
 import org.asciidoctor.ast.StructuralNode;
 import org.asciidoctor.maven.site.ast.NodeProcessor;
 import org.asciidoctor.maven.site.ast.processors.test.NodeProcessorTest;
 import org.junit.jupiter.api.Test;
-
-import java.io.StringWriter;
-import java.nio.file.FileSystems;
-import java.util.Collections;
-import java.util.Map;
-import java.util.stream.Collectors;
 
 import static org.assertj.core.api.Assertions.assertThat;
 

--- a/asciidoctor-parser-doxia-module/src/test/java/org/asciidoctor/maven/site/ast/processors/ListingNodeProcessorTest.java
+++ b/asciidoctor-parser-doxia-module/src/test/java/org/asciidoctor/maven/site/ast/processors/ListingNodeProcessorTest.java
@@ -1,14 +1,14 @@
 package org.asciidoctor.maven.site.ast.processors;
 
+import java.io.StringWriter;
+import java.util.Collections;
+
 import org.asciidoctor.Asciidoctor;
 import org.asciidoctor.Options;
 import org.asciidoctor.ast.StructuralNode;
 import org.asciidoctor.maven.site.ast.NodeProcessor;
 import org.asciidoctor.maven.site.ast.processors.test.NodeProcessorTest;
 import org.junit.jupiter.api.Test;
-
-import java.io.StringWriter;
-import java.util.Collections;
 
 import static org.asciidoctor.maven.site.ast.processors.test.StringTestUtils.clean;
 import static org.assertj.core.api.Assertions.assertThat;
@@ -28,7 +28,7 @@ class ListingNodeProcessorTest {
         String html = process(content);
 
         assertThat(html)
-                .isEqualTo(expectedHtmlCodeBlock());
+            .isEqualTo(expectedHtmlCodeBlock());
     }
 
     @Test
@@ -38,16 +38,16 @@ class ListingNodeProcessorTest {
         String html = process(content);
 
         assertThat(html)
-                .isEqualTo(expectedHtmlCodeBlock());
+            .isEqualTo(expectedHtmlCodeBlock());
     }
 
     private static String expectedHtmlCodeBlock() {
         // Actual styling is added in JS by prettify
         return "<div class=\"source\"><pre class=\"prettyprint\"><code>class HelloWorldLanguage {" +
-                "    public static void main(String[] args) {" +
-                "        System.out.println(\"Hello, World!\");" +
-                "    }" +
-                "}</code></pre></div>";
+            "    public static void main(String[] args) {" +
+            "        System.out.println(\"Hello, World!\");" +
+            "    }" +
+            "}</code></pre></div>";
     }
 
     @Test
@@ -57,7 +57,7 @@ class ListingNodeProcessorTest {
         String html = process(content);
 
         assertThat(html)
-                .startsWith("<div class=\"source\"><pre class=\"prettyprint linenums\"><code>");
+            .startsWith("<div class=\"source\"><pre class=\"prettyprint linenums\"><code>");
     }
 
     @Test
@@ -67,7 +67,7 @@ class ListingNodeProcessorTest {
         String html = process(content);
 
         assertThat(html)
-                .startsWith("<div class=\"source\"><pre class=\"prettyprint linenums\"><code>");
+            .startsWith("<div class=\"source\"><pre class=\"prettyprint linenums\"><code>");
     }
 
     @Test
@@ -77,11 +77,11 @@ class ListingNodeProcessorTest {
         String html = process(content);
 
         assertThat(html)
-                .isEqualTo("<div><pre>class HelloWorldLanguage {" +
-                        "    public static void main(String[] args) {" +
-                        "        System.out.println(\"Hello, World!\");" +
-                        "    }" +
-                        "}</pre></div>");
+            .isEqualTo("<div><pre>class HelloWorldLanguage {" +
+                "    public static void main(String[] args) {" +
+                "        System.out.println(\"Hello, World!\");" +
+                "    }" +
+                "}</pre></div>");
     }
 
     private String documentWithFullSourceBlock() {
@@ -98,21 +98,21 @@ class ListingNodeProcessorTest {
 
     private static String buildDocument(String blockDefinition) {
         return "= Document tile\n\n"
-                + "== Section\n\n"
-                + blockDefinition + "\n" +
-                "----\n" +
-                "class HelloWorldLanguage {\n" +
-                "    public static void main(String[] args) {\n" +
-                "        System.out.println(\"Hello, World!\");\n" +
-                "    }\n" +
-                "}\n" +
-                "----\n";
+            + "== Section\n\n"
+            + blockDefinition + "\n" +
+            "----\n" +
+            "class HelloWorldLanguage {\n" +
+            "    public static void main(String[] args) {\n" +
+            "        System.out.println(\"Hello, World!\");\n" +
+            "    }\n" +
+            "}\n" +
+            "----\n";
     }
 
     private String process(String content) {
         StructuralNode node = asciidoctor.load(content, Options.builder().build())
-                .findBy(Collections.singletonMap("context", ":listing"))
-                .get(0);
+            .findBy(Collections.singletonMap("context", ":listing"))
+            .get(0);
 
         nodeProcessor.process(node);
 

--- a/asciidoctor-parser-doxia-module/src/test/java/org/asciidoctor/maven/site/ast/processors/LiteralNodeProcessorTest.java
+++ b/asciidoctor-parser-doxia-module/src/test/java/org/asciidoctor/maven/site/ast/processors/LiteralNodeProcessorTest.java
@@ -1,14 +1,14 @@
 package org.asciidoctor.maven.site.ast.processors;
 
+import java.io.StringWriter;
+import java.util.Collections;
+
 import org.asciidoctor.Asciidoctor;
 import org.asciidoctor.Options;
 import org.asciidoctor.ast.StructuralNode;
 import org.asciidoctor.maven.site.ast.NodeProcessor;
 import org.asciidoctor.maven.site.ast.processors.test.NodeProcessorTest;
 import org.junit.jupiter.api.Test;
-
-import java.io.StringWriter;
-import java.util.Collections;
 
 import static org.assertj.core.api.Assertions.assertThat;
 

--- a/asciidoctor-parser-doxia-module/src/test/java/org/asciidoctor/maven/site/ast/processors/TableNodeProcessorTest.java
+++ b/asciidoctor-parser-doxia-module/src/test/java/org/asciidoctor/maven/site/ast/processors/TableNodeProcessorTest.java
@@ -1,5 +1,11 @@
 package org.asciidoctor.maven.site.ast.processors;
 
+import java.io.StringWriter;
+import java.util.Arrays;
+import java.util.Collections;
+import java.util.List;
+import java.util.stream.Collectors;
+
 import org.asciidoctor.Asciidoctor;
 import org.asciidoctor.Options;
 import org.asciidoctor.ast.StructuralNode;
@@ -7,14 +13,11 @@ import org.asciidoctor.maven.site.ast.NodeProcessor;
 import org.asciidoctor.maven.site.ast.processors.test.NodeProcessorTest;
 import org.junit.jupiter.api.Test;
 
-import java.io.StringWriter;
-import java.util.Arrays;
-import java.util.Collections;
-import java.util.List;
-import java.util.stream.Collectors;
-
 import static java.util.Collections.emptyList;
-import static org.asciidoctor.maven.site.ast.processors.TableNodeProcessorTest.DocumentBuilder.CaptionOptions.*;
+import static org.asciidoctor.maven.site.ast.processors.TableNodeProcessorTest.DocumentBuilder.CaptionOptions.disableLabelForTable;
+import static org.asciidoctor.maven.site.ast.processors.TableNodeProcessorTest.DocumentBuilder.CaptionOptions.disableLabelsGlobally;
+import static org.asciidoctor.maven.site.ast.processors.TableNodeProcessorTest.DocumentBuilder.CaptionOptions.noCaption;
+import static org.asciidoctor.maven.site.ast.processors.TableNodeProcessorTest.DocumentBuilder.CaptionOptions.simpleCaption;
 import static org.asciidoctor.maven.site.ast.processors.TableNodeProcessorTest.DocumentBuilder.documentWithTable;
 import static org.asciidoctor.maven.site.ast.processors.test.StringTestUtils.clean;
 import static org.assertj.core.api.Assertions.assertThat;

--- a/asciidoctor-parser-doxia-module/src/test/java/org/asciidoctor/maven/site/ast/processors/test/JUnitNodeProcessorExtension.java
+++ b/asciidoctor-parser-doxia-module/src/test/java/org/asciidoctor/maven/site/ast/processors/test/JUnitNodeProcessorExtension.java
@@ -1,5 +1,8 @@
 package org.asciidoctor.maven.site.ast.processors.test;
 
+import java.io.StringWriter;
+import java.lang.reflect.Field;
+
 import org.apache.commons.lang3.tuple.Pair;
 import org.apache.maven.doxia.sink.Sink;
 import org.asciidoctor.Asciidoctor;
@@ -7,10 +10,9 @@ import org.asciidoctor.maven.site.ast.NodeProcessor;
 import org.junit.jupiter.api.extension.ExtensionContext;
 import org.junit.jupiter.api.extension.TestInstancePostProcessor;
 
-import java.io.StringWriter;
-import java.lang.reflect.Field;
-
-import static org.asciidoctor.maven.site.ast.processors.test.ReflectionUtils.*;
+import static org.asciidoctor.maven.site.ast.processors.test.ReflectionUtils.extractField;
+import static org.asciidoctor.maven.site.ast.processors.test.ReflectionUtils.findField;
+import static org.asciidoctor.maven.site.ast.processors.test.ReflectionUtils.injectField;
 
 public class JUnitNodeProcessorExtension implements TestInstancePostProcessor {
 

--- a/asciidoctor-parser-doxia-module/src/test/java/org/asciidoctor/maven/site/ast/processors/test/NodeProcessorTest.java
+++ b/asciidoctor-parser-doxia-module/src/test/java/org/asciidoctor/maven/site/ast/processors/test/NodeProcessorTest.java
@@ -1,12 +1,12 @@
 package org.asciidoctor.maven.site.ast.processors.test;
 
-import org.asciidoctor.maven.site.ast.NodeProcessor;
-import org.junit.jupiter.api.extension.ExtendWith;
-
 import java.lang.annotation.ElementType;
 import java.lang.annotation.Retention;
 import java.lang.annotation.RetentionPolicy;
 import java.lang.annotation.Target;
+
+import org.asciidoctor.maven.site.ast.NodeProcessor;
+import org.junit.jupiter.api.extension.ExtendWith;
 
 @Target({ElementType.TYPE})
 @Retention(RetentionPolicy.RUNTIME)

--- a/asciidoctor-parser-doxia-module/src/test/java/org/asciidoctor/maven/site/ast/processors/test/TestNodeProcessorFactory.java
+++ b/asciidoctor-parser-doxia-module/src/test/java/org/asciidoctor/maven/site/ast/processors/test/TestNodeProcessorFactory.java
@@ -1,5 +1,7 @@
 package org.asciidoctor.maven.site.ast.processors.test;
 
+import java.lang.reflect.Constructor;
+
 import lombok.SneakyThrows;
 import org.apache.commons.lang3.tuple.Pair;
 import org.apache.maven.doxia.sink.Sink;
@@ -7,8 +9,6 @@ import org.apache.maven.doxia.siterenderer.RenderingContext;
 import org.apache.maven.doxia.siterenderer.sink.SiteRendererSink;
 import org.asciidoctor.maven.site.ast.NodeProcessor;
 import org.mockito.Mockito;
-
-import java.lang.reflect.Constructor;
 
 public class TestNodeProcessorFactory {
 

--- a/docs/modules/project/pages/contributing.adoc
+++ b/docs/modules/project/pages/contributing.adoc
@@ -16,12 +16,22 @@ There are multiple ways where you can help:
 Developer setup for hacking on this project isn't very difficult.
 The requirements are very small:
 
-* Java 8 or higher
+* Java 11 or higher
 * Maven 3
 
 Everything else will be brought in by Maven.
 This is a typical Maven Java project, nothing special.
 You should be able to use IntelliJ, Eclipse, or NetBeans without any issue for hacking on the project.
+
+== Code formatting
+
+The project doesn't have a strict policy, but there are some rules provided in using https://editorconfig.org/[.editorconfig] file.
+Check your IDE for `editorconfig` support.
+
+The rules are:
+
+* Use of spaces for indentation.
+* Maven import https://maven.apache.org/developers/conventions/code.html#java-code-convention-import-layouts[policy].
 
 == Testing
 


### PR DESCRIPTION
**What kind of change does this PR introduce?** (check at least one)
<!-- Update "[ ]" to "[x]" to check a box -->

- [ ] Bugfix
- [ ] Feature
- [ ] Documentation
- [x] Refactor
- [ ] Build improvement
- [ ] Other (please describe)


**What is the goal of this pull request?**

A bit of a personal change. I don't believe in strong formatting policies because those make things harder for contributors.
However, there are some IDE configurations that are helpful to have when contributing to Maven projects.
This PR tries to address that at leas for IntelliJ.


**Are there any alternative ways to implement this?**

There are plenty of tools. But editorconfig is supported by IntellKJ and vscode.

**Are there any implications of this pull request? Anything a user must know?**

no

**Is it related to an existing issue?**
<!-- If Yes, please add a line of the form: `Fixes #Issue` --> 
- [ ] Yes
- [ ] No

*Finally, please add a corresponding entry to CHANGELOG.adoc*
