### PR TITLE
Mark Zip mojo as deprecated for removal in next major

### DIFF
--- a/asciidoctor-maven-plugin/src/main/java/org/asciidoctor/maven/AsciidoctorZipMojo.java
+++ b/asciidoctor-maven-plugin/src/main/java/org/asciidoctor/maven/AsciidoctorZipMojo.java
@@ -11,6 +11,7 @@ import org.apache.maven.plugins.annotations.Parameter;
 import org.apache.maven.project.MavenProjectHelper;
 import org.asciidoctor.maven.io.Zips;
 
+@Deprecated(since = "3.0.0", forRemoval = true)
 @Mojo(name = "zip")
 public class AsciidoctorZipMojo extends AsciidoctorMojo {
     public static final String PREFIX = AsciidoctorMaven.PREFIX + "zip.";


### PR DESCRIPTION
As a simple reminder.

Related to #145
