### PR TITLE
(main) Use 'chat.asciidoctor.org' for Zulip urls in README

### DIFF
--- a/README.adoc
+++ b/README.adoc
@@ -18,6 +18,7 @@ ifndef::env-github[:icons: font]
 :uri-maven: http://maven.apache.org
 :uri-license: {uri-repo}/blob/main/LICENSE.txt
 :uri-docs: https://docs.asciidoctor.org/maven-tools/latest
+:uri-project-chat: https://chat.asciidoctor.org
 // GitHub customization
 ifdef::env-github[]
 :badges:
@@ -35,7 +36,7 @@ ifdef::badges[]
 image:{uri-repo}/workflows/Build/badge.svg[Build Status,link={uri-repo}/actions]
 image:http://img.shields.io/coveralls/{project-repo}/main.svg["Coverage Status", link="https://coveralls.io/r/{project-repo}?branch=main"]
 image:https://maven-badges.herokuapp.com/maven-central/org.asciidoctor/asciidoctor-maven-plugin/badge.svg["Maven Central",link="https://maven-badges.herokuapp.com/maven-central/org.asciidoctor/asciidoctor-maven-plugin"]
-image:https://img.shields.io/badge/zulip-join_chat-brightgreen.svg[project chat,link=https://asciidoctor.zulipchat.com/]
+image:https://img.shields.io/badge/zulip-join_chat-brightgreen.svg[project chat,link={uri-project-chat}]
 endif::[]
 
 The Asciidoctor Maven Plugin is the official way to convert your {uri-asciidoc}[AsciiDoc] documentation using {uri-asciidoctor}[Asciidoctor] from an {uri-maven}[Apache Maven] build.
@@ -47,7 +48,7 @@ The conversion can happen in 2 flavors:
 . as a Maven site integration: AsciiDoc files are integrated with Maven reports, which comes with
 a few limitations (see below for details).
 
-Full documentations is available in the {uri-docs}[USER MANUAL], if you have questions, please drop them at the https://asciidoctor.zulipchat.com/#narrow/stream/users[PROJECT CHAT].
+Full documentations is available in the {uri-docs}[USER MANUAL], if you have questions, please drop them at the {uri-project-chat}/#narrow/stream/users[PROJECT CHAT].
 
 ifndef::env-site[]
 .Translations of the document are available in the following languages:


### PR DESCRIPTION
Thank you for opening a pull request and contributing to asciidoctor-maven-plugin!

**What kind of change does this PR introduce?** (check at least one)
<!-- Update "[ ]" to "[x]" to check a box -->

- [ ] Bugfix
- [ ] Feature
- [x] Documentation
- [ ] Refactor
- [ ] Build improvement
- [ ] Other (please describe)


**What is the goal of this pull request?**

Fix chat URL to use preferred `chat.asciidoctor.org`

**Are there any alternative ways to implement this?**

no

**Are there any implications of this pull request? Anything a user must know?**

no

**Is it related to an existing issue?**
<!-- If Yes, please add a line of the form: `Fixes #Issue` --> 
- [ ] Yes
- [x] No

*Finally, please add a corresponding entry to CHANGELOG.adoc*
