### PR TITLE
Add compatibility with maven-site-plugin v3.20.0

### DIFF
--- a/CHANGELOG.adoc
+++ b/CHANGELOG.adoc
@@ -20,6 +20,7 @@ Bug Fixes::
 Improvements::
 
   * Added support for AsciidoctorJ v3.0.0 (#651)
+  * Add compatibility with maven-site-plugin v3.20.0 (#934)
 
 Build / Infrastructure::
 

--- a/CHANGELOG.adoc
+++ b/CHANGELOG.adoc
@@ -16,11 +16,12 @@ For a detailed view of what has changed, refer to the {uri-repo}/commits/main[co
 Bug Fixes::
 
   * Fix open IMG tags in parser-doxia-module (#930)
+  * Fix naming in Asciidoctor Converter Doxia Module pom (#934)
 
 Improvements::
 
   * Added support for AsciidoctorJ v3.0.0 (#651)
-  * Add compatibility with maven-site-plugin v3.20.0 (#934)
+  * Add compatibility with maven-site-plugin v3.20.0 and Doxia v2.0.0 (#933)
 
 Build / Infrastructure::
 

--- a/asciidoctor-converter-doxia-module/pom.xml
+++ b/asciidoctor-converter-doxia-module/pom.xml
@@ -46,7 +46,7 @@
         <dependency>
             <groupId>org.apache.maven.doxia</groupId>
             <artifactId>doxia-site-renderer</artifactId>
-            <version>1.11.1</version>
+            <version>${doxia.sitetools.version}</version>
             <scope>test</scope>
         </dependency>
     </dependencies>

--- a/asciidoctor-converter-doxia-module/pom.xml
+++ b/asciidoctor-converter-doxia-module/pom.xml
@@ -12,8 +12,8 @@
     <artifactId>asciidoctor-converter-doxia-module</artifactId>
     <packaging>jar</packaging>
 
-    <name>Asciidoctor Converter Doxia Parser</name>
-    <description>Asciidoctor Doxia Parser based on Asciidoctor Html converter (for Maven Site integration)</description>
+    <name>Asciidoctor Converter Doxia Module</name>
+    <description>Asciidoctor Doxia Module based on Asciidoctor Html converter (for Maven Site integration)</description>
     <url>https://github.com/asciidoctor/asciidoctor-maven-plugin</url>
 
     <dependencies>

--- a/asciidoctor-converter-doxia-module/src/it/maven-site-plugin/pom.xml
+++ b/asciidoctor-converter-doxia-module/src/it/maven-site-plugin/pom.xml
@@ -28,8 +28,7 @@
             <plugin>
                 <groupId>org.apache.maven.plugins</groupId>
                 <artifactId>maven-site-plugin</artifactId>
-                <!-- v2.2.2 of the plugin require Maven Site Plugin 3.1x.0 alongside Doxia 1.11.1 -->
-                <version>3.12.1</version>
+                <version>3.20.0</version>
                 <configuration>
                     <asciidoc>
                         <baseDir>${project.basedir}/src/site/asciidoc</baseDir>

--- a/asciidoctor-converter-doxia-module/src/it/maven-site-plugin/pom.xml
+++ b/asciidoctor-converter-doxia-module/src/it/maven-site-plugin/pom.xml
@@ -51,6 +51,7 @@
                             <toclevels>2</toclevels>
                         </attributes>
                     </asciidoc>
+                    <relativizeSiteLinks>false</relativizeSiteLinks>
                     <moduleExcludes>
                         <asciidoc>**/_*.adoc,**/_*/</asciidoc>
                     </moduleExcludes>

--- a/asciidoctor-converter-doxia-module/src/it/maven-site-plugin/src/site/site.xml
+++ b/asciidoctor-converter-doxia-module/src/it/maven-site-plugin/src/site/site.xml
@@ -14,6 +14,6 @@
     <skin>
         <groupId>org.apache.maven.skins</groupId>
         <artifactId>maven-fluido-skin</artifactId>
-        <version>1.12.0</version>
+        <version>2.0.0-M9</version>
     </skin>
 </project>

--- a/asciidoctor-converter-doxia-module/src/it/maven-site-plugin/src/site/site.xml
+++ b/asciidoctor-converter-doxia-module/src/it/maven-site-plugin/src/site/site.xml
@@ -1,4 +1,6 @@
-<project name="Maven Site Plugin IT">
+<site xmlns="http://maven.apache.org/SITE/2.0.0"
+      xmlns:xsi="http://www.w3.org/2001/XMLSchema-instance"
+      xsi:schemaLocation="http://maven.apache.org/SITE/2.0.0 https://maven.apache.org/xsd/site-2.0.0.xsd">
     <body>
         <breadcrumbs>
             <item name="Doxia" href="https://maven.apache.org/doxia/index.html"/>
@@ -16,4 +18,4 @@
         <artifactId>maven-fluido-skin</artifactId>
         <version>2.0.0-M9</version>
     </skin>
-</project>
+</site>

--- a/asciidoctor-converter-doxia-module/src/main/java/org/asciidoctor/maven/site/AsciidoctorConverterDoxiaParser.java
+++ b/asciidoctor-converter-doxia-module/src/main/java/org/asciidoctor/maven/site/AsciidoctorConverterDoxiaParser.java
@@ -108,7 +108,6 @@ public class AsciidoctorConverterDoxiaParser extends AbstractTextParser {
             logRecord -> logger.info(LogRecordFormatter.format(logRecord, siteDirectory)));
         asciidoctor.registerLogHandler(memoryLogHandler);
         // disable default console output of AsciidoctorJ
-        // TODO validate if still needed
         java.util.logging.Logger.getLogger("asciidoctor").setUseParentHandlers(false);
         return memoryLogHandler;
     }

--- a/asciidoctor-parser-doxia-module/pom.xml
+++ b/asciidoctor-parser-doxia-module/pom.xml
@@ -46,7 +46,7 @@
         <dependency>
             <groupId>org.apache.maven.doxia</groupId>
             <artifactId>doxia-site-renderer</artifactId>
-            <version>1.11.1</version>
+            <version>${doxia.sitetools.version}</version>
             <scope>test</scope>
         </dependency>
     </dependencies>

--- a/asciidoctor-parser-doxia-module/src/it/maven-site-plugin/pom.xml
+++ b/asciidoctor-parser-doxia-module/src/it/maven-site-plugin/pom.xml
@@ -23,7 +23,7 @@
             <plugin>
                 <groupId>org.apache.maven.plugins</groupId>
                 <artifactId>maven-site-plugin</artifactId>
-                <version>3.12.1</version>
+                <version>3.20.0</version>
                 <configuration>
                     <asciidoc>
                         <baseDir>${project.basedir}/src/site/asciidoc</baseDir>

--- a/asciidoctor-parser-doxia-module/src/it/maven-site-plugin/pom.xml
+++ b/asciidoctor-parser-doxia-module/src/it/maven-site-plugin/pom.xml
@@ -31,6 +31,7 @@
                             <toclevels>2</toclevels>
                         </attributes>
                     </asciidoc>
+                    <relativizeSiteLinks>false</relativizeSiteLinks>
                     <moduleExcludes>
                         <asciidoc>**/_*.adoc,**/_*/</asciidoc>
                     </moduleExcludes>

--- a/asciidoctor-parser-doxia-module/src/it/maven-site-plugin/src/site/site.xml
+++ b/asciidoctor-parser-doxia-module/src/it/maven-site-plugin/src/site/site.xml
@@ -7,11 +7,11 @@
         <menu name="AsciiDoc Pages">
             <item name="Sample" href="sample.html"/>
         </menu>
-        ${reports}
+        <menu ref="reports"/>
     </body>
     <skin>
         <groupId>org.apache.maven.skins</groupId>
         <artifactId>maven-fluido-skin</artifactId>
-        <version>1.12.0</version>
+        <version>2.0.0-M9</version>
     </skin>
 </project>

--- a/asciidoctor-parser-doxia-module/src/it/maven-site-plugin/src/site/site.xml
+++ b/asciidoctor-parser-doxia-module/src/it/maven-site-plugin/src/site/site.xml
@@ -1,4 +1,6 @@
-<project name="Maven Site Plugin IT">
+<site xmlns="http://maven.apache.org/SITE/2.0.0"
+      xmlns:xsi="http://www.w3.org/2001/XMLSchema-instance"
+      xsi:schemaLocation="http://maven.apache.org/SITE/2.0.0 https://maven.apache.org/xsd/site-2.0.0.xsd">
     <body>
         <breadcrumbs>
             <item name="Doxia" href="https://maven.apache.org/doxia/index.html"/>
@@ -14,4 +16,4 @@
         <artifactId>maven-fluido-skin</artifactId>
         <version>2.0.0-M9</version>
     </skin>
-</project>
+</site>

--- a/asciidoctor-parser-doxia-module/src/it/maven-site-plugin/validate.groovy
+++ b/asciidoctor-parser-doxia-module/src/it/maven-site-plugin/validate.groovy
@@ -153,13 +153,13 @@ class HtmlAsserter {
     void containsSectionTitle(String value, int level) {
         def found = -1
 
-        def id = value.replaceAll(" ", "_")
+        def id = value.toLowerCase().replaceAll(" ", "_")
         if (level == 2) {
-            found = find("<h2><a name=\"$id\"></a>$value</h2>")
+            found = find("<h2><a id=\"$id\"></a>$value</h2>")
         } else if (level == 3) {
-            found = find("<h3><a name=\"$id\"></a>$value</h3>")
+            found = find("<h3><a id=\"$id\"></a>$value</h3>")
         } else if (level == 4) {
-            found = find("<h4><a name=\"$id\"></a>$value</h4>")
+            found = find("<h4><a id=\"$id\"></a>$value</h4>")
         }
         assertFound("Section Title (level:$level)", value, found)
     }
@@ -185,7 +185,7 @@ class HtmlAsserter {
     }
 
     void containsOrderedList(String... values) {
-        def found = find("<ol style=\"list-style-type: decimal\"><li>${values.join('</li><li>')}</li></ol>")
+        def found = find("<ol style=\"list-style-type: decimal;\"><li>${values.join('</li><li>')}</li></ol>")
         assertFound("Ordered list", values.join(','), found)
     }
 

--- a/asciidoctor-parser-doxia-module/src/it/maven-site-plugin/validate.groovy
+++ b/asciidoctor-parser-doxia-module/src/it/maven-site-plugin/validate.groovy
@@ -136,7 +136,7 @@ class HtmlAsserter {
     }
 
     void containsBreadcrumbs(String value) {
-        def found = find("<li class=\"active \">${value}</li>")
+        def found = find("<li class=\"active\">${value}</li>")
         assertFound("Breadcrumb", value, found)
     }
 

--- a/asciidoctor-parser-doxia-module/src/main/java/org/asciidoctor/maven/site/parser/AsciidoctorAstDoxiaParser.java
+++ b/asciidoctor-parser-doxia-module/src/main/java/org/asciidoctor/maven/site/parser/AsciidoctorAstDoxiaParser.java
@@ -23,14 +23,15 @@ import org.asciidoctor.maven.log.LogHandler;
 import org.asciidoctor.maven.log.LogRecordFormatter;
 import org.asciidoctor.maven.log.LogRecordsProcessors;
 import org.asciidoctor.maven.log.MemoryLogHandler;
-import org.asciidoctor.maven.site.HeaderMetadata;
 import org.asciidoctor.maven.site.HeadParser;
+import org.asciidoctor.maven.site.HeaderMetadata;
 import org.asciidoctor.maven.site.SiteConversionConfiguration;
 import org.asciidoctor.maven.site.SiteConversionConfigurationParser;
 import org.asciidoctor.maven.site.SiteLogHandlerDeserializer;
 import org.codehaus.plexus.component.annotations.Component;
 import org.codehaus.plexus.util.IOUtil;
 import org.codehaus.plexus.util.xml.Xpp3Dom;
+import org.slf4j.LoggerFactory;
 
 import static org.asciidoctor.maven.commons.StringUtils.isNotBlank;
 
@@ -44,6 +45,8 @@ import static org.asciidoctor.maven.commons.StringUtils.isNotBlank;
  */
 @Component(role = Parser.class, hint = AsciidoctorAstDoxiaParser.ROLE_HINT)
 public class AsciidoctorAstDoxiaParser extends AbstractTextParser {
+
+    private final org.slf4j.Logger logger = LoggerFactory.getLogger(AsciidoctorAstDoxiaParser.class);
 
     @Inject
     protected Provider<MavenProject> mavenProjectProvider;
@@ -64,7 +67,7 @@ public class AsciidoctorAstDoxiaParser extends AbstractTextParser {
                 source = "";
             }
         } catch (IOException ex) {
-            getLog().error("Could not read AsciiDoc source: " + ex.getLocalizedMessage());
+            logger.error("Could not read AsciiDoc source: {}", ex.getLocalizedMessage());
             return;
         }
 
@@ -88,13 +91,13 @@ public class AsciidoctorAstDoxiaParser extends AbstractTextParser {
         final MemoryLogHandler memoryLogHandler = asciidoctorLoggingSetup(asciidoctor, logHandler, siteDirectory);
 
         if (isNotBlank(reference))
-            getLog().debug("Document loaded: " + reference);
+            logger.debug("Document loaded: {}", reference);
 
         Document document = asciidoctor.load(source, conversionConfig.getOptions());
 
         try {
             // process log messages according to mojo configuration
-            new LogRecordsProcessors(logHandler, siteDirectory, errorMessage -> getLog().error(errorMessage))
+            new LogRecordsProcessors(logHandler, siteDirectory, errorMessage -> logger.error(errorMessage))
                     .processLogRecords(memoryLogHandler);
 
         } catch (Exception exception) {
@@ -116,7 +119,7 @@ public class AsciidoctorAstDoxiaParser extends AbstractTextParser {
     private MemoryLogHandler asciidoctorLoggingSetup(Asciidoctor asciidoctor, LogHandler logHandler, File siteDirectory) {
 
         final MemoryLogHandler memoryLogHandler = new MemoryLogHandler(logHandler.getOutputToConsole(),
-                logRecord -> getLog().info(LogRecordFormatter.format(logRecord, siteDirectory)));
+            logRecord -> logger.info(LogRecordFormatter.format(logRecord, siteDirectory)));
         asciidoctor.registerLogHandler(memoryLogHandler);
         // disable default console output of AsciidoctorJ
         Logger.getLogger("asciidoctor").setUseParentHandlers(false);
@@ -161,7 +164,7 @@ public class AsciidoctorAstDoxiaParser extends AbstractTextParser {
             try {
                 asciidoctor.requireLibrary(require);
             } catch (Exception ex) {
-                getLog().error(ex.getLocalizedMessage());
+                logger.error(ex.getLocalizedMessage());
             }
         }
     }

--- a/asciidoctor-parser-doxia-module/src/main/java/org/asciidoctor/maven/site/parser/AsciidoctorAstDoxiaParser.java
+++ b/asciidoctor-parser-doxia-module/src/main/java/org/asciidoctor/maven/site/parser/AsciidoctorAstDoxiaParser.java
@@ -1,6 +1,7 @@
 package org.asciidoctor.maven.site.parser;
 
 import javax.inject.Inject;
+import javax.inject.Named;
 import javax.inject.Provider;
 import java.io.File;
 import java.io.IOException;
@@ -9,7 +10,6 @@ import java.util.logging.Logger;
 
 import org.apache.maven.doxia.parser.AbstractTextParser;
 import org.apache.maven.doxia.parser.ParseException;
-import org.apache.maven.doxia.parser.Parser;
 import org.apache.maven.doxia.sink.Sink;
 import org.apache.maven.project.MavenProject;
 import org.asciidoctor.Asciidoctor;
@@ -28,7 +28,6 @@ import org.asciidoctor.maven.site.HeaderMetadata;
 import org.asciidoctor.maven.site.SiteConversionConfiguration;
 import org.asciidoctor.maven.site.SiteConversionConfigurationParser;
 import org.asciidoctor.maven.site.SiteLogHandlerDeserializer;
-import org.codehaus.plexus.component.annotations.Component;
 import org.codehaus.plexus.util.IOUtil;
 import org.codehaus.plexus.util.xml.Xpp3Dom;
 import org.slf4j.LoggerFactory;
@@ -43,7 +42,7 @@ import static org.asciidoctor.maven.commons.StringUtils.isNotBlank;
  * @author abelsromero
  * @since 3.0.0
  */
-@Component(role = Parser.class, hint = AsciidoctorAstDoxiaParser.ROLE_HINT)
+@Named(AsciidoctorAstDoxiaParser.ROLE_HINT)
 public class AsciidoctorAstDoxiaParser extends AbstractTextParser {
 
     private final org.slf4j.Logger logger = LoggerFactory.getLogger(AsciidoctorAstDoxiaParser.class);

--- a/asciidoctor-parser-doxia-module/src/main/java/org/asciidoctor/maven/site/parser/AsciidoctorAstDoxiaParser.java
+++ b/asciidoctor-parser-doxia-module/src/main/java/org/asciidoctor/maven/site/parser/AsciidoctorAstDoxiaParser.java
@@ -1,7 +1,6 @@
 package org.asciidoctor.maven.site.parser;
 
 import javax.inject.Inject;
-import javax.inject.Named;
 import javax.inject.Provider;
 import java.io.File;
 import java.io.IOException;
@@ -10,6 +9,7 @@ import java.util.logging.Logger;
 
 import org.apache.maven.doxia.parser.AbstractTextParser;
 import org.apache.maven.doxia.parser.ParseException;
+import org.apache.maven.doxia.parser.Parser;
 import org.apache.maven.doxia.sink.Sink;
 import org.apache.maven.project.MavenProject;
 import org.asciidoctor.Asciidoctor;
@@ -28,6 +28,7 @@ import org.asciidoctor.maven.site.HeaderMetadata;
 import org.asciidoctor.maven.site.SiteConversionConfiguration;
 import org.asciidoctor.maven.site.SiteConversionConfigurationParser;
 import org.asciidoctor.maven.site.SiteLogHandlerDeserializer;
+import org.codehaus.plexus.component.annotations.Component;
 import org.codehaus.plexus.util.IOUtil;
 import org.codehaus.plexus.util.xml.Xpp3Dom;
 import org.slf4j.LoggerFactory;
@@ -42,7 +43,7 @@ import static org.asciidoctor.maven.commons.StringUtils.isNotBlank;
  * @author abelsromero
  * @since 3.0.0
  */
-@Named(AsciidoctorAstDoxiaParser.ROLE_HINT)
+@Component(role = Parser.class, hint = AsciidoctorAstDoxiaParser.ROLE_HINT)
 public class AsciidoctorAstDoxiaParser extends AbstractTextParser {
 
     private final org.slf4j.Logger logger = LoggerFactory.getLogger(AsciidoctorAstDoxiaParser.class);

--- a/asciidoctor-parser-doxia-module/src/main/java/org/asciidoctor/maven/site/parser/AsciidoctorAstDoxiaParserModule.java
+++ b/asciidoctor-parser-doxia-module/src/main/java/org/asciidoctor/maven/site/parser/AsciidoctorAstDoxiaParserModule.java
@@ -1,8 +1,8 @@
 package org.asciidoctor.maven.site.parser;
 
-import javax.inject.Named;
-
 import org.apache.maven.doxia.parser.module.AbstractParserModule;
+import org.apache.maven.doxia.parser.module.ParserModule;
+import org.codehaus.plexus.component.annotations.Component;
 
 /**
  * This class is the entry point for integration with the Maven Site Plugin
@@ -13,7 +13,7 @@ import org.apache.maven.doxia.parser.module.AbstractParserModule;
  * @author abelsromero
  * @since 3.0.0
  */
-@Named(AsciidoctorAstDoxiaParser.ROLE_HINT)
+@Component(role = ParserModule.class, hint = AsciidoctorAstDoxiaParser.ROLE_HINT)
 public class AsciidoctorAstDoxiaParserModule extends AbstractParserModule {
 
     /**

--- a/asciidoctor-parser-doxia-module/src/main/java/org/asciidoctor/maven/site/parser/AsciidoctorAstDoxiaParserModule.java
+++ b/asciidoctor-parser-doxia-module/src/main/java/org/asciidoctor/maven/site/parser/AsciidoctorAstDoxiaParserModule.java
@@ -1,8 +1,8 @@
 package org.asciidoctor.maven.site.parser;
 
+import javax.inject.Named;
+
 import org.apache.maven.doxia.parser.module.AbstractParserModule;
-import org.apache.maven.doxia.parser.module.ParserModule;
-import org.codehaus.plexus.component.annotations.Component;
 
 /**
  * This class is the entry point for integration with the Maven Site Plugin
@@ -13,7 +13,7 @@ import org.codehaus.plexus.component.annotations.Component;
  * @author abelsromero
  * @since 3.0.0
  */
-@Component(role = ParserModule.class, hint = AsciidoctorAstDoxiaParser.ROLE_HINT)
+@Named(AsciidoctorAstDoxiaParser.ROLE_HINT)
 public class AsciidoctorAstDoxiaParserModule extends AbstractParserModule {
 
     /**

--- a/asciidoctor-parser-doxia-module/src/main/java/org/asciidoctor/maven/site/parser/processors/ImageNodeProcessor.java
+++ b/asciidoctor-parser-doxia-module/src/main/java/org/asciidoctor/maven/site/parser/processors/ImageNodeProcessor.java
@@ -40,7 +40,9 @@ public class ImageNodeProcessor extends AbstractSinkNodeProcessor implements Nod
         final String imagesdir = (String) node.getAttribute("imagesdir");
         String imagePath = isBlank(imagesdir) ? target : formatPath(imagesdir, target);
         final SinkEventAttributeSet attributes = new SinkEventAttributeSet();
-        attributes.addAttribute(Attribute.ALT, alt);
+        if (!isBlank(alt))
+            attributes.addAttribute(Attribute.ALT, alt);
+
         getSink().figureGraphics(imagePath, attributes);
     }
 

--- a/asciidoctor-parser-doxia-module/src/test/java/org/asciidoctor/maven/site/parser/AsciidoctorAstDoxiaParserTest.java
+++ b/asciidoctor-parser-doxia-module/src/test/java/org/asciidoctor/maven/site/parser/AsciidoctorAstDoxiaParserTest.java
@@ -44,18 +44,18 @@ class AsciidoctorAstDoxiaParserTest {
         String result = parse(parser, srcAsciidoc);
 
         assertThat(result)
-                .isEqualTo("<h1>Document Title</h1>" +
-                        "<p>Preamble paragraph.</p>" +
-                        "<h2><a name=\"Section_A\"></a>Section A</h2>" +
+                .isEqualTo("<h1>Document Title</h1><p>Preamble paragraph.</p>" +
+                        "<h2><a id=\"id_section_a\"></a>Section A</h2>" +
                         "<p><strong>Section A</strong> paragraph.</p>" +
-                        "<h3><a name=\"Section_A_Subsection\"></a>Section A Subsection</h3>" +
+                        "<h3><a id=\"id_section_a_subsection\"></a>Section A Subsection</h3>" +
                         "<p><strong>Section A</strong> 'subsection' paragraph.</p>" +
-                        "<h2><a name=\"Section_B\"></a>Section B</h2>" +
+                        "<h2><a id=\"id_section_b\"></a>Section B</h2>" +
                         "<p><strong>Section B</strong> paragraph.</p>" +
                         "<ul>" +
                         "<li>Item 1</li>" +
                         "<li>Item 2</li>" +
-                        "<li>Item 3</li></ul><div class=\"source\"><pre class=\"prettyprint\"><code>require 'asciidoctor'</code></pre></div>");
+                        "<li>Item 3</li></ul>" +
+                        "<div class=\"source\"><pre class=\"prettyprint\"><code>require 'asciidoctor'</code></pre></div>");
     }
 
     @Test

--- a/asciidoctor-parser-doxia-module/src/test/java/org/asciidoctor/maven/site/parser/NodeSinkerTest.java
+++ b/asciidoctor-parser-doxia-module/src/test/java/org/asciidoctor/maven/site/parser/NodeSinkerTest.java
@@ -1,5 +1,8 @@
 package org.asciidoctor.maven.site.parser;
 
+import java.io.StringWriter;
+import java.util.Arrays;
+
 import org.apache.maven.doxia.sink.Sink;
 import org.asciidoctor.ast.Document;
 import org.asciidoctor.ast.ListItem;
@@ -11,9 +14,6 @@ import org.asciidoctor.jruby.ast.impl.TableImpl;
 import org.junit.jupiter.api.BeforeEach;
 import org.junit.jupiter.api.Test;
 import org.mockito.Mockito;
-
-import java.io.StringWriter;
-import java.util.Arrays;
 
 import static org.asciidoctor.maven.site.parser.processors.test.ReflectionUtils.extractField;
 import static org.asciidoctor.maven.site.parser.processors.test.TestNodeProcessorFactory.createSink;
@@ -122,6 +122,7 @@ class NodeSinkerTest {
     @Test
     void should_process_image_node() {
         StructuralNode mockNode = mockNode("image", BlockImpl.class);
+        Mockito.when(mockNode.getAttribute(Mockito.eq("target"))).thenReturn("image.png");
 
         nodesSinker.processNode(mockNode);
 

--- a/asciidoctor-parser-doxia-module/src/test/java/org/asciidoctor/maven/site/parser/NodeSinkerTest.java
+++ b/asciidoctor-parser-doxia-module/src/test/java/org/asciidoctor/maven/site/parser/NodeSinkerTest.java
@@ -2,6 +2,7 @@ package org.asciidoctor.maven.site.parser;
 
 import java.io.StringWriter;
 import java.util.Arrays;
+import java.util.List;
 
 import org.apache.maven.doxia.sink.Sink;
 import org.asciidoctor.ast.Document;
@@ -72,7 +73,7 @@ class NodeSinkerTest {
     void should_process_preamble_node() {
         StructuralNode mockNode = mockNode("preamble");
         StructuralNode literalBlock = mockNode("literal", BlockImpl.class);
-        Mockito.when(mockNode.getBlocks()).thenReturn(Arrays.asList(literalBlock));
+        Mockito.when(mockNode.getBlocks()).thenReturn(List.of(literalBlock));
 
         nodesSinker.processNode(mockNode);
 
@@ -143,7 +144,7 @@ class NodeSinkerTest {
         StructuralNode mockNode = mockNode("ulist", BlockImpl.class);
         ListItem mockListItem = mockNode("list_item", ListItem.class);
         Mockito.when(mockListItem.getMarker()).thenReturn("*");
-        Mockito.when(mockNode.getBlocks()).thenReturn(Arrays.asList(mockListItem));
+        Mockito.when(mockNode.getBlocks()).thenReturn(List.of(mockListItem));
 
         nodesSinker.processNode(mockNode);
 
@@ -155,7 +156,7 @@ class NodeSinkerTest {
         StructuralNode mockNode = mockNode("olist", BlockImpl.class);
         ListItem mockListItem = mockNode("list_item", ListItem.class);
         Mockito.when(mockListItem.getMarker()).thenReturn(".");
-        Mockito.when(mockNode.getBlocks()).thenReturn(Arrays.asList(mockListItem));
+        Mockito.when(mockNode.getBlocks()).thenReturn(List.of(mockListItem));
 
         nodesSinker.processNode(mockNode);
 

--- a/asciidoctor-parser-doxia-module/src/test/java/org/asciidoctor/maven/site/parser/processors/OrderedListNodeProcessorTest.java
+++ b/asciidoctor-parser-doxia-module/src/test/java/org/asciidoctor/maven/site/parser/processors/OrderedListNodeProcessorTest.java
@@ -39,7 +39,7 @@ class OrderedListNodeProcessorTest {
         String html = process(content);
 
         assertThat(html)
-                .isEqualTo("<ol style=\"list-style-type: decimal\">" +
+                .isEqualTo("<ol style=\"list-style-type: decimal;\">" +
                         "<li>ordered item 1</li>" +
                         "<li>ordered item 2</li></ol>");
     }
@@ -51,15 +51,15 @@ class OrderedListNodeProcessorTest {
         String html = process(content);
 
         assertThat(html)
-                .isEqualTo("<ol style=\"list-style-type: decimal\">" +
+                .isEqualTo("<ol style=\"list-style-type: decimal;\">" +
                         "<li>ordered item 1" +
-                        "<ol style=\"list-style-type: decimal\">" +
+                        "<ol style=\"list-style-type: decimal;\">" +
                         "<li>ordered item 1 1</li></ol></li>" +
                         "<li>ordered item 1 2</li>" +
                         "<li>ordered item 2" +
-                        "<ol style=\"list-style-type: decimal\">" +
+                        "<ol style=\"list-style-type: decimal;\">" +
                         "<li>ordered item 2 1" +
-                        "<ol style=\"list-style-type: decimal\">" +
+                        "<ol style=\"list-style-type: decimal;\">" +
                         "<li>ordered item 2 1 1</li></ol></li></ol></li></ol>");
     }
 

--- a/asciidoctor-parser-doxia-module/src/test/java/org/asciidoctor/maven/site/parser/processors/SectionNodeProcessorTest.java
+++ b/asciidoctor-parser-doxia-module/src/test/java/org/asciidoctor/maven/site/parser/processors/SectionNodeProcessorTest.java
@@ -38,7 +38,7 @@ class SectionNodeProcessorTest {
         String html = process(content, 1);
 
         assertThat(html)
-                .isEqualTo("<h2><a name=\"First_section_title\"></a>First section title</h2>");
+                .isEqualTo("<h2><a id=\"_first_section_title\"></a>First section title</h2>");
     }
 
     @Test
@@ -48,7 +48,7 @@ class SectionNodeProcessorTest {
         String html = process(content, 2);
 
         assertThat(html)
-                .isEqualTo("<h3><a name=\"Second_section_title\"></a>Second section title</h3>");
+                .isEqualTo("<h3><a id=\"_second_section_title\"></a>Second section title</h3>");
     }
 
     @Test
@@ -58,7 +58,7 @@ class SectionNodeProcessorTest {
         String html = process(content, 3);
 
         assertThat(html)
-                .isEqualTo("<h4><a name=\"Third_section_title\"></a>Third section title</h4>");
+                .isEqualTo("<h4><a id=\"_third_section_title\"></a>Third section title</h4>");
     }
 
     @Test
@@ -68,7 +68,7 @@ class SectionNodeProcessorTest {
         String html = process(content, 4);
 
         assertThat(html)
-                .isEqualTo("<h5><a name=\"Fourth_section_title\"></a>Fourth section title</h5>");
+                .isEqualTo("<h5><a id=\"_fourth_section_title\"></a>Fourth section title</h5>");
     }
 
     @Test
@@ -78,7 +78,7 @@ class SectionNodeProcessorTest {
         String html = process(content, 5);
 
         assertThat(html)
-                .isEqualTo("<h6><a name=\"Fifth_section_title\"></a>Fifth section title</h6>");
+                .isEqualTo("<h5><a id=\"_fifth_section_title\"></a>Fifth section title</h5>");
     }
 
     @Test
@@ -90,17 +90,17 @@ class SectionNodeProcessorTest {
 
         // With numbering
         assertThat(process(content, 1, attributes))
-                .isEqualTo("<h2><a name=\"a1._First_section_title\"></a>1. First section title</h2>");
+                .isEqualTo("<h2><a id=\"_first_section_title\"></a>1. First section title</h2>");
         assertThat(process(content, 2, attributes))
-                .isEqualTo("<h3><a name=\"a1.1._Second_section_title\"></a>1.1. Second section title</h3>");
+                .isEqualTo("<h3><a id=\"_second_section_title\"></a>1.1. Second section title</h3>");
         assertThat(process(content, 3, attributes))
-                .isEqualTo("<h4><a name=\"a1.1.1._Third_section_title\"></a>1.1.1. Third section title</h4>");
+                .isEqualTo("<h4><a id=\"_third_section_title\"></a>1.1.1. Third section title</h4>");
 
         // Without numbering by default
         assertThat(process(content, 4, attributes))
-                .isEqualTo("<h5><a name=\"Fourth_section_title\"></a>Fourth section title</h5>");
+                .isEqualTo("<h5><a id=\"_fourth_section_title\"></a>Fourth section title</h5>");
         assertThat(process(content, 5, attributes))
-                .isEqualTo("<h6><a name=\"Fifth_section_title\"></a>Fifth section title</h6>");
+                .isEqualTo("<h5><a id=\"_fifth_section_title\"></a>Fifth section title</h5>");
     }
 
     @Test
@@ -113,15 +113,15 @@ class SectionNodeProcessorTest {
 
         // With numbering
         assertThat(process(content, 1, attributes))
-                .isEqualTo("<h2><a name=\"a1._First_section_title\"></a>1. First section title</h2>");
+                .isEqualTo("<h2><a id=\"_first_section_title\"></a>1. First section title</h2>");
         assertThat(process(content, 2, attributes))
-                .isEqualTo("<h3><a name=\"a1.1._Second_section_title\"></a>1.1. Second section title</h3>");
+                .isEqualTo("<h3><a id=\"_second_section_title\"></a>1.1. Second section title</h3>");
         assertThat(process(content, 3, attributes))
-                .isEqualTo("<h4><a name=\"a1.1.1._Third_section_title\"></a>1.1.1. Third section title</h4>");
+                .isEqualTo("<h4><a id=\"_third_section_title\"></a>1.1.1. Third section title</h4>");
         assertThat(process(content, 4, attributes))
-                .isEqualTo("<h5><a name=\"a1.1.1.1._Fourth_section_title\"></a>1.1.1.1. Fourth section title</h5>");
+                .isEqualTo("<h5><a id=\"_fourth_section_title\"></a>1.1.1.1. Fourth section title</h5>");
         assertThat(process(content, 5, attributes))
-                .isEqualTo("<h6><a name=\"a1.1.1.1.1._Fifth_section_title\"></a>1.1.1.1.1. Fifth section title</h6>");
+                .isEqualTo("<h5><a id=\"_fifth_section_title\"></a>1.1.1.1.1. Fifth section title</h5>");
     }
 
     private String documentWithSections() {

--- a/asciidoctor-parser-doxia-module/src/test/java/org/asciidoctor/maven/site/parser/processors/TableNodeProcessorTest.java
+++ b/asciidoctor-parser-doxia-module/src/test/java/org/asciidoctor/maven/site/parser/processors/TableNodeProcessorTest.java
@@ -45,15 +45,15 @@ class TableNodeProcessorTest {
 
         // Header for now is just first row with class=a
         assertThat(html)
-                .isEqualTo("<table border=\"0\" class=\"bodyTable\">" +
+                .isEqualTo("<table class=\"bodyTable\">" +
                         "<tr class=\"a\">" +
                         "<th>Name</th>" +
                         "<th>Language</th></tr>" +
                         "<tr class=\"b\">" +
-                        "<td align=\"left\">JRuby</td>" +
+                        "<td style=\"text-align: left;\">JRuby</td>" +
                         "<td>Java</td></tr>" +
                         "<tr class=\"a\">" +
-                        "<td align=\"left\">Rubinius</td>" +
+                        "<td style=\"text-align: left;\">Rubinius</td>" +
                         "<td>Ruby</td></tr></table>");
     }
 
@@ -64,12 +64,12 @@ class TableNodeProcessorTest {
         String html = process(content);
 
         assertThat(html)
-                .isEqualTo(clean("<table border=\"0\" class=\"bodyTable\">" +
+                .isEqualTo(clean("<table class=\"bodyTable\">" +
                         "<tr class=\"a\">" +
-                        "<td align=\"left\">JRuby</td>" +
+                        "<td style=\"text-align: left;\">JRuby</td>" +
                         "<td>Java</td></tr>" +
                         "<tr class=\"b\">" +
-                        "<td align=\"left\">Rubinius</td>" +
+                        "<td style=\"text-align: left;\">Rubinius</td>" +
                         "<td>Ruby</td></tr></table>"));
     }
 
@@ -90,13 +90,12 @@ class TableNodeProcessorTest {
         String html = process(content);
 
         assertThat(html)
-                .startsWith("<table border=\"0\" class=\"bodyTable\"><caption>Table 1. Table caption&#8230;&#8203;or title</caption>")
-                .isEqualTo("<table border=\"0\" class=\"bodyTable\"><caption>Table 1. Table caption&#8230;&#8203;or title</caption>" +
+                .isEqualTo("<table class=\"bodyTable\"><caption>Table 1. Table caption&#8230;&#8203;or title</caption>" +
                         "<tr class=\"a\">" +
-                        "<td align=\"left\">JRuby</td>" +
+                        "<td style=\"text-align: left;\">JRuby</td>" +
                         "<td>Java</td></tr>" +
                         "<tr class=\"b\">" +
-                        "<td align=\"left\">Rubinius</td>" +
+                        "<td style=\"text-align: left;\">Rubinius</td>" +
                         "<td>Ruby</td></tr></table>");
     }
 
@@ -123,29 +122,29 @@ class TableNodeProcessorTest {
     }
 
     private static String expectedNoLabelBeginning() {
-        return "<table border=\"0\" class=\"bodyTable\"><caption>Table caption&#8230;&#8203;or title</caption>";
+        return "<table class=\"bodyTable\"><caption>Table caption&#8230;&#8203;or title</caption>";
     }
 
     private static String expectedTableWithoutLabel() {
-        return "<table border=\"0\" class=\"bodyTable\"><caption>Table caption&#8230;&#8203;or title</caption>" +
+        return "<table class=\"bodyTable\"><caption>Table caption&#8230;&#8203;or title</caption>" +
                 "<tr class=\"a\">" +
-                "<td align=\"left\">JRuby</td>" +
+                "<td style=\"text-align: left;\">JRuby</td>" +
                 "<td>Java</td></tr>" +
                 "<tr class=\"b\">" +
-                "<td align=\"left\">Rubinius</td>" +
+                "<td style=\"text-align: left;\">Rubinius</td>" +
                 "<td>Ruby</td></tr></table>";
     }
 
     private static String expectedTableWithoutCaption() {
-        return "<table border=\"0\" class=\"bodyTable\">" +
+        return "<table class=\"bodyTable\">" +
                 "<tr class=\"a\">" +
-                "<td align=\"left\">JRuby</td>" +
+                "<td style=\"text-align: left;\">JRuby</td>" +
                 "<td>Java</td></tr>" +
                 "<tr class=\"b\">" +
-                "<td align=\"left\">Rubinius</td>" +
+                "<td style=\"text-align: left;\">Rubinius</td>" +
                 "<td>Ruby</td></tr>" +
                 "<tr class=\"a\">" +
-                "<td align=\"left\"><strong>Opal</strong></td>" +
+                "<td style=\"text-align: left;\"><strong>Opal</strong></td>" +
                 "<td><em>JavaScript</em></td></tr></table>";
     }
 

--- a/asciidoctor-parser-doxia-module/src/test/java/org/asciidoctor/maven/site/parser/processors/test/Html.java
+++ b/asciidoctor-parser-doxia-module/src/test/java/org/asciidoctor/maven/site/parser/processors/test/Html.java
@@ -2,7 +2,7 @@ package org.asciidoctor.maven.site.parser.processors.test;
 
 public class Html {
 
-    public static final String LIST_STYLE_TYPE_DECIMAL = "list-style-type: decimal";
+    public static final String LIST_STYLE_TYPE_DECIMAL = "list-style-type: decimal;";
 
     public static String strong(String text) {
         return htmlElement("strong", text);

--- a/asciidoctor-parser-doxia-module/src/test/java/org/asciidoctor/maven/site/parser/processors/test/TestNodeProcessorFactory.java
+++ b/asciidoctor-parser-doxia-module/src/test/java/org/asciidoctor/maven/site/parser/processors/test/TestNodeProcessorFactory.java
@@ -5,7 +5,7 @@ import java.lang.reflect.Constructor;
 import lombok.SneakyThrows;
 import org.apache.commons.lang3.tuple.Pair;
 import org.apache.maven.doxia.sink.Sink;
-import org.apache.maven.doxia.siterenderer.RenderingContext;
+import org.apache.maven.doxia.siterenderer.DocumentRenderingContext;
 import org.apache.maven.doxia.siterenderer.sink.SiteRendererSink;
 import org.asciidoctor.maven.site.parser.NodeProcessor;
 import org.mockito.Mockito;
@@ -20,6 +20,6 @@ public class TestNodeProcessorFactory {
     }
 
     public static Sink createSink() {
-        return new SiteRendererSink(Mockito.mock(RenderingContext.class));
+        return new SiteRendererSink(Mockito.mock(DocumentRenderingContext.class));
     }
 }

--- a/docs/modules/site-integration/pages/compatibility-matrix.adoc
+++ b/docs/modules/site-integration/pages/compatibility-matrix.adoc
@@ -11,7 +11,7 @@ Versions not listed below are not supported, please consider upgrading.
 |Asciidoctor Doxia Module | Maven Site Plugin | Supported
 
 |v3.0.x
-|v3.12.x
+|v3.1x.x ~ v3.12.x
 |Yes
 
 |v3.1.x

--- a/docs/modules/site-integration/pages/compatibility-matrix.adoc
+++ b/docs/modules/site-integration/pages/compatibility-matrix.adoc
@@ -10,8 +10,12 @@ Versions not listed below are not supported, please consider upgrading.
 |===
 |Asciidoctor Doxia Module | Maven Site Plugin | Supported
 
-|v3.x.x
-|v3.1x.x
+|v3.0.x
+|v3.12.x
+|Yes
+
+|v3.1.x
+|v3.20.x
 |Yes
 
 |===

--- a/pom.xml
+++ b/pom.xml
@@ -71,7 +71,8 @@
         <project.build.sourceEncoding>UTF-8</project.build.sourceEncoding>
         <project.java.version>11</project.java.version>
         <maven.version>3.9.9</maven.version>
-        <doxia.version>1.12.0</doxia.version>
+        <doxia.version>2.0.0-M12</doxia.version>
+        <doxia.sitetools.version>2.0.0-M19</doxia.sitetools.version>
         <plexus-component-metadata.version>2.2.0</plexus-component-metadata.version>
         <asciidoctorj.version>3.0.0</asciidoctorj.version>
         <jruby.version>9.4.6.0</jruby.version>


### PR DESCRIPTION
* Bump Doxia and Doxia-sitetools to the same versions as maven-site-plugin (v2.0.x-MX)
* Apply required code changes to code and test
* Update site.xml in ITs to new novel (https://maven.apache.org/xsd/site-2.0.0.xsd)

TODO:
- [x] Fix tests that required updated assertions due to changes in generated HTML
- [x] Rename milestone to 3.1.0.

**What kind of change does this PR introduce?** (check at least one)
<!-- Update "[ ]" to "[x]" to check a box -->

- [ ] Bugfix
- [x] Feature
- [ ] Documentation
- [ ] Refactor
- [ ] Build improvement
- [ ] Other (please describe)


**What is the goal of this pull request?**

Add compatibility with maven-site-plugin v3.20.0.
This requires code, tests and documentation changes due to breaking changes introduced by Doxia.

**Are there any alternative ways to implement this?**

We can try to get the code compatible with previous versions of maven-site-plugin.
But that would required doubling not only the code, but also tests due to changes in generated HTML.
For the sake of simplicity, if someone needs to use older maven-site-plugin, I'd rather do 3.0.x patch releases and keep 3.1.0 for maven-site 3.20.0

**Are there any implications of this pull request? Anything a user must know?**

Users wanting to use newer v3.1.0 will need to bump maven-site, and vice-versa.

**Is it related to an existing issue?**
<!-- If Yes, please add a line of the form: `Fixes #Issue` --> 
- [x] Yes
- [ ] No

#933 

