### PR TITLE
Fix duplicated titles in 3.x.x migration guides

### DIFF
--- a/docs/modules/plugin/pages/v3-migration-guide.adoc
+++ b/docs/modules/plugin/pages/v3-migration-guide.adoc
@@ -1,4 +1,4 @@
-= Asciidoctor Maven Plugin 3.x.x Migration Guide
+= Maven Plugin 3.x.x Migration Guide
 :navtitle: 3.x.x Migration Guide
 
 The `asciidoctor-maven-plugin` 3.0.0 introduces some breaking changes.
@@ -23,6 +23,7 @@ Minimal Java version is 11.
 
 For anyone in need of a Java 8 compatible release, v2.5.x of the plugin will be supported for some time after v3.0.x release.
 Note this also imposes versions on dependencies, for example:
+
 * Only AsciidoctorJ v2.5.x
 * Only asciidoctorj-diagram previous v2.2.8
 

--- a/docs/modules/site-integration/pages/parser-module-setup-and-configuration.adoc
+++ b/docs/modules/site-integration/pages/parser-module-setup-and-configuration.adoc
@@ -3,13 +3,13 @@
 :fluido-skin-url: https://maven.apache.org/skins/maven-fluido-skin/
 
 WARNING: This module is still considered experimental and early stages.
-Please, consider sharing feedback and report any issue you find or improvement you consider to help us improve.
+Please, consider sharing feedback and reporting any issue you find, or improvement you consider to help us improve.
 
 This module uses Asciidoctor to parse AsciiDoc source files and then uses a custom converter adapted to Maven Site styles.
 Compatibility is being validated with the default skin and specially https://maven.apache.org/skins/maven-fluido-skin/[Fluido skin].
 
-This module should be used by those desiring a simple out-of-the-box experience and willing to sacrifice from AsciiDoc feature.
-Some noteworthy features not yet supported are admonitions or includes.
+This module should be used by those desiring a simple out-of-the-box experience and willing to sacrifice some AsciiDoc features (for now).
+See <<_supported_asciidoc_elements>> below for details on support.
 
 == Setup
 

--- a/docs/modules/site-integration/pages/v3-migration-guide.adoc
+++ b/docs/modules/site-integration/pages/v3-migration-guide.adoc
@@ -1,5 +1,7 @@
-= Asciidoctor Maven Plugin 3.x.x Migration Guide
+= Site integration 3.x.x Migration Guide
 :navtitle: 3.x.x Migration Guide
+:doxia-compatible-module-name: asciidoctor-converter-doxia-module
+:doxia-new-module-name: asciidoctor-parser-doxia-module
 
 The `asciidoctor-maven-plugin` and its Doxia Modules 3.0.0 introduces some breaking changes.
 This guide will provide the steps required to update a project currently using 2.x.x version.
@@ -9,18 +11,18 @@ NOTE: New configuration details are highlighted in *bold*.
 
 == Motivations
 
-Changes in this version have been motivated to improve the plugin evolution and maintenance.
+Changes in this version have been motivated to provide a new easier to use asciidoctor to build sites with Maven site plugin.
 With that goal in mind, the single project that contained both the maven plugin and site integration components has been split into different maven submodules.
-The main advantage for most users is that usage of the asciidoctor-maven-plugin will not require downloading Doxia dependencies.
+
+The old Doxia module embedded in `asciidocto-maven-plugin` library it's now an independent JAR called `{doxia-compatible-module-name}`, and a new one has been created `{doxia-new-module-name}`.
 
 == Changes
 
 === Site plugin module renamed
-:doxia-module-name: asciidoctor-converter-doxia-module
 
-The https://maven.apache.org/doxia/[Doxia] module has been extracted into a separated subproject named `{doxia-module-name}`.
+The https://maven.apache.org/doxia/[Doxia] module has been extracted into a separated subproject named `{doxia-compatible-module-name}`.
 
-*Rename the maven-site-plugin dependency from `asciidoctor-maven-plugin` to `{doxia-module-name}`.*
+*Rename the maven-site-plugin dependency from `asciidoctor-maven-plugin` to `{doxia-compatible-module-name}`.*
 
 [source,xml,subs=attributes+]
 .new configuration
@@ -32,7 +34,7 @@ The https://maven.apache.org/doxia/[Doxia] module has been extracted into a sepa
     <dependencies>
         <dependency>
             <groupId>org.asciidoctor</groupId>
-            <artifactId>{doxia-module-name}</artifactId>
+            <artifactId>{doxia-compatible-module-name}</artifactId>
             <version>{release-version}</version>
         </dependency>
     </dependencies>


### PR DESCRIPTION
**What kind of change does this PR introduce?** (check at least one)
<!-- Update "[ ]" to "[x]" to check a box -->

- [ ] Bugfix
- [ ] Feature
- [x] Documentation
- [ ] Refactor
- [ ] Build improvement
- [ ] Other (please describe)


**What is the goal of this pull request?**

Address duplicated titles for migration guides (https://github.com/asciidoctor/docs.asciidoctor.org/pull/78#issuecomment-1947199056)

* Make the title different for plugin and site modules
* Other fixes and style reviews


**Are there any alternative ways to implement this?**

no

**Are there any implications of this pull request? Anything a user must know?**

no

**Is it related to an existing issue?**
<!-- If Yes, please add a line of the form: `Fixes #Issue` --> 
- [ ] Yes
- [x] No

*Finally, please add a corresponding entry to CHANGELOG.adoc*
