### PR TITLE
Force artifact install when building javadocs in CI (#742)

### DIFF
--- a/.github/workflows/build.yaml
+++ b/.github/workflows/build.yaml
@@ -63,8 +63,8 @@ jobs:
           java-distribution: 'temurin'
           java-version: ${{ matrix.java }}
           maven-version: ${{ matrix.maven }}
-      - name: Build & Test
-        run: mvn -B clean javadoc:jar
+      - name: Build javadoc
+        run: mvn clean install -DskipTests && mvn clean javadoc:javadoc
   signature:
     name: Sign artifacts
     environment: test

--- a/CHANGELOG.adoc
+++ b/CHANGELOG.adoc
@@ -13,6 +13,10 @@ For a detailed view of what has changed, refer to the {uri-repo}/commits/main[co
 
 == Unreleased
 
+Build / Infrastructure::
+
+  * Fix javadoc check flake in CI (#814)
+
 == v3.0.0 (2024-01-30)
 
 Bug Fixes::


### PR DESCRIPTION
Thank you for opening a pull request and contributing to asciidoctor-maven-plugin!

**What kind of change does this PR introduce?** (check at least one)
<!-- Update "[ ]" to "[x]" to check a box -->

- [ ] Bugfix
- [ ] Feature
- [ ] Documentation
- [ ] Refactor
- [x] Build improvement
- [ ] Other (please describe)


**What is the goal of this pull request?**

Fix javadoc build flakes in CI

```
**Failed to execute goal on project asciidoctor-maven-plugin: Could not resolve dependencies for project org.asciidoctor:asciidoctor-maven-plugin:maven-plugin:3.0.1-SNAPSHOT: The following artifacts could not be resolved: org.asciidoctor:asciidoctor-maven-commons:jar:3.0.1-SNAPSHOT (absent): Could not find artifact org.asciidoctor:asciidoctor-maven-commons:jar:3.0.1-SNAPSHOT -> [Help 1]**
````

**Are there any alternative ways to implement this?**

This is an experiment :crossed_fingers: 

**Are there any implications of this pull request? Anything a user must know?**


**Is it related to an existing issue?**
<!-- If Yes, please add a line of the form: `Fixes #Issue` --> 
- [x] Yes #742 
- [] No

*Finally, please add a corresponding entry to CHANGELOG.adoc*
