### PR TITLE
(main) Fix IMG tag closing in parser-doxia-module

### DIFF
--- a/CHANGELOG.adoc
+++ b/CHANGELOG.adoc
@@ -13,6 +13,10 @@ For a detailed view of what has changed, refer to the {uri-repo}/commits/main[co
 
 == Unreleased
 
+Bug Fixes::
+
+  * Fix open IMG tags in parser-doxia-module (#930)
+
 Build / Infrastructure::
 
   * Fix javadoc check flake in CI (#814)

--- a/asciidoctor-parser-doxia-module/src/it/maven-site-plugin/validate.groovy
+++ b/asciidoctor-parser-doxia-module/src/it/maven-site-plugin/validate.groovy
@@ -175,7 +175,7 @@ class HtmlAsserter {
     }
 
     void containsImage(String value) {
-        def found = find("<img src=\"$value\" alt=\"Asciidoctor is awesome\">")
+        def found = find("<img src=\"$value\" alt=\"Asciidoctor is awesome\" />")
         assertFound("Image", value, found)
     }
 

--- a/asciidoctor-parser-doxia-module/src/main/java/org/asciidoctor/maven/site/parser/processors/ImageNodeProcessor.java
+++ b/asciidoctor-parser-doxia-module/src/main/java/org/asciidoctor/maven/site/parser/processors/ImageNodeProcessor.java
@@ -1,8 +1,10 @@
 package org.asciidoctor.maven.site.parser.processors;
 
+import javax.swing.text.html.HTML.Attribute;
 import java.nio.file.FileSystems;
 
 import org.apache.maven.doxia.sink.Sink;
+import org.apache.maven.doxia.sink.impl.SinkEventAttributeSet;
 import org.asciidoctor.ast.StructuralNode;
 import org.asciidoctor.maven.site.parser.NodeProcessor;
 
@@ -37,7 +39,9 @@ public class ImageNodeProcessor extends AbstractSinkNodeProcessor implements Nod
 
         final String imagesdir = (String) node.getAttribute("imagesdir");
         String imagePath = isBlank(imagesdir) ? target : formatPath(imagesdir, target);
-        getSink().rawText(String.format("<img src=\"%s\" alt=\"%s\">", imagePath, alt));
+        final SinkEventAttributeSet attributes = new SinkEventAttributeSet();
+        attributes.addAttribute(Attribute.ALT, alt);
+        getSink().figureGraphics(imagePath, attributes);
     }
 
     private String formatPath(String imagesdir, String target) {

--- a/asciidoctor-parser-doxia-module/src/test/java/org/asciidoctor/maven/site/parser/processors/ImageNodeProcessorTest.java
+++ b/asciidoctor-parser-doxia-module/src/test/java/org/asciidoctor/maven/site/parser/processors/ImageNodeProcessorTest.java
@@ -30,7 +30,7 @@ class ImageNodeProcessorTest {
         String html = process(content, 0);
 
         assertThat(html)
-                .isEqualTo("<img src=\"images/tiger.png\" alt=\"Kitty\">");
+                .isEqualTo("<img src=\"images/tiger.png\" alt=\"Kitty\" />");
     }
 
     @Test
@@ -41,7 +41,7 @@ class ImageNodeProcessorTest {
 
         final String separator = FileSystems.getDefault().getSeparator();
         assertThat(html)
-                .isEqualTo("<img src=\"prefix-path" + separator + "images/tiger.png\" alt=\"Kitty\">");
+                .isEqualTo("<img src=\"prefix-path" + separator + "images/tiger.png\" alt=\"Kitty\" />");
     }
 
     private String documentWithImage() {


### PR DESCRIPTION
Thank you for opening a pull request and contributing to asciidoctor-maven-plugin!

**What kind of change does this PR introduce?** (check at least one)
<!-- Update "[ ]" to "[x]" to check a box -->

- [x] Bugfix
- [ ] Feature
- [ ] Documentation
- [ ] Refactor
- [ ] Build improvement
- [ ] Other (please describe)


**What is the goal of this pull request?**

Fix image tag not being closed in `asciidoctor-parser-doxia-module`.

**Are there any alternative ways to implement this?**

The solution delegates in the proper sink `figureGraphics`, we could have simply applied the change with `rawText`.
But I think is important to rely in raw as little as possible.

**Are there any implications of this pull request? Anything a user must know?**


**Is it related to an existing issue?**
<!-- If Yes, please add a line of the form: `Fixes #Issue` --> 
- [x] Yes
- [ ] No

Fixes https://github.com/asciidoctor/asciidoctor-maven-plugin/issues/783

*Finally, please add a corresponding entry to CHANGELOG.adoc*
