### PR TITLE
Set document title for Maven site

### DIFF
--- a/src/main/java/org/asciidoctor/maven/site/AsciidoctorDoxiaParser.java
+++ b/src/main/java/org/asciidoctor/maven/site/AsciidoctorDoxiaParser.java
@@ -20,6 +20,11 @@ import java.io.File;
 import java.io.IOException;
 import java.io.Reader;
 import java.util.logging.Logger;
+import java.util.regex.Matcher;
+import java.util.regex.Pattern;
+
+import static java.util.regex.Pattern.CASE_INSENSITIVE;
+import static java.util.regex.Pattern.DOTALL;
 
 /**
  * This class is used by <a href="https://maven.apache.org/doxia/overview.html">the Doxia framework</a>
@@ -32,6 +37,8 @@ import java.util.logging.Logger;
  */
 @Component(role = Parser.class, hint = AsciidoctorDoxiaParser.ROLE_HINT)
 public class AsciidoctorDoxiaParser extends AbstractTextParser {
+
+    private static final Pattern TITLE_PATTERN = Pattern.compile("^.*<h1>([^<]*)</h1>.*$", DOTALL | CASE_INSENSITIVE);
 
     @Inject
     protected Provider<MavenProject> mavenProjectProvider;
@@ -84,6 +91,14 @@ public class AsciidoctorDoxiaParser extends AbstractTextParser {
         } catch (Exception exception) {
             throw new ParseException(exception.getMessage(), exception);
         }
+
+        // Set document title
+        sink.head();
+        sink.title();
+        Matcher titleMatcher = TITLE_PATTERN.matcher(asciidocHtml);
+        sink.text(titleMatcher.matches() ? titleMatcher.group(1) : "[Untitled]");
+        sink.title_();
+        sink.head_();
 
         sink.rawText(asciidocHtml);
     }


### PR DESCRIPTION
The document title is e.g. displayed in breadcrumbs.

Thank you for opening a pull request and contributing to asciidoctor-maven-plugin!

**What kind of change does this PR introduce?** (check at least one)
<!-- Update "[ ]" to "[x]" to check a box -->

- [x] Bugfix
- [x] Feature
- [ ] Documentation
- [ ] Refactor
- [ ] Build improvement
- [ ] Other (please describe)

**What is the goal of this pull request?**

Fix problem discussed with @abelsromero in [Zulip](https://asciidoctor.zulipchat.com/#narrow/stream/279642-users/topic/Use.20PlantUML.20in.20Maven.20Site/near/419668801).

**Are there any alternative ways to implement this?**

Parsing asciidoc instead of generated HTML. This was just a **quick fix to demonstrate how to do it** in general. Instead of parsing the content of the first `h1` tag in the generated HTML, we could scan the asciidoc from the reader for the first `# My doc title` section or, if not found, look for `:title: My doc title`. That would probably be more efficient and also circumvent problems with possibly encoded HTML entities like `&amp;` etc. Reading the asciidoc line by line and stopping at the first match might also be faster, but I did not do any gold plating here. Feel free to merge and then commit improvements on top.

P.S.: The Doxia sink FAQ says: [Avoid sink.rawText!](https://maven.apache.org/doxia/developers/sink.html#avoid-sink-rawtext)

**Are there any implications of this pull request? Anything a user must know?**

It should be documented how the user can set the document title in his asciidoc documents.

**Is it related to an existing issue?**
<!-- If Yes, please add a line of the form: `Fixes #Issue` --> 
- [ ] Yes
- [x] No

*Finally, please add a corresponding entry to CHANGELOG.adoc*

Please do that yourself, thanks.