### PR TITLE
Support "Captioned titles" in asciidoctor-parser-doxia-module

### DIFF
--- a/CHANGELOG.adoc
+++ b/CHANGELOG.adoc
@@ -17,15 +17,19 @@ Bug Fixes::
 
   * Fix open IMG tags in parser-doxia-module (#930)
   * Fix naming in Asciidoctor Converter Doxia Module pom (#934)
+  * Fix empty table generating <table> element (asciidoctor-parser-doxia-module) (#938)
 
 Improvements::
 
   * Added support for AsciidoctorJ v3.0.0 (#651)
   * Add compatibility with maven-site-plugin v3.20.0 and Doxia v2.0.0 (#933)
-  * Add support for code blocks titles in asciidoctor-parser-doxia-module (#935)
-  * Refactor AST traversal method in asciidoctor-parser-doxia-module (#944)
+  * Add support for code blocks titles (asciidoctor-parser-doxia-module) (#935)
+  * Refactor AST traversal method (asciidoctor-parser-doxia-module) (#944)
   * Empty titles in document or empty literals no longer generate <h1> or <pre> in asciidoctor-parser-doxia-module (#944)
-  * Sections are now wrapped in <div> in asciidoctor-parser-doxia-module (#944)
+  * Sections are now wrapped in <div> in (asciidoctor-parser-doxia-module) (#944)
+  * Add support for inline and Example blocks (asciidoctor-parser-doxia-module) (#938)
+  * Add support for captioned titles in appendixes, tables, listing, figure, and examples (asciidoctor-parser-doxia-module) (#938)
+
 
 Build / Infrastructure::
 

--- a/asciidoctor-parser-doxia-module/src/it/maven-site-plugin/src/site/asciidoc/sample.adoc
+++ b/asciidoctor-parser-doxia-module/src/it/maven-site-plugin/src/site/asciidoc/sample.adoc
@@ -91,3 +91,16 @@ Linux:::
 BSD:::
 . FreeBSD
 . NetBSD
+
+=== Examples
+
+.Optional title (1)
+====
+This is an example of an example block (1).
+====
+
+.Optional title (2)
+[example]
+This is an example of an example block (2).
+*dadsas* https://dasd.com
+

--- a/asciidoctor-parser-doxia-module/src/it/maven-site-plugin/validate.groovy
+++ b/asciidoctor-parser-doxia-module/src/it/maven-site-plugin/validate.groovy
@@ -58,6 +58,10 @@ new HtmlAsserter(htmlContent).with { asserter ->
     asserter.containsUnorderedList("Desktop", "Server")
     asserter.descriptionListTerm("BSD")
     asserter.containsOrderedList("FreeBSD", "NetBSD")
+
+    asserter.containsSectionTitle("Examples", 3)
+    asserter.containsExampleDiv()
+    asserter.containsExampleDiv()
 }
 
 String strong(String text) {
@@ -224,8 +228,15 @@ class HtmlAsserter {
         }
     }
 
+    void containsExampleDiv() {
+        final def key = "<div style=\"background: #fffef7;"
+        def found = find(key)
+        assertFound("Example <div>", key, found)
+    }
+
     void assertTableCaption(String htmlBlock, String caption) {
-        def start = htmlBlock.indexOf("<caption>") + "<caption>".length()
+        def start = htmlBlock.indexOf("<caption") + "<caption".length()
+        start = htmlBlock.indexOf(">", start) + 1
         def end = htmlBlock.indexOf("</caption>")
         if (start < 0 || end < 0)
             fail("Caption not found ($start, $end)")
@@ -239,11 +250,11 @@ class HtmlAsserter {
 
     void assertTableHeaders(String htmlBlock, List<String> headers) {
         def actualHeaders = Arrays.stream(htmlBlock.split("<"))
-                .filter(line -> line.startsWith("th>"))
-                .map(line -> {
-                    return line.substring("th>".length())
-                })
-                .collect(Collectors.toList())
+            .filter(line -> line.startsWith("th>"))
+            .map(line -> {
+                return line.substring("th>".length())
+            })
+            .collect(Collectors.toList())
 
         if (actualHeaders != headers)
             fail("Table headers not valid. Found: $actualHeaders, expected: $headers")
@@ -266,8 +277,8 @@ class HtmlAsserter {
     // Removes linebreaks to validate to avoid OS dependant issues.
     private String clean(String value) {
         return value.replaceAll("\r\n", "")
-                .replaceAll("\n", "")
-                .trim();
+            .replaceAll("\n", "")
+            .trim();
     }
 }
 

--- a/asciidoctor-parser-doxia-module/src/main/java/org/asciidoctor/maven/site/parser/NodeSinker.java
+++ b/asciidoctor-parser-doxia-module/src/main/java/org/asciidoctor/maven/site/parser/NodeSinker.java
@@ -7,6 +7,7 @@ import org.apache.maven.doxia.sink.Sink;
 import org.asciidoctor.ast.StructuralNode;
 import org.asciidoctor.maven.site.parser.processors.DescriptionListNodeProcessor;
 import org.asciidoctor.maven.site.parser.processors.DocumentNodeProcessor;
+import org.asciidoctor.maven.site.parser.processors.ExampleNodeProcessor;
 import org.asciidoctor.maven.site.parser.processors.ImageNodeProcessor;
 import org.asciidoctor.maven.site.parser.processors.ListItemNodeProcessor;
 import org.asciidoctor.maven.site.parser.processors.ListingNodeProcessor;
@@ -35,6 +36,7 @@ public class NodeSinker {
         nodeProcessors = Arrays.asList(
             new DescriptionListNodeProcessor(sink, this),
             new DocumentNodeProcessor(sink, this),
+            new ExampleNodeProcessor(sink, this),
             new ImageNodeProcessor(sink, this),
             new ListItemNodeProcessor(sink, this),
             new ListingNodeProcessor(sink, this),

--- a/asciidoctor-parser-doxia-module/src/main/java/org/asciidoctor/maven/site/parser/processors/DocumentNodeProcessor.java
+++ b/asciidoctor-parser-doxia-module/src/main/java/org/asciidoctor/maven/site/parser/processors/DocumentNodeProcessor.java
@@ -18,7 +18,8 @@ public class DocumentNodeProcessor extends AbstractSinkNodeProcessor implements 
     /**
      * Constructor.
      *
-     * @param sink Doxia {@link Sink}
+     * @param sink       Doxia {@link Sink}
+     * @param nodeSinker
      */
     public DocumentNodeProcessor(Sink sink, NodeSinker nodeSinker) {
         super(sink, nodeSinker);

--- a/asciidoctor-parser-doxia-module/src/main/java/org/asciidoctor/maven/site/parser/processors/ExampleNodeProcessor.java
+++ b/asciidoctor-parser-doxia-module/src/main/java/org/asciidoctor/maven/site/parser/processors/ExampleNodeProcessor.java
@@ -41,7 +41,7 @@ public class ExampleNodeProcessor extends AbstractSinkNodeProcessor implements N
         final Sink sink = getSink();
 
         sink.division();
-        final String title = TitleExtractor.getText(node);
+        final String title = TitleCaptionExtractor.getText(node);
         if (isNotBlank(title)) {
             sink.division(SinkAttributes.of(STYLE, Styles.CAPTION));
             sink.text(title);

--- a/asciidoctor-parser-doxia-module/src/main/java/org/asciidoctor/maven/site/parser/processors/ExampleNodeProcessor.java
+++ b/asciidoctor-parser-doxia-module/src/main/java/org/asciidoctor/maven/site/parser/processors/ExampleNodeProcessor.java
@@ -50,12 +50,22 @@ public class ExampleNodeProcessor extends AbstractSinkNodeProcessor implements N
 
         final List<StructuralNode> blocks = node.getBlocks();
         if (!blocks.isEmpty()) {
-            sink.division(SinkAttributes.of(STYLE, Styles.EXAMPLE));
-            blocks.forEach(this::sink);
-            sink.division_();
+            divWrap(sink, node, () -> blocks.forEach(this::sink));
+        } else {
+            // For :content_model: simple (inline)
+            // https://docs.asciidoctor.org/asciidoc/latest/blocks/example-blocks/#example-style-syntax
+            final String content = (String) node.getContent();
+            if (isNotBlank(content)) {
+                divWrap(sink, node, () -> sink.rawText(content));
+            }
         }
 
         sink.division_();
+    }
 
+    void divWrap(Sink sink, StructuralNode node, Runnable consumer) {
+        sink.division(SinkAttributes.of(STYLE, Styles.EXAMPLE));
+        consumer.run();
+        sink.division_();
     }
 }

--- a/asciidoctor-parser-doxia-module/src/main/java/org/asciidoctor/maven/site/parser/processors/ExampleNodeProcessor.java
+++ b/asciidoctor-parser-doxia-module/src/main/java/org/asciidoctor/maven/site/parser/processors/ExampleNodeProcessor.java
@@ -1,6 +1,5 @@
 package org.asciidoctor.maven.site.parser.processors;
 
-import java.nio.file.FileSystems;
 import java.util.List;
 
 import org.apache.maven.doxia.sink.Sink;
@@ -58,13 +57,5 @@ public class ExampleNodeProcessor extends AbstractSinkNodeProcessor implements N
 
         sink.division_();
 
-    }
-
-    private String formatPath(String imagesdir, String target) {
-        if (imagesdir.endsWith("/") || imagesdir.endsWith("\\")) {
-            return imagesdir + target;
-        } else {
-            return imagesdir + FileSystems.getDefault().getSeparator() + target;
-        }
     }
 }

--- a/asciidoctor-parser-doxia-module/src/main/java/org/asciidoctor/maven/site/parser/processors/ExampleNodeProcessor.java
+++ b/asciidoctor-parser-doxia-module/src/main/java/org/asciidoctor/maven/site/parser/processors/ExampleNodeProcessor.java
@@ -1,31 +1,32 @@
 package org.asciidoctor.maven.site.parser.processors;
 
+import java.nio.file.FileSystems;
+import java.util.List;
+
 import org.apache.maven.doxia.sink.Sink;
 import org.asciidoctor.ast.StructuralNode;
 import org.asciidoctor.maven.site.parser.NodeProcessor;
+import org.asciidoctor.maven.site.parser.NodeSinker;
 
-import javax.swing.text.html.HTML.Attribute;
-import java.nio.file.FileSystems;
-
-import static javax.swing.text.html.HTML.Attribute.ALT;
-import static org.asciidoctor.maven.commons.StringUtils.isBlank;
+import static javax.swing.text.html.HTML.Attribute.STYLE;
 import static org.asciidoctor.maven.commons.StringUtils.isNotBlank;
 
 /**
  * Inline images are processed as paragraphs.
  *
  * @author abelsromero
- * @since 3.0.0
+ * @since 3.1.0
  */
 public class ExampleNodeProcessor extends AbstractSinkNodeProcessor implements NodeProcessor {
 
     /**
      * Constructor.
      *
-     * @param sink Doxia {@link Sink}
+     * @param sink       Doxia {@link Sink}
+     * @param nodeSinker
      */
-    public ExampleNodeProcessor(Sink sink) {
-        super(sink);
+    public ExampleNodeProcessor(Sink sink, NodeSinker nodeSinker) {
+        super(sink, nodeSinker);
     }
 
     @Override
@@ -39,14 +40,24 @@ public class ExampleNodeProcessor extends AbstractSinkNodeProcessor implements N
         //  - For consistency
         //  - Using `figureCaption` requires wrapping the image in <figure> which adds indentation
         final Sink sink = getSink();
-//        sink.division();
+
+        sink.division();
         final String title = TitleExtractor.getText(node);
         if (isNotBlank(title)) {
-            sink.division(SinkAttributes.of(Attribute.STYLE, Styles.CAPTION));
+            sink.division(SinkAttributes.of(STYLE, Styles.CAPTION));
             sink.text(title);
             sink.division_();
         }
-//        sink.division_();
+
+        final List<StructuralNode> blocks = node.getBlocks();
+        if (!blocks.isEmpty()) {
+            sink.division(SinkAttributes.of(STYLE, Styles.EXAMPLE));
+            blocks.forEach(this::sink);
+            sink.division_();
+        }
+
+        sink.division_();
+
     }
 
     private String formatPath(String imagesdir, String target) {

--- a/asciidoctor-parser-doxia-module/src/main/java/org/asciidoctor/maven/site/parser/processors/ExampleNodeProcessor.java
+++ b/asciidoctor-parser-doxia-module/src/main/java/org/asciidoctor/maven/site/parser/processors/ExampleNodeProcessor.java
@@ -1,12 +1,11 @@
 package org.asciidoctor.maven.site.parser.processors;
 
-import javax.swing.text.html.HTML.Attribute;
-import java.nio.file.FileSystems;
-
 import org.apache.maven.doxia.sink.Sink;
 import org.asciidoctor.ast.StructuralNode;
 import org.asciidoctor.maven.site.parser.NodeProcessor;
-import org.asciidoctor.maven.site.parser.NodeSinker;
+
+import javax.swing.text.html.HTML.Attribute;
+import java.nio.file.FileSystems;
 
 import static javax.swing.text.html.HTML.Attribute.ALT;
 import static org.asciidoctor.maven.commons.StringUtils.isBlank;
@@ -18,44 +17,36 @@ import static org.asciidoctor.maven.commons.StringUtils.isNotBlank;
  * @author abelsromero
  * @since 3.0.0
  */
-public class ImageNodeProcessor extends AbstractSinkNodeProcessor implements NodeProcessor {
+public class ExampleNodeProcessor extends AbstractSinkNodeProcessor implements NodeProcessor {
 
     /**
      * Constructor.
      *
-     * @param sink       Doxia {@link Sink}
-     * @param nodeSinker
+     * @param sink Doxia {@link Sink}
      */
-    public ImageNodeProcessor(Sink sink, NodeSinker nodeSinker) {
-        super(sink, nodeSinker);
+    public ExampleNodeProcessor(Sink sink) {
+        super(sink);
     }
 
     @Override
     public boolean applies(StructuralNode node) {
-        return "image".equals(node.getNodeName());
+        return "example".equals(node.getNodeName());
     }
 
     @Override
     public void process(StructuralNode node) {
-        final String target = (String) node.getAttribute("target");
-        final String alt = (String) node.getAttribute("alt");
-
-        final String imagesdir = (String) node.getAttribute("imagesdir");
-        final String imagePath = isBlank(imagesdir) ? target : formatPath(imagesdir, target);
-
         // Add caption as a div (same as Asciidoctor):
         //  - For consistency
         //  - Using `figureCaption` requires wrapping the image in <figure> which adds indentation
         final Sink sink = getSink();
-        sink.division();
-        sink.figureGraphics(imagePath, !isBlank(alt) ? SinkAttributes.of(ALT, alt) : null);
+//        sink.division();
         final String title = TitleExtractor.getText(node);
         if (isNotBlank(title)) {
             sink.division(SinkAttributes.of(Attribute.STYLE, Styles.CAPTION));
             sink.text(title);
             sink.division_();
         }
-        sink.division_();
+//        sink.division_();
     }
 
     private String formatPath(String imagesdir, String target) {

--- a/asciidoctor-parser-doxia-module/src/main/java/org/asciidoctor/maven/site/parser/processors/ImageNodeProcessor.java
+++ b/asciidoctor-parser-doxia-module/src/main/java/org/asciidoctor/maven/site/parser/processors/ImageNodeProcessor.java
@@ -51,8 +51,6 @@ public class ImageNodeProcessor extends AbstractSinkNodeProcessor implements Nod
         sink.figureGraphics(imagePath, !isBlank(alt) ? SinkAttributes.of(ALT, alt) : null);
         final String title = TitleExtractor.getText(node);
         if (isNotBlank(title)) {
-            // TODO use figcaption? or use div for tables for consistency?
-            // I think use div...if it looks better and now that we have the infrastructure set
             sink.division(SinkAttributes.of(STYLE, Styles.CAPTION));
             sink.text(title);
             sink.division_();

--- a/asciidoctor-parser-doxia-module/src/main/java/org/asciidoctor/maven/site/parser/processors/ImageNodeProcessor.java
+++ b/asciidoctor-parser-doxia-module/src/main/java/org/asciidoctor/maven/site/parser/processors/ImageNodeProcessor.java
@@ -51,6 +51,8 @@ public class ImageNodeProcessor extends AbstractSinkNodeProcessor implements Nod
         sink.figureGraphics(imagePath, !isBlank(alt) ? SinkAttributes.of(ALT, alt) : null);
         final String title = TitleExtractor.getText(node);
         if (isNotBlank(title)) {
+            // TODO use figcaption? or use div for tables for consistency?
+            // I think use div...if it looks better and now that we have the infrastructure set
             sink.division(SinkAttributes.of(STYLE, Styles.CAPTION));
             sink.text(title);
             sink.division_();

--- a/asciidoctor-parser-doxia-module/src/main/java/org/asciidoctor/maven/site/parser/processors/ImageNodeProcessor.java
+++ b/asciidoctor-parser-doxia-module/src/main/java/org/asciidoctor/maven/site/parser/processors/ImageNodeProcessor.java
@@ -1,6 +1,5 @@
 package org.asciidoctor.maven.site.parser.processors;
 
-import javax.swing.text.html.HTML.Attribute;
 import java.nio.file.FileSystems;
 
 import org.apache.maven.doxia.sink.Sink;
@@ -9,6 +8,7 @@ import org.asciidoctor.maven.site.parser.NodeProcessor;
 import org.asciidoctor.maven.site.parser.NodeSinker;
 
 import static javax.swing.text.html.HTML.Attribute.ALT;
+import static javax.swing.text.html.HTML.Attribute.STYLE;
 import static org.asciidoctor.maven.commons.StringUtils.isBlank;
 import static org.asciidoctor.maven.commons.StringUtils.isNotBlank;
 
@@ -51,7 +51,7 @@ public class ImageNodeProcessor extends AbstractSinkNodeProcessor implements Nod
         sink.figureGraphics(imagePath, !isBlank(alt) ? SinkAttributes.of(ALT, alt) : null);
         final String title = TitleExtractor.getText(node);
         if (isNotBlank(title)) {
-            sink.division(SinkAttributes.of(Attribute.STYLE, Styles.CAPTION));
+            sink.division(SinkAttributes.of(STYLE, Styles.CAPTION));
             sink.text(title);
             sink.division_();
         }

--- a/asciidoctor-parser-doxia-module/src/main/java/org/asciidoctor/maven/site/parser/processors/ImageNodeProcessor.java
+++ b/asciidoctor-parser-doxia-module/src/main/java/org/asciidoctor/maven/site/parser/processors/ImageNodeProcessor.java
@@ -49,7 +49,7 @@ public class ImageNodeProcessor extends AbstractSinkNodeProcessor implements Nod
         final Sink sink = getSink();
         sink.division();
         sink.figureGraphics(imagePath, !isBlank(alt) ? SinkAttributes.of(ALT, alt) : null);
-        final String title = TitleExtractor.getText(node);
+        final String title = TitleCaptionExtractor.getText(node);
         if (isNotBlank(title)) {
             sink.division(SinkAttributes.of(STYLE, Styles.CAPTION));
             sink.text(title);

--- a/asciidoctor-parser-doxia-module/src/main/java/org/asciidoctor/maven/site/parser/processors/ListingNodeProcessor.java
+++ b/asciidoctor-parser-doxia-module/src/main/java/org/asciidoctor/maven/site/parser/processors/ListingNodeProcessor.java
@@ -2,8 +2,6 @@ package org.asciidoctor.maven.site.parser.processors;
 
 import org.apache.maven.doxia.sink.Sink;
 import org.asciidoctor.ast.StructuralNode;
-import org.asciidoctor.maven.commons.StringUtils;
-import org.asciidoctor.jruby.ast.impl.BlockImpl;
 import org.asciidoctor.maven.site.parser.NodeProcessor;
 import org.asciidoctor.maven.site.parser.NodeSinker;
 
@@ -74,7 +72,7 @@ public class ListingNodeProcessor extends AbstractSinkNodeProcessor implements N
     }
 
     private static void processTitle(StructuralNode node, StringBuilder contentBuilder) {
-        final String title = TitleExtractor.getText(node);
+        final String title = TitleCaptionExtractor.getText(node);
         if (isNotBlank(title)) {
             contentBuilder.append("<div style=\"" + Styles.CAPTION + "\" >" + title + "</div>");
         }

--- a/asciidoctor-parser-doxia-module/src/main/java/org/asciidoctor/maven/site/parser/processors/ListingNodeProcessor.java
+++ b/asciidoctor-parser-doxia-module/src/main/java/org/asciidoctor/maven/site/parser/processors/ListingNodeProcessor.java
@@ -3,6 +3,7 @@ package org.asciidoctor.maven.site.parser.processors;
 import org.apache.maven.doxia.sink.Sink;
 import org.asciidoctor.ast.StructuralNode;
 import org.asciidoctor.maven.commons.StringUtils;
+import org.asciidoctor.jruby.ast.impl.BlockImpl;
 import org.asciidoctor.maven.site.parser.NodeProcessor;
 import org.asciidoctor.maven.site.parser.NodeSinker;
 
@@ -39,20 +40,15 @@ public class ListingNodeProcessor extends AbstractSinkNodeProcessor implements N
     @Override
     public void process(StructuralNode node) {
         final StringBuilder contentBuilder = new StringBuilder();
-        String language = (String) node.getAttribute("language");
-        String style = node.getStyle();
+        final String language = (String) node.getAttribute("language");
+        final String style = node.getStyle();
 
         boolean isSourceBlock = isSourceBlock(language, style);
 
         if (isSourceBlock) {
             // source class triggers prettify auto-detection
             contentBuilder.append("<div class=\"source\">");
-
-            final String title = node.getTitle();
-            if (StringUtils.isNotBlank(title)) {
-                contentBuilder.append("<div style=\"color: #7a2518; margin-bottom: .25em;\" >" + title + "</div>");
-            }
-
+            processTitle(node, contentBuilder);
             contentBuilder.append("<pre class=\"")
                 .append(FLUIDO_SKIN_SOURCE_HIGHLIGHTER);
             if (isLinenumsEnabled(node))
@@ -75,6 +71,13 @@ public class ListingNodeProcessor extends AbstractSinkNodeProcessor implements N
         contentBuilder.append("</pre></div>");
 
         getSink().rawText(contentBuilder.toString());
+    }
+
+    private static void processTitle(StructuralNode node, StringBuilder contentBuilder) {
+        final String title = TitleExtractor.getText(node);
+        if (isNotBlank(title)) {
+            contentBuilder.append("<div style=\"" + Styles.CAPTION + "\" >" + title + "</div>");
+        }
     }
 
     private boolean isLinenumsEnabled(StructuralNode node) {

--- a/asciidoctor-parser-doxia-module/src/main/java/org/asciidoctor/maven/site/parser/processors/SectionNodeProcessor.java
+++ b/asciidoctor-parser-doxia-module/src/main/java/org/asciidoctor/maven/site/parser/processors/SectionNodeProcessor.java
@@ -3,6 +3,8 @@ package org.asciidoctor.maven.site.parser.processors;
 import org.apache.maven.doxia.sink.Sink;
 import org.asciidoctor.ast.Section;
 import org.asciidoctor.ast.StructuralNode;
+import org.asciidoctor.jruby.ast.impl.SectionImpl;
+import org.asciidoctor.maven.commons.StringUtils;
 import org.asciidoctor.maven.site.parser.NodeProcessor;
 import org.asciidoctor.maven.site.parser.NodeSinker;
 import org.slf4j.Logger;
@@ -77,7 +79,14 @@ public class SectionNodeProcessor extends AbstractSinkNodeProcessor implements N
         final Long sectnumlevels = getSectnumlevels(node);
         final int level = node.getLevel();
         if (numbered && level <= sectnumlevels) {
-            return String.format("%s %s", node.getSectnum(), title);
+            // Use 'getString' instead of method to support pre-3.0.0 AsciidoctorJ
+            final String caption = node.getCaption();
+            final String sectnum = ((SectionImpl) node).getString("sectnum");
+            if (StringUtils.isBlank(caption)) {
+                return String.format("%s %s", sectnum, title);
+            } else {
+                return String.format("%s %s", caption, title);
+            }
         }
         return title;
     }

--- a/asciidoctor-parser-doxia-module/src/main/java/org/asciidoctor/maven/site/parser/processors/SectionNodeProcessor.java
+++ b/asciidoctor-parser-doxia-module/src/main/java/org/asciidoctor/maven/site/parser/processors/SectionNodeProcessor.java
@@ -85,7 +85,7 @@ public class SectionNodeProcessor extends AbstractSinkNodeProcessor implements N
             if (StringUtils.isBlank(caption)) {
                 return String.format("%s %s", sectnum, title);
             } else {
-                return String.format("%s %s", caption, title);
+                return String.format("%s %s", caption.trim(), title);
             }
         }
         return title;

--- a/asciidoctor-parser-doxia-module/src/main/java/org/asciidoctor/maven/site/parser/processors/SinkAttributes.java
+++ b/asciidoctor-parser-doxia-module/src/main/java/org/asciidoctor/maven/site/parser/processors/SinkAttributes.java
@@ -1,0 +1,16 @@
+package org.asciidoctor.maven.site.parser.processors;
+
+import javax.swing.text.html.HTML.Attribute;
+
+import org.apache.maven.doxia.sink.SinkEventAttributes;
+import org.apache.maven.doxia.sink.impl.SinkEventAttributeSet;
+
+class SinkAttributes {
+
+    static SinkEventAttributes of(Attribute name, String value) {
+        final var attributes = new SinkEventAttributeSet();
+        attributes.addAttribute(name, value);
+        return attributes;
+    }
+
+}

--- a/asciidoctor-parser-doxia-module/src/main/java/org/asciidoctor/maven/site/parser/processors/Styles.java
+++ b/asciidoctor-parser-doxia-module/src/main/java/org/asciidoctor/maven/site/parser/processors/Styles.java
@@ -1,18 +1,21 @@
 package org.asciidoctor.maven.site.parser.processors;
 
+import java.util.stream.Collectors;
+import java.util.stream.Stream;
+
 class Styles {
 
-    public static final String CAPTION = new StringBuilder()
-        .append("color: #7a2518;")
-        .append("margin-bottom: .25em;")
-        .toString();
+    public static final String CAPTION = Stream.of(
+        "color: #7a2518",
+        "margin-bottom: .25em"
+    ).collect(Collectors.joining("; "));
 
 
-    public static final String EXAMPLE = new StringBuilder()
-        .append("background: #fffef7;")
-        .append("border: 1px solid #e6e6e6;")
-        .append("border-color: #e0e0dc;")
-        .append("box-shadow: 0 1px 4px #e0e0dc;")
-        .append("padding: 1.25em;")
-        .toString();
+    public static final String EXAMPLE = Stream.of(
+        "background: #fffef7",
+        "border-color: #e0e0dc",
+        "border: 1px solid #e6e6e6",
+        "box-shadow: 0 1px 4px #e0e0dc",
+        "padding: 1.25em"
+    ).collect(Collectors.joining("; "));
 }

--- a/asciidoctor-parser-doxia-module/src/main/java/org/asciidoctor/maven/site/parser/processors/Styles.java
+++ b/asciidoctor-parser-doxia-module/src/main/java/org/asciidoctor/maven/site/parser/processors/Styles.java
@@ -16,6 +16,7 @@ class Styles {
         "border-color: #e0e0dc",
         "border: 1px solid #e6e6e6",
         "box-shadow: 0 1px 4px #e0e0dc",
+        "margin-bottom: 1.25em",
         "padding: 1.25em"
     ).collect(Collectors.joining("; "));
 }

--- a/asciidoctor-parser-doxia-module/src/main/java/org/asciidoctor/maven/site/parser/processors/Styles.java
+++ b/asciidoctor-parser-doxia-module/src/main/java/org/asciidoctor/maven/site/parser/processors/Styles.java
@@ -2,5 +2,17 @@ package org.asciidoctor.maven.site.parser.processors;
 
 class Styles {
 
-    public static final String CAPTION = "color: #7a2518; margin-bottom: .25em;";
+    public static final String CAPTION = new StringBuilder()
+        .append("color: #7a2518;")
+        .append("margin-bottom: .25em;")
+        .toString();
+
+
+    public static final String EXAMPLE = new StringBuilder()
+        .append("background: #fffef7;")
+        .append("border: 1px solid #e6e6e6;")
+        .append("border-color: #e0e0dc;")
+        .append("box-shadow: 0 1px 4px #e0e0dc;")
+        .append("padding: 1.25em;")
+        .toString();
 }

--- a/asciidoctor-parser-doxia-module/src/main/java/org/asciidoctor/maven/site/parser/processors/Styles.java
+++ b/asciidoctor-parser-doxia-module/src/main/java/org/asciidoctor/maven/site/parser/processors/Styles.java
@@ -1,0 +1,6 @@
+package org.asciidoctor.maven.site.parser.processors;
+
+class Styles {
+
+    public static final String CAPTION = "color: #7a2518; margin-bottom: .25em;";
+}

--- a/asciidoctor-parser-doxia-module/src/main/java/org/asciidoctor/maven/site/parser/processors/TableNodeProcessor.java
+++ b/asciidoctor-parser-doxia-module/src/main/java/org/asciidoctor/maven/site/parser/processors/TableNodeProcessor.java
@@ -10,6 +10,7 @@ import org.asciidoctor.jruby.ast.impl.TableImpl;
 import org.asciidoctor.maven.site.parser.NodeProcessor;
 import org.asciidoctor.maven.site.parser.NodeSinker;
 
+import static javax.swing.text.html.HTML.Attribute.STYLE;
 import static org.apache.maven.doxia.sink.Sink.JUSTIFY_LEFT;
 import static org.asciidoctor.maven.commons.StringUtils.isNotBlank;
 
@@ -84,7 +85,9 @@ public class TableNodeProcessor extends AbstractSinkNodeProcessor implements Nod
         // final String title = node.getTitle();
         final String title = TitleExtractor.getText(node);
         if (isNotBlank(title)) {
-            sink.tableCaption();
+            // Contrary to other cases where we use <div>, we use <caption>: same as Fluido and Asciidoctor
+            // TODO Have a proper CSS stylesheet injected
+            sink.tableCaption(SinkAttributes.of(STYLE, Styles.CAPTION + "; text-align: left"));
             // getCaption returns
             // - "" when '[caption=]'
             // - null when ':table-caption!:

--- a/asciidoctor-parser-doxia-module/src/main/java/org/asciidoctor/maven/site/parser/processors/TableNodeProcessor.java
+++ b/asciidoctor-parser-doxia-module/src/main/java/org/asciidoctor/maven/site/parser/processors/TableNodeProcessor.java
@@ -45,7 +45,6 @@ public class TableNodeProcessor extends AbstractSinkNodeProcessor implements Nod
         sink.table();
         sink.tableRows(new int[]{JUSTIFY_LEFT}, false);
         List<Row> header = tableNode.getHeader();
-        List<StructuralNode> blocks = node.getBlocks();
         if (!header.isEmpty()) {
             sink.tableRow();
 
@@ -78,14 +77,19 @@ public class TableNodeProcessor extends AbstractSinkNodeProcessor implements Nod
     private void processCaption(StructuralNode node, Sink sink) {
         // 'null' when not set or '[caption=]'
         final String tableCaption = (String) node.getAttribute("table-caption");
+        final String caption = node.getCaption();
         // disable single caption
+
+        // if "[caption=]" -> remove caption
+        // disable too, when ":table-caption!:"
 
         final String title = node.getTitle();
         if (isNotBlank(title)) {
-            // TODO why do we do this next line?
-            // node.getContentModel();
             sink.tableCaption();
-            // It's safe: getCaption returns "" when '[caption=]' is set
+            sink.figureCaption();
+            // getCaption returns
+            // - "" when '[caption=]'
+            // - null when ':table-caption!:
             if (isBlank(node.getCaption()))
                 sink.text(node.getTitle());
             else

--- a/asciidoctor-parser-doxia-module/src/main/java/org/asciidoctor/maven/site/parser/processors/TableNodeProcessor.java
+++ b/asciidoctor-parser-doxia-module/src/main/java/org/asciidoctor/maven/site/parser/processors/TableNodeProcessor.java
@@ -83,7 +83,7 @@ public class TableNodeProcessor extends AbstractSinkNodeProcessor implements Nod
         // if "[caption=]" -> remove caption
         // disable too, when ":table-caption!:"
         // final String title = node.getTitle();
-        final String title = TitleExtractor.getText(node);
+        final String title = TitleCaptionExtractor.getText(node);
         if (isNotBlank(title)) {
             // Contrary to other cases where we use <div>, we use <caption>: same as Fluido and Asciidoctor
             // TODO Have a proper CSS stylesheet injected

--- a/asciidoctor-parser-doxia-module/src/main/java/org/asciidoctor/maven/site/parser/processors/TableNodeProcessor.java
+++ b/asciidoctor-parser-doxia-module/src/main/java/org/asciidoctor/maven/site/parser/processors/TableNodeProcessor.java
@@ -44,7 +44,13 @@ public class TableNodeProcessor extends AbstractSinkNodeProcessor implements Nod
         final Sink sink = getSink();
         sink.table();
         sink.tableRows(new int[]{JUSTIFY_LEFT}, false);
-        List<Row> header = tableNode.getHeader();
+        final List<Row> header = tableNode.getHeader();
+        final List<Row> rows = tableNode.getBody();
+
+        if (header.isEmpty() && rows.isEmpty()) {
+            return;
+        }
+
         if (!header.isEmpty()) {
             sink.tableRow();
 
@@ -58,7 +64,7 @@ public class TableNodeProcessor extends AbstractSinkNodeProcessor implements Nod
             sink.tableRow_();
         }
 
-        for (Row row : tableNode.getBody()) {
+        for (Row row : rows) {
             sink.tableRow();
             for (Cell cell : row.getCells()) {
                 sink.tableCell();

--- a/asciidoctor-parser-doxia-module/src/main/java/org/asciidoctor/maven/site/parser/processors/TableNodeProcessor.java
+++ b/asciidoctor-parser-doxia-module/src/main/java/org/asciidoctor/maven/site/parser/processors/TableNodeProcessor.java
@@ -11,7 +11,6 @@ import org.asciidoctor.maven.site.parser.NodeProcessor;
 import org.asciidoctor.maven.site.parser.NodeSinker;
 
 import static org.apache.maven.doxia.sink.Sink.JUSTIFY_LEFT;
-import static org.asciidoctor.maven.commons.StringUtils.isBlank;
 import static org.asciidoctor.maven.commons.StringUtils.isNotBlank;
 
 /**
@@ -82,18 +81,14 @@ public class TableNodeProcessor extends AbstractSinkNodeProcessor implements Nod
 
         // if "[caption=]" -> remove caption
         // disable too, when ":table-caption!:"
-
-        final String title = node.getTitle();
+        // final String title = node.getTitle();
+        final String title = TitleExtractor.getText(node);
         if (isNotBlank(title)) {
             sink.tableCaption();
-            sink.figureCaption();
             // getCaption returns
             // - "" when '[caption=]'
             // - null when ':table-caption!:
-            if (isBlank(node.getCaption()))
-                sink.text(node.getTitle());
-            else
-                sink.text(node.getCaption() + node.getTitle());
+            sink.text(title);
             sink.tableCaption_();
         }
     }

--- a/asciidoctor-parser-doxia-module/src/main/java/org/asciidoctor/maven/site/parser/processors/TitleCaptionExtractor.java
+++ b/asciidoctor-parser-doxia-module/src/main/java/org/asciidoctor/maven/site/parser/processors/TitleCaptionExtractor.java
@@ -4,9 +4,15 @@ import org.asciidoctor.ast.StructuralNode;
 
 import static org.asciidoctor.maven.commons.StringUtils.isBlank;
 
-class TitleExtractor {
+/**
+ * Utility to extract composed title and caption text.
+ *
+ * @author abelsromero
+ * @since 3.1.0
+ */
+class TitleCaptionExtractor {
 
-    // TODO is this being re-used properly: examples? tables?
+    // Not used in SectionNodeProcessor to avoid extra node processing
     static String getText(StructuralNode node) {
         // Caption is returned when a title is set in:
         // - Image blocks
@@ -14,5 +20,4 @@ class TitleExtractor {
         final String caption = node.getCaption();
         return isBlank(caption) ? node.getTitle() : String.format("%s %s", caption.trim(), node.getTitle());
     }
-
 }

--- a/asciidoctor-parser-doxia-module/src/main/java/org/asciidoctor/maven/site/parser/processors/TitleExtractor.java
+++ b/asciidoctor-parser-doxia-module/src/main/java/org/asciidoctor/maven/site/parser/processors/TitleExtractor.java
@@ -6,12 +6,13 @@ import static org.asciidoctor.maven.commons.StringUtils.isBlank;
 
 class TitleExtractor {
 
+    // TODO is this being re-used properly: examples? tables?
     static String getText(StructuralNode node) {
         // Caption is returned when a title is set in:
-        // - Listings
         // - Image blocks
+        // - Listings
         final String caption = node.getCaption();
-        return isBlank(caption) ? node.getTitle() : caption + node.getTitle();
+        return isBlank(caption) ? node.getTitle() : String.format("%s %s", caption.trim(), node.getTitle());
     }
 
 }

--- a/asciidoctor-parser-doxia-module/src/main/java/org/asciidoctor/maven/site/parser/processors/TitleExtractor.java
+++ b/asciidoctor-parser-doxia-module/src/main/java/org/asciidoctor/maven/site/parser/processors/TitleExtractor.java
@@ -1,0 +1,17 @@
+package org.asciidoctor.maven.site.parser.processors;
+
+import org.asciidoctor.ast.StructuralNode;
+
+import static org.asciidoctor.maven.commons.StringUtils.isBlank;
+
+class TitleExtractor {
+
+    static String getText(StructuralNode node) {
+        // Caption is returned when a title is set in:
+        // - Listings
+        // - Image blocks
+        final String caption = node.getCaption();
+        return isBlank(caption) ? node.getTitle() : caption + node.getTitle();
+    }
+
+}

--- a/asciidoctor-parser-doxia-module/src/test/java/org/asciidoctor/maven/site/parser/AsciidoctorAstDoxiaParserTest.java
+++ b/asciidoctor-parser-doxia-module/src/test/java/org/asciidoctor/maven/site/parser/AsciidoctorAstDoxiaParserTest.java
@@ -18,7 +18,7 @@ import org.mockito.Mockito;
 
 import static org.asciidoctor.maven.site.parser.AsciidoctorAstDoxiaParserTest.TestMocks.mockAsciidoctorDoxiaParser;
 import static org.asciidoctor.maven.site.parser.processors.test.ReflectionUtils.extractField;
-import static org.asciidoctor.maven.site.parser.processors.test.StringTestUtils.clean;
+import static org.asciidoctor.maven.site.parser.processors.test.StringTestUtils.removeLineBreaks;
 import static org.asciidoctor.maven.site.parser.processors.test.TestNodeProcessorFactory.createSink;
 import static org.assertj.core.api.Assertions.assertThat;
 import static org.assertj.core.api.Assertions.catchThrowable;
@@ -195,12 +195,12 @@ class AsciidoctorAstDoxiaParserTest {
 
     private String parse(AbstractTextParser parser, File source) throws FileNotFoundException, ParseException {
         parser.parse(new FileReader(source), sink);
-        return clean(sinkWriter.toString());
+        return removeLineBreaks(sinkWriter.toString());
     }
 
     private String parse(AbstractTextParser parser, String source) throws ParseException {
         parser.parse(new StringReader(source), sink);
-        return clean(sinkWriter.toString());
+        return removeLineBreaks(sinkWriter.toString());
     }
 
     static class TestMocks {

--- a/asciidoctor-parser-doxia-module/src/test/java/org/asciidoctor/maven/site/parser/NodeSinkerTest.java
+++ b/asciidoctor-parser-doxia-module/src/test/java/org/asciidoctor/maven/site/parser/NodeSinkerTest.java
@@ -5,9 +5,12 @@ import java.util.List;
 
 import org.apache.maven.doxia.sink.Sink;
 import org.asciidoctor.ast.Block;
+import org.asciidoctor.ast.Cell;
 import org.asciidoctor.ast.Document;
 import org.asciidoctor.ast.ListItem;
+import org.asciidoctor.ast.Row;
 import org.asciidoctor.ast.StructuralNode;
+import org.asciidoctor.ast.Table;
 import org.asciidoctor.jruby.ast.impl.BlockImpl;
 import org.asciidoctor.jruby.ast.impl.DocumentImpl;
 import org.asciidoctor.jruby.ast.impl.SectionImpl;
@@ -105,6 +108,11 @@ class NodeSinkerTest {
     @Test
     void should_process_table_node() {
         StructuralNode mockNode = mockNode("table", TableImpl.class);
+        Cell mockCell = Mockito.mock(Cell.class);
+        Mockito.when(mockCell.getText()).thenReturn("Cell text");
+        Row mockRow = Mockito.mock(Row.class);
+        Mockito.when(mockRow.getCells()).thenReturn(List.of(mockCell));
+        Mockito.when(((Table) mockNode).getBody()).thenReturn(List.of(mockRow));
 
         nodeSinker.sink(mockNode);
 

--- a/asciidoctor-parser-doxia-module/src/test/java/org/asciidoctor/maven/site/parser/processors/DescriptionListNodeProcessorTest.java
+++ b/asciidoctor-parser-doxia-module/src/test/java/org/asciidoctor/maven/site/parser/processors/DescriptionListNodeProcessorTest.java
@@ -12,7 +12,7 @@ import org.asciidoctor.maven.site.parser.processors.test.NodeProcessorTest;
 import org.junit.jupiter.api.Test;
 
 import static org.asciidoctor.maven.site.parser.processors.test.Html.*;
-import static org.asciidoctor.maven.site.parser.processors.test.StringTestUtils.clean;
+import static org.asciidoctor.maven.site.parser.processors.test.StringTestUtils.removeLineBreaks;
 import static org.assertj.core.api.Assertions.assertThat;
 
 @NodeProcessorTest(DescriptionListNodeProcessor.class)
@@ -146,6 +146,6 @@ class DescriptionListNodeProcessorTest {
 
         nodeProcessor.process(node);
 
-        return clean(sinkWriter.toString());
+        return removeLineBreaks(sinkWriter.toString());
     }
 }

--- a/asciidoctor-parser-doxia-module/src/test/java/org/asciidoctor/maven/site/parser/processors/ExampleNodeProcessorTest.java
+++ b/asciidoctor-parser-doxia-module/src/test/java/org/asciidoctor/maven/site/parser/processors/ExampleNodeProcessorTest.java
@@ -13,13 +13,14 @@ import org.asciidoctor.maven.site.parser.processors.test.NodeProcessorTest;
 import org.junit.jupiter.api.Test;
 
 import static org.asciidoctor.maven.site.parser.processors.test.Html.*;
+import static org.asciidoctor.maven.site.parser.processors.test.StringTestUtils.removeLineBreaks;
 import static org.assertj.core.api.Assertions.assertThat;
 
 @NodeProcessorTest(ExampleNodeProcessor.class)
 class ExampleNodeProcessorTest {
 
-    public static final String EXAMPLE_TITLE_OPENING = "<div style=\"color: #7a2518;margin-bottom: .25em;\">";
-    public static final String EXAMPLE_CONTENT_OPENING = "<div style=\"background: #fffef7;border: 1px solid #e6e6e6;border-color: #e0e0dc;box-shadow: 0 1px 4px #e0e0dc;padding: 1.25em;\">";
+    public static final String EXAMPLE_TITLE_OPENING = "<div style=\"color: #7a2518; margin-bottom: .25em\">";
+    public static final String EXAMPLE_CONTENT_OPENING = "<div style=\"background: #fffef7; border-color: #e0e0dc; border: 1px solid #e6e6e6; box-shadow: 0 1px 4px #e0e0dc; padding: 1.25em\">";
 
     private Asciidoctor asciidoctor;
     private NodeProcessor nodeProcessor;

--- a/asciidoctor-parser-doxia-module/src/test/java/org/asciidoctor/maven/site/parser/processors/ExampleNodeProcessorTest.java
+++ b/asciidoctor-parser-doxia-module/src/test/java/org/asciidoctor/maven/site/parser/processors/ExampleNodeProcessorTest.java
@@ -1,0 +1,174 @@
+package org.asciidoctor.maven.site.parser.processors;
+
+import java.io.StringWriter;
+import java.util.Collections;
+import java.util.List;
+import java.util.stream.Collectors;
+
+import org.asciidoctor.Asciidoctor;
+import org.asciidoctor.Options;
+import org.asciidoctor.ast.StructuralNode;
+import org.asciidoctor.maven.site.parser.NodeProcessor;
+import org.asciidoctor.maven.site.parser.processors.test.NodeProcessorTest;
+import org.junit.jupiter.api.Test;
+
+import static org.asciidoctor.maven.site.parser.processors.test.Html.*;
+import static org.assertj.core.api.Assertions.assertThat;
+
+@NodeProcessorTest(ExampleNodeProcessor.class)
+class ExampleNodeProcessorTest {
+
+    public static final String EXAMPLE_TITLE_OPENING = "<div style=\"color: #7a2518;margin-bottom: .25em;\">";
+    public static final String EXAMPLE_CONTENT_OPENING = "<div style=\"background: #fffef7;border: 1px solid #e6e6e6;border-color: #e0e0dc;box-shadow: 0 1px 4px #e0e0dc;padding: 1.25em;\">";
+
+    private Asciidoctor asciidoctor;
+    private NodeProcessor nodeProcessor;
+    private StringWriter sinkWriter;
+
+    @Test
+    void should_convert_empty_example() {
+        String content = documentWithExample(null, null, List.of());
+
+        String html = process(content);
+
+        assertThat(html)
+            .isEqualTo(div(""));
+    }
+
+    @Test
+    void should_convert_minimal_example() {
+        String content = documentWithExample("SomeText", null, List.of());
+
+        String html = process(content);
+
+        assertThat(html)
+            .isEqualTo(div(
+                EXAMPLE_CONTENT_OPENING +
+                    p("SomeText") +
+                    "</div>"));
+    }
+
+    @Test
+    void should_convert_example_with_title() {
+        String content = documentWithExample("SomeText", "The title", List.of());
+
+        String html = process(content);
+
+        assertThat(html)
+            .isEqualTo(div(
+                EXAMPLE_TITLE_OPENING + "Example 1. The title</div>" +
+                    EXAMPLE_CONTENT_OPENING +
+                    p("SomeText") +
+                    "</div>"));
+    }
+
+    @Test
+    void should_convert_example_with_title_without_caption() {
+        String content = documentWithExample("SomeText", "The title", List.of(":example-caption!:"));
+
+        String html = process(content);
+
+        assertThat(html)
+            .isEqualTo(div(
+                EXAMPLE_TITLE_OPENING + "The title</div>" +
+                    EXAMPLE_CONTENT_OPENING +
+                    p("SomeText") +
+                    "</div>"));
+    }
+
+    @Test
+    void should_convert_with_nested_link() {
+        final String link = "https://docs.asciidoctor.org/";
+        String content = documentWithExample(link, null, List.of());
+
+        String html = process(content);
+
+        assertThat(html)
+            .isEqualTo(div(
+                EXAMPLE_CONTENT_OPENING +
+                    p("<a href=\"https://docs.asciidoctor.org/\" class=\"bare\">https://docs.asciidoctor.org/</a>") +
+                    "</div>"));
+    }
+
+    @Test
+    void should_convert_with_nested_table() {
+        final String table = "|===\n" +
+            "|Header 1 |Header 2\n" +
+            "|Column 1, row 1\n" +
+            "|Column 2, row 1\n" +
+            "|===";
+        String content = documentWithExample(table, null, List.of());
+
+        String html = process(content);
+
+        assertThat(html)
+            .isEqualTo(div(
+                EXAMPLE_CONTENT_OPENING +
+                    "<table class=\"bodyTable\">" +
+                    "<tr class=\"a\"><td style=\"text-align: left;\">Header 1</td><td>Header 2</td></tr>" +
+                    "<tr class=\"b\"><td style=\"text-align: left;\">Column 1, row 1</td><td>Column 2, row 1</td></tr>" +
+                    "</table>" +
+                    "</div>"));
+    }
+
+    @Test
+    void should_convert_with_nested_list() {
+        final String list = "* Un\n" +
+            "** Dos\n" +
+            "* Tres\n" +
+            "** Quatre";
+        String content = documentWithExample(list, null, List.of());
+
+        String html = process(content);
+
+        assertThat(html)
+            .isEqualTo(div(
+                EXAMPLE_CONTENT_OPENING +
+                    ul(
+                        li("Un" + ul(li("Dos"))) +
+                            li("Tres" + ul(li("Quatre")))
+                    ) +
+                    "</div>"));
+    }
+
+    @Test
+    void should_convert_with_multiple_nested_elements() {
+        final String list = "* Un\n" +
+            "** Dos\n" +
+            "* Tres\n" +
+            "** Quatre";
+        final String link = "https://docs.asciidoctor.org/";
+        String content = documentWithExample(list + "\n\n" + link, null, List.of());
+
+        String html = process(content);
+
+        assertThat(html)
+            .isEqualTo(div(
+                EXAMPLE_CONTENT_OPENING +
+                    ul(
+                        li("Un" + ul(li("Dos"))) +
+                            li("Tres" + ul(li("Quatre")))
+                    ) +
+                    p("<a href=\"https://docs.asciidoctor.org/\" class=\"bare\">https://docs.asciidoctor.org/</a>") +
+                    "</div>"));
+    }
+
+    private String documentWithExample(String text, String title, List<String> attributes) {
+        return "= Tile\n\n" + "== Section\n\n" +
+            (attributes.isEmpty() ? "" : attributes.stream().collect(Collectors.joining("\n"))) + "\n" +
+            (title == null ? "" : "." + title) + "\n" +
+            "====" + "\n" +
+            (text == null ? "" : text) + "\n" +
+            "====" + "\n";
+    }
+
+    private String process(String content) {
+        StructuralNode node = asciidoctor.load(content, Options.builder().build())
+            .findBy(Collections.singletonMap("context", ":example"))
+            .get(0);
+
+        nodeProcessor.process(node);
+
+        return removeLineBreaks(sinkWriter.toString());
+    }
+}

--- a/asciidoctor-parser-doxia-module/src/test/java/org/asciidoctor/maven/site/parser/processors/ExampleNodeProcessorTest.java
+++ b/asciidoctor-parser-doxia-module/src/test/java/org/asciidoctor/maven/site/parser/processors/ExampleNodeProcessorTest.java
@@ -10,6 +10,7 @@ import org.asciidoctor.Options;
 import org.asciidoctor.ast.StructuralNode;
 import org.asciidoctor.maven.site.parser.NodeProcessor;
 import org.asciidoctor.maven.site.parser.processors.test.NodeProcessorTest;
+import org.junit.jupiter.api.Nested;
 import org.junit.jupiter.api.Test;
 
 import static org.asciidoctor.maven.site.parser.processors.test.Html.*;
@@ -20,7 +21,7 @@ import static org.assertj.core.api.Assertions.assertThat;
 class ExampleNodeProcessorTest {
 
     public static final String EXAMPLE_TITLE_OPENING = "<div style=\"color: #7a2518; margin-bottom: .25em\">";
-    public static final String EXAMPLE_CONTENT_OPENING = "<div style=\"background: #fffef7; border-color: #e0e0dc; border: 1px solid #e6e6e6; box-shadow: 0 1px 4px #e0e0dc; padding: 1.25em\">";
+    public static final String EXAMPLE_CONTENT_OPENING = "<div style=\"background: #fffef7; border-color: #e0e0dc; border: 1px solid #e6e6e6; box-shadow: 0 1px 4px #e0e0dc; margin-bottom: 1.25em; padding: 1.25em\">";
 
     private Asciidoctor asciidoctor;
     private NodeProcessor nodeProcessor;
@@ -171,5 +172,58 @@ class ExampleNodeProcessorTest {
         nodeProcessor.process(node);
 
         return removeLineBreaks(sinkWriter.toString());
+    }
+
+    @Nested
+    class WithSimpleContentModel {
+
+        @Test
+        void should_convert_minimal_example() {
+            String content = "= Tile\n\n" + "== Section\n\n" +
+                "[example]\n" +
+                "SomeText";
+
+            String html = process(content);
+
+            // Content is directly embedded instead of delegated to paragraph processor
+            assertThat(html)
+                .isEqualTo(div(
+                    EXAMPLE_CONTENT_OPENING +
+                        "SomeText" +
+                        "</div>"));
+        }
+
+        @Test
+        void should_convert_minimal_example_with_title() {
+            String content = "= Tile\n\n" + "== Section\n\n" +
+                ".Optional title\n" +
+                "[example]\n" +
+                "SomeText";
+
+            String html = process(content);
+
+            assertThat(html)
+                .isEqualTo(div(
+                    EXAMPLE_TITLE_OPENING + "Example 1. Optional title</div>" +
+                        EXAMPLE_CONTENT_OPENING +
+                        "SomeText" +
+                        "</div>"));
+        }
+
+        @Test
+        void should_convert_minimal_example_with_link() {
+            final String link = "https://docs.asciidoctor.org/";
+            String content = "= Tile\n\n" + "== Section\n\n" +
+                "[example]\n" +
+                "SomeText, " + link;
+
+            String html = process(content);
+
+            assertThat(html)
+                .isEqualTo(div(
+                        EXAMPLE_CONTENT_OPENING +
+                        "SomeText, <a href=\"https://docs.asciidoctor.org/\" class=\"bare\">https://docs.asciidoctor.org/</a>" +
+                        "</div>"));
+        }
     }
 }

--- a/asciidoctor-parser-doxia-module/src/test/java/org/asciidoctor/maven/site/parser/processors/ImageNodeProcessorTest.java
+++ b/asciidoctor-parser-doxia-module/src/test/java/org/asciidoctor/maven/site/parser/processors/ImageNodeProcessorTest.java
@@ -10,9 +10,11 @@ import org.asciidoctor.Asciidoctor;
 import org.asciidoctor.Options;
 import org.asciidoctor.ast.StructuralNode;
 import org.asciidoctor.maven.site.parser.NodeProcessor;
+import org.asciidoctor.maven.site.parser.processors.test.Html;
 import org.asciidoctor.maven.site.parser.processors.test.NodeProcessorTest;
 import org.junit.jupiter.api.Test;
 
+import static org.asciidoctor.maven.site.parser.processors.test.Html.div;
 import static org.assertj.core.api.Assertions.assertThat;
 
 @NodeProcessorTest(ImageNodeProcessor.class)
@@ -29,7 +31,7 @@ class ImageNodeProcessorTest {
         String html = process(content, 0);
 
         assertThat(html)
-                .isEqualTo("<img src=\"images/tiger.png\" alt=\"Kitty\" />");
+                .isEqualTo(div("<img src=\"images/tiger.png\" alt=\"Kitty\" />"));
     }
 
     @Test
@@ -40,7 +42,7 @@ class ImageNodeProcessorTest {
 
         final String separator = FileSystems.getDefault().getSeparator();
         assertThat(html)
-                .isEqualTo("<img src=\"prefix-path" + separator + "images/tiger.png\" alt=\"Kitty\" />");
+                .isEqualTo(div("<img src=\"prefix-path" + separator + "images/tiger.png\" alt=\"Kitty\" />"));
     }
 
     private String documentWithImage() {

--- a/asciidoctor-parser-doxia-module/src/test/java/org/asciidoctor/maven/site/parser/processors/ListingNodeProcessorTest.java
+++ b/asciidoctor-parser-doxia-module/src/test/java/org/asciidoctor/maven/site/parser/processors/ListingNodeProcessorTest.java
@@ -11,7 +11,7 @@ import org.asciidoctor.maven.site.parser.processors.test.NodeProcessorTest;
 import org.junit.jupiter.api.Test;
 
 import static org.asciidoctor.maven.commons.StringUtils.isNotBlank;
-import static org.asciidoctor.maven.site.parser.processors.test.StringTestUtils.clean;
+import static org.asciidoctor.maven.site.parser.processors.test.StringTestUtils.removeLineBreaks;
 import static org.assertj.core.api.Assertions.assertThat;
 
 @NodeProcessorTest(ListingNodeProcessor.class)
@@ -138,7 +138,7 @@ class ListingNodeProcessorTest {
     }
 
     private static String expectedTitle(String title) {
-        return "<div style=\"color: #7a2518; margin-bottom: .25em;\" >" + title + "</div>";
+        return "<div style=\"color: #7a2518; margin-bottom: .25em\" >" + title + "</div>";
     }
 
     private String process(String content) {
@@ -148,6 +148,6 @@ class ListingNodeProcessorTest {
 
         nodeProcessor.process(node);
 
-        return clean(sinkWriter.toString());
+        return removeLineBreaks(sinkWriter.toString());
     }
 }

--- a/asciidoctor-parser-doxia-module/src/test/java/org/asciidoctor/maven/site/parser/processors/OrderedListNodeProcessorTest.java
+++ b/asciidoctor-parser-doxia-module/src/test/java/org/asciidoctor/maven/site/parser/processors/OrderedListNodeProcessorTest.java
@@ -6,14 +6,12 @@ import org.asciidoctor.Options;
 import org.asciidoctor.ast.StructuralNode;
 import org.asciidoctor.maven.site.parser.NodeProcessor;
 import org.asciidoctor.maven.site.parser.processors.test.NodeProcessorTest;
-import org.junit.jupiter.api.BeforeEach;
 import org.junit.jupiter.api.Test;
 
 import java.io.StringWriter;
-import java.util.Arrays;
 import java.util.Collections;
 
-import static org.asciidoctor.maven.site.parser.processors.test.StringTestUtils.clean;
+import static org.asciidoctor.maven.site.parser.processors.test.StringTestUtils.removeLineBreaks;
 import static org.assertj.core.api.Assertions.assertThat;
 
 @NodeProcessorTest(OrderedListNodeProcessor.class)
@@ -80,6 +78,6 @@ class OrderedListNodeProcessorTest {
 
         nodeProcessor.process(node);
 
-        return clean(sinkWriter.toString());
+        return removeLineBreaks(sinkWriter.toString());
     }
 }

--- a/asciidoctor-parser-doxia-module/src/test/java/org/asciidoctor/maven/site/parser/processors/SectionNodeProcessorTest.java
+++ b/asciidoctor-parser-doxia-module/src/test/java/org/asciidoctor/maven/site/parser/processors/SectionNodeProcessorTest.java
@@ -11,6 +11,7 @@ import org.asciidoctor.maven.site.parser.NodeProcessor;
 import org.asciidoctor.maven.site.parser.processors.test.NodeProcessorTest;
 import org.junit.jupiter.api.Test;
 
+import static org.asciidoctor.maven.site.parser.processors.test.Html.removeLineBreaks;
 import static org.assertj.core.api.Assertions.assertThat;
 
 @NodeProcessorTest(SectionNodeProcessor.class)
@@ -200,10 +201,6 @@ class SectionNodeProcessorTest {
         reset(sinkWriter);
         nodeProcessor.process(node);
         return removeLineBreaks(sinkWriter.toString().trim());
-    }
-
-    private static String removeLineBreaks(String html) {
-        return html.replaceAll("(\r)?\n", "");
     }
 
     private void reset(StringWriter sinkWriter) {

--- a/asciidoctor-parser-doxia-module/src/test/java/org/asciidoctor/maven/site/parser/processors/SectionNodeProcessorTest.java
+++ b/asciidoctor-parser-doxia-module/src/test/java/org/asciidoctor/maven/site/parser/processors/SectionNodeProcessorTest.java
@@ -11,7 +11,9 @@ import org.asciidoctor.maven.site.parser.NodeProcessor;
 import org.asciidoctor.maven.site.parser.processors.test.NodeProcessorTest;
 import org.junit.jupiter.api.Test;
 
-import static org.asciidoctor.maven.site.parser.processors.test.Html.*;
+import static org.asciidoctor.maven.site.parser.processors.test.Html.div;
+import static org.asciidoctor.maven.site.parser.processors.test.Html.p;
+import static org.asciidoctor.maven.site.parser.processors.test.StringTestUtils.removeLineBreaks;
 import static org.assertj.core.api.Assertions.assertThat;
 
 @NodeProcessorTest(SectionNodeProcessor.class)
@@ -154,28 +156,41 @@ class SectionNodeProcessorTest {
         String content = "= Document tile\n\n" +
             "== Section title\n\nSection body\n\n" +
             "[appendix]\n" +
-            "== Appendix title 1\n\nSection body\n\n" +
+            "=== Appendix title 1\n\nSection body\n\n" +
             "[appendix]\n" +
-            "== Appendix title 2\n\nSection body\n\n";
+            "=== Appendix title 2\n\nSection body\n\n";
 
         String html = process(content, 1);
 
         assertThat(html)
             .isEqualTo(div("<h2><a id=\"_section_title\"></a>Section title</h2>" +
                 p("Section body") +
-                div("<h3><a id=\"_second_section_title\"></a>Second section title</h3>" +
-                    p("Second section body") +
-                    div("<h4><a id=\"_third_section_title\"></a>Third section title</h4>" +
-                        p("Third section body") +
-                        div("<h5><a id=\"_fourth_section_title\"></a>Fourth section title</h5>" +
-                            p("Fourth section body") +
-                            div("<h5><a id=\"_fifth_section_title\"></a>Fifth section title</h5>" +
-                                p("Fifth section body")))))));
+                div("<h3><a id=\"_appendix_title_1\"></a>Appendix A: Appendix title 1</h3>" +
+                    p("Section body")) +
+                div("<h3><a id=\"_appendix_title_2\"></a>Appendix B: Appendix title 2</h3>" +
+                    p("Section body"))));
     }
 
     @Test
-    void should_convert_sections_with_appendices_and_custom_caption() {
+    void should_convert_sections_with_appendices_and_custom_captions() {
+        String content = "= Document tile\n" +
+            ":appendix-caption: App.\n" +
+            ":appendix-number: C\n\n" +
+            "== Section title\n\nSection body\n\n" +
+            "[appendix]\n" +
+            "=== Appendix title 1\n\nSection body\n\n" +
+            "[appendix]\n" +
+            "=== Appendix title 2\n\nSection body\n\n";
 
+        String html = process(content, 1);
+
+        assertThat(html)
+            .isEqualTo(div("<h2><a id=\"_section_title\"></a>Section title</h2>" +
+                p("Section body") +
+                div("<h3><a id=\"_appendix_title_1\"></a>App. D: Appendix title 1</h3>" +
+                    p("Section body")) +
+                div("<h3><a id=\"_appendix_title_2\"></a>App. E: Appendix title 2</h3>" +
+                    p("Section body"))));
     }
 
     private String documentWithSections() {

--- a/asciidoctor-parser-doxia-module/src/test/java/org/asciidoctor/maven/site/parser/processors/SectionNodeProcessorTest.java
+++ b/asciidoctor-parser-doxia-module/src/test/java/org/asciidoctor/maven/site/parser/processors/SectionNodeProcessorTest.java
@@ -11,7 +11,7 @@ import org.asciidoctor.maven.site.parser.NodeProcessor;
 import org.asciidoctor.maven.site.parser.processors.test.NodeProcessorTest;
 import org.junit.jupiter.api.Test;
 
-import static org.asciidoctor.maven.site.parser.processors.test.Html.removeLineBreaks;
+import static org.asciidoctor.maven.site.parser.processors.test.Html.*;
 import static org.assertj.core.api.Assertions.assertThat;
 
 @NodeProcessorTest(SectionNodeProcessor.class)
@@ -28,7 +28,7 @@ class SectionNodeProcessorTest {
         String html = process(content, 0);
 
         assertThat(html)
-            .isEqualTo("<div><h1>Document tile</h1></div>");
+            .isEqualTo(div("<h1>Document tile</h1>"));
     }
 
     @Test
@@ -38,21 +38,16 @@ class SectionNodeProcessorTest {
         String html = process(content, 1);
 
         assertThat(html)
-            .isEqualTo("<div>" +
-                "<h2><a id=\"_first_section_title\"></a>First section title</h2>" +
-                "<p>First section body</p>" +
-                "<div>" +
-                "<h3><a id=\"_second_section_title\"></a>Second section title</h3>" +
-                "<p>Second section body</p>" +
-                "<div>" +
-                "<h4><a id=\"_third_section_title\"></a>Third section title</h4>" +
-                "<p>Third section body</p>" +
-                "<div>" +
-                "<h5><a id=\"_fourth_section_title\"></a>Fourth section title</h5>" +
-                "<p>Fourth section body</p>" +
-                "<div>" +
-                "<h5><a id=\"_fifth_section_title\"></a>Fifth section title</h5>" +
-                "<p>Fifth section body</p></div></div></div></div></div>");
+            .isEqualTo(div("<h2><a id=\"_first_section_title\"></a>First section title</h2>" +
+                p("First section body") +
+                div("<h3><a id=\"_second_section_title\"></a>Second section title</h3>" +
+                    p("Second section body") +
+                    div("<h4><a id=\"_third_section_title\"></a>Third section title</h4>" +
+                        p("Third section body") +
+                        div("<h5><a id=\"_fourth_section_title\"></a>Fourth section title</h5>" +
+                            p("Fourth section body") +
+                            div("<h5><a id=\"_fifth_section_title\"></a>Fifth section title</h5>" +
+                                p("Fifth section body")))))));
     }
 
     @Test
@@ -62,18 +57,15 @@ class SectionNodeProcessorTest {
         String html = process(content, 2);
 
         assertThat(html)
-            .isEqualTo("<div>" +
+            .isEqualTo(div(
                 "<h3><a id=\"_second_section_title\"></a>Second section title</h3>" +
-                "<p>Second section body</p>" +
-                "<div>" +
-                "<h4><a id=\"_third_section_title\"></a>Third section title</h4>" +
-                "<p>Third section body</p>" +
-                "<div>" +
-                "<h5><a id=\"_fourth_section_title\"></a>Fourth section title</h5>" +
-                "<p>Fourth section body</p>" +
-                "<div>" +
-                "<h5><a id=\"_fifth_section_title\"></a>Fifth section title</h5>" +
-                "<p>Fifth section body</p></div></div></div></div>");
+                    p("Second section body") +
+                    div("<h4><a id=\"_third_section_title\"></a>Third section title</h4>" +
+                        p("Third section body") +
+                        div("<h5><a id=\"_fourth_section_title\"></a>Fourth section title</h5>" +
+                            "<p>Fourth section body</p>" +
+                            div("<h5><a id=\"_fifth_section_title\"></a>Fifth section title</h5>" +
+                                p("Fifth section body"))))));
     }
 
     @Test
@@ -83,15 +75,13 @@ class SectionNodeProcessorTest {
         String html = process(content, 3);
 
         assertThat(html)
-            .isEqualTo("<div>" +
+            .isEqualTo(div(
                 "<h4><a id=\"_third_section_title\"></a>Third section title</h4>" +
-                "<p>Third section body</p>" +
-                "<div>" +
-                "<h5><a id=\"_fourth_section_title\"></a>Fourth section title</h5>" +
-                "<p>Fourth section body</p>" +
-                "<div>" +
-                "<h5><a id=\"_fifth_section_title\"></a>Fifth section title</h5>" +
-                "<p>Fifth section body</p></div></div></div>");
+                    p("Third section body") +
+                    div("<h5><a id=\"_fourth_section_title\"></a>Fourth section title</h5>" +
+                        p("Fourth section body") +
+                        div("<h5><a id=\"_fifth_section_title\"></a>Fifth section title</h5>" +
+                            p("Fifth section body")))));
     }
 
     @Test
@@ -101,12 +91,10 @@ class SectionNodeProcessorTest {
         String html = process(content, 4);
 
         assertThat(html)
-            .isEqualTo("<div>" +
-                "<h5><a id=\"_fourth_section_title\"></a>Fourth section title</h5>" +
-                "<p>Fourth section body</p>" +
-                "<div>" +
-                "<h5><a id=\"_fifth_section_title\"></a>Fifth section title</h5>" +
-                "<p>Fifth section body</p></div></div>");
+            .isEqualTo(div("<h5><a id=\"_fourth_section_title\"></a>Fourth section title</h5>" +
+                p("Fourth section body") +
+                div("<h5><a id=\"_fifth_section_title\"></a>Fifth section title</h5>" +
+                    p("Fifth section body"))));
     }
 
     @Test
@@ -116,9 +104,8 @@ class SectionNodeProcessorTest {
         String html = process(content, 5);
 
         assertThat(html)
-            .isEqualTo("<div>" +
-                "<h5><a id=\"_fifth_section_title\"></a>Fifth section title</h5>" +
-                "<p>Fifth section body</p></div>");
+            .isEqualTo(div("<h5><a id=\"_fifth_section_title\"></a>Fifth section title</h5>" +
+                p("Fifth section body")));
     }
 
     @Test
@@ -128,23 +115,17 @@ class SectionNodeProcessorTest {
             .build();
         String content = documentWithSections();
 
-        // With numbering
         assertThat(process(content, 1, attributes))
-            .isEqualTo("<div>" +
-                "<h2><a id=\"_first_section_title\"></a>1. First section title</h2>" +
-                "<p>First section body</p>" +
-                "<div>" +
-                "<h3><a id=\"_second_section_title\"></a>1.1. Second section title</h3>" +
-                "<p>Second section body</p>" +
-                "<div>" +
-                "<h4><a id=\"_third_section_title\"></a>1.1.1. Third section title</h4>" +
-                "<p>Third section body</p>" +
-                "<div>" +
-                "<h5><a id=\"_fourth_section_title\"></a>Fourth section title</h5>" +
-                "<p>Fourth section body</p>" +
-                "<div>" +
-                "<h5><a id=\"_fifth_section_title\"></a>Fifth section title</h5>" +
-                "<p>Fifth section body</p></div></div></div></div></div>");
+            .isEqualTo(div("<h2><a id=\"_first_section_title\"></a>1. First section title</h2>" +
+                p("First section body") +
+                div("<h3><a id=\"_second_section_title\"></a>1.1. Second section title</h3>" +
+                    p("Second section body") +
+                    div("<h4><a id=\"_third_section_title\"></a>1.1.1. Third section title</h4>" +
+                        p("Third section body") +
+                        div("<h5><a id=\"_fourth_section_title\"></a>Fourth section title</h5>" +
+                            p("Fourth section body") +
+                            div("<h5><a id=\"_fifth_section_title\"></a>Fifth section title</h5>" +
+                                p("Fifth section body")))))));
     }
 
     @Test
@@ -155,23 +136,46 @@ class SectionNodeProcessorTest {
             .build();
         String content = documentWithSections();
 
-        // With numbering
         assertThat(process(content, 1, attributes))
-            .isEqualTo("<div>" +
-                "<h2><a id=\"_first_section_title\"></a>1. First section title</h2>" +
-                "<p>First section body</p>" +
-                "<div>" +
-                "<h3><a id=\"_second_section_title\"></a>1.1. Second section title</h3>" +
-                "<p>Second section body</p>" +
-                "<div>" +
-                "<h4><a id=\"_third_section_title\"></a>1.1.1. Third section title</h4>" +
-                "<p>Third section body</p>" +
-                "<div>" +
-                "<h5><a id=\"_fourth_section_title\"></a>1.1.1.1. Fourth section title</h5>" +
-                "<p>Fourth section body</p>" +
-                "<div>" +
-                "<h5><a id=\"_fifth_section_title\"></a>1.1.1.1.1. Fifth section title</h5>" +
-                "<p>Fifth section body</p></div></div></div></div></div>");
+            .isEqualTo(div("<h2><a id=\"_first_section_title\"></a>1. First section title</h2>" +
+                p("First section body") +
+                div("<h3><a id=\"_second_section_title\"></a>1.1. Second section title</h3>" +
+                    p("Second section body") +
+                    div("<h4><a id=\"_third_section_title\"></a>1.1.1. Third section title</h4>" +
+                        p("Third section body") +
+                        div("<h5><a id=\"_fourth_section_title\"></a>1.1.1.1. Fourth section title</h5>" +
+                            p("Fourth section body") +
+                            div("<h5><a id=\"_fifth_section_title\"></a>1.1.1.1.1. Fifth section title</h5>" +
+                                p("Fifth section body")))))));
+    }
+
+    @Test
+    void should_convert_sections_with_appendices() {
+        String content = "= Document tile\n\n" +
+            "== Section title\n\nSection body\n\n" +
+            "[appendix]\n" +
+            "== Appendix title 1\n\nSection body\n\n" +
+            "[appendix]\n" +
+            "== Appendix title 2\n\nSection body\n\n";
+
+        String html = process(content, 1);
+
+        assertThat(html)
+            .isEqualTo(div("<h2><a id=\"_section_title\"></a>Section title</h2>" +
+                p("Section body") +
+                div("<h3><a id=\"_second_section_title\"></a>Second section title</h3>" +
+                    p("Second section body") +
+                    div("<h4><a id=\"_third_section_title\"></a>Third section title</h4>" +
+                        p("Third section body") +
+                        div("<h5><a id=\"_fourth_section_title\"></a>Fourth section title</h5>" +
+                            p("Fourth section body") +
+                            div("<h5><a id=\"_fifth_section_title\"></a>Fifth section title</h5>" +
+                                p("Fifth section body")))))));
+    }
+
+    @Test
+    void should_convert_sections_with_appendices_and_custom_caption() {
+
     }
 
     private String documentWithSections() {

--- a/asciidoctor-parser-doxia-module/src/test/java/org/asciidoctor/maven/site/parser/processors/TableNodeProcessorTest.java
+++ b/asciidoctor-parser-doxia-module/src/test/java/org/asciidoctor/maven/site/parser/processors/TableNodeProcessorTest.java
@@ -29,6 +29,8 @@ import static org.assertj.core.api.Assertions.assertThat;
 @NodeProcessorTest(TableNodeProcessor.class)
 class TableNodeProcessorTest {
 
+    private static final String CAPTION_STYLE = "color: #7a2518; margin-bottom: .25em; text-align: left";
+
     private Asciidoctor asciidoctor;
     private NodeProcessor nodeProcessor;
     private StringWriter sinkWriter;
@@ -86,7 +88,7 @@ class TableNodeProcessorTest {
         String html = process(content);
 
         assertThat(html)
-            .isEqualTo("<table class=\"bodyTable\"><caption>Table 1. Table caption&#8230;&#8203;or title</caption>" +
+            .isEqualTo("<table class=\"bodyTable\"><caption style=\"" + CAPTION_STYLE + "\">Table 1. Table caption&#8230;&#8203;or title</caption>" +
                 "<tr class=\"a\">" +
                 "<td style=\"text-align: left;\">JRuby</td>" +
                 "<td>Java</td></tr>" +
@@ -119,12 +121,12 @@ class TableNodeProcessorTest {
 
     private static String expectedNoLabelBeginning() {
         return "<table class=\"bodyTable\">" +
-            "<caption>Table caption&#8230;&#8203;or title</caption>";
+            "<caption style=\"" + CAPTION_STYLE + "\">Table caption&#8230;&#8203;or title</caption>";
     }
 
     private static String expectedTableWithoutLabel() {
         return "<table class=\"bodyTable\">" +
-            "<caption>Table caption&#8230;&#8203;or title</caption>" +
+            "<caption style=\"" + CAPTION_STYLE + "\">Table caption&#8230;&#8203;or title</caption>" +
             "<tr class=\"a\">" +
             "<td style=\"text-align: left;\">JRuby</td>" +
             "<td>Java</td></tr>" +

--- a/asciidoctor-parser-doxia-module/src/test/java/org/asciidoctor/maven/site/parser/processors/TableNodeProcessorTest.java
+++ b/asciidoctor-parser-doxia-module/src/test/java/org/asciidoctor/maven/site/parser/processors/TableNodeProcessorTest.java
@@ -36,6 +36,22 @@ class TableNodeProcessorTest {
     private StringWriter sinkWriter;
 
     @Test
+    void should_convert_empty_table() {
+        String content = "= Document tile\n" +
+            "\n" +
+            "\n" +
+            "== Section\n" +
+            "|===\n" +
+            "|===";
+
+        String html = process(content);
+
+        // Header for now is just first row with class=a
+        assertThat(html)
+            .isEmpty();
+    }
+
+    @Test
     void should_convert_table_with_header() {
         String content = documentWithTable(true, noCaption, emptyList());
 

--- a/asciidoctor-parser-doxia-module/src/test/java/org/asciidoctor/maven/site/parser/processors/TableNodeProcessorTest.java
+++ b/asciidoctor-parser-doxia-module/src/test/java/org/asciidoctor/maven/site/parser/processors/TableNodeProcessorTest.java
@@ -14,12 +14,9 @@ import org.asciidoctor.maven.site.parser.processors.test.NodeProcessorTest;
 import org.junit.jupiter.api.Test;
 
 import static java.util.Collections.emptyList;
-import static org.asciidoctor.maven.site.parser.processors.TableNodeProcessorTest.DocumentBuilder.CaptionOptions.disableLabelForTable;
-import static org.asciidoctor.maven.site.parser.processors.TableNodeProcessorTest.DocumentBuilder.CaptionOptions.disableLabelsGlobally;
-import static org.asciidoctor.maven.site.parser.processors.TableNodeProcessorTest.DocumentBuilder.CaptionOptions.noCaption;
-import static org.asciidoctor.maven.site.parser.processors.TableNodeProcessorTest.DocumentBuilder.CaptionOptions.simpleCaption;
+import static org.asciidoctor.maven.site.parser.processors.TableNodeProcessorTest.DocumentBuilder.CaptionOptions.*;
 import static org.asciidoctor.maven.site.parser.processors.TableNodeProcessorTest.DocumentBuilder.documentWithTable;
-import static org.asciidoctor.maven.site.parser.processors.test.StringTestUtils.clean;
+import static org.asciidoctor.maven.site.parser.processors.test.StringTestUtils.removeLineBreaks;
 import static org.assertj.core.api.Assertions.assertThat;
 
 /**
@@ -44,16 +41,16 @@ class TableNodeProcessorTest {
 
         // Header for now is just first row with class=a
         assertThat(html)
-                .isEqualTo("<table class=\"bodyTable\">" +
-                        "<tr class=\"a\">" +
-                        "<th>Name</th>" +
-                        "<th>Language</th></tr>" +
-                        "<tr class=\"b\">" +
-                        "<td style=\"text-align: left;\">JRuby</td>" +
-                        "<td>Java</td></tr>" +
-                        "<tr class=\"a\">" +
-                        "<td style=\"text-align: left;\">Rubinius</td>" +
-                        "<td>Ruby</td></tr></table>");
+            .isEqualTo("<table class=\"bodyTable\">" +
+                "<tr class=\"a\">" +
+                "<th>Name</th>" +
+                "<th>Language</th></tr>" +
+                "<tr class=\"b\">" +
+                "<td style=\"text-align: left;\">JRuby</td>" +
+                "<td>Java</td></tr>" +
+                "<tr class=\"a\">" +
+                "<td style=\"text-align: left;\">Rubinius</td>" +
+                "<td>Ruby</td></tr></table>");
     }
 
     @Test
@@ -63,13 +60,13 @@ class TableNodeProcessorTest {
         String html = process(content);
 
         assertThat(html)
-                .isEqualTo(clean("<table class=\"bodyTable\">" +
-                        "<tr class=\"a\">" +
-                        "<td style=\"text-align: left;\">JRuby</td>" +
-                        "<td>Java</td></tr>" +
-                        "<tr class=\"b\">" +
-                        "<td style=\"text-align: left;\">Rubinius</td>" +
-                        "<td>Ruby</td></tr></table>"));
+            .isEqualTo(removeLineBreaks("<table class=\"bodyTable\">" +
+                "<tr class=\"a\">" +
+                "<td style=\"text-align: left;\">JRuby</td>" +
+                "<td>Java</td></tr>" +
+                "<tr class=\"b\">" +
+                "<td style=\"text-align: left;\">Rubinius</td>" +
+                "<td>Ruby</td></tr></table>"));
     }
 
     @Test
@@ -79,23 +76,23 @@ class TableNodeProcessorTest {
         String html = process(content);
 
         assertThat(html)
-                .isEqualTo(expectedTableWithoutCaption());
+            .isEqualTo(expectedTableWithoutCaption());
     }
 
     @Test
-    void should_convert_table_with_label_and_title() {
+    void should_convert_table_with_caption_and_title() {
         String content = documentWithTable(false, simpleCaption, emptyList());
 
         String html = process(content);
 
         assertThat(html)
-                .isEqualTo("<table class=\"bodyTable\"><caption>Table 1. Table caption&#8230;&#8203;or title</caption>" +
-                        "<tr class=\"a\">" +
-                        "<td style=\"text-align: left;\">JRuby</td>" +
-                        "<td>Java</td></tr>" +
-                        "<tr class=\"b\">" +
-                        "<td style=\"text-align: left;\">Rubinius</td>" +
-                        "<td>Ruby</td></tr></table>");
+            .isEqualTo("<table class=\"bodyTable\"><caption>Table 1. Table caption&#8230;&#8203;or title</caption>" +
+                "<tr class=\"a\">" +
+                "<td style=\"text-align: left;\">JRuby</td>" +
+                "<td>Java</td></tr>" +
+                "<tr class=\"b\">" +
+                "<td style=\"text-align: left;\">Rubinius</td>" +
+                "<td>Ruby</td></tr></table>");
     }
 
     @Test
@@ -105,8 +102,8 @@ class TableNodeProcessorTest {
         String html = process(content);
 
         assertThat(html)
-                .startsWith(expectedNoLabelBeginning())
-                .isEqualTo(expectedTableWithoutLabel());
+            .startsWith(expectedNoLabelBeginning())
+            .isEqualTo(expectedTableWithoutLabel());
     }
 
     @Test
@@ -116,44 +113,46 @@ class TableNodeProcessorTest {
         String html = process(content);
 
         assertThat(html)
-                .startsWith(expectedNoLabelBeginning())
-                .isEqualTo(expectedTableWithoutLabel());
+            .startsWith(expectedNoLabelBeginning())
+            .isEqualTo(expectedTableWithoutLabel());
     }
 
     private static String expectedNoLabelBeginning() {
-        return "<table class=\"bodyTable\"><caption>Table caption&#8230;&#8203;or title</caption>";
+        return "<table class=\"bodyTable\">" +
+            "<caption>Table caption&#8230;&#8203;or title</caption>";
     }
 
     private static String expectedTableWithoutLabel() {
-        return "<table class=\"bodyTable\"><caption>Table caption&#8230;&#8203;or title</caption>" +
-                "<tr class=\"a\">" +
-                "<td style=\"text-align: left;\">JRuby</td>" +
-                "<td>Java</td></tr>" +
-                "<tr class=\"b\">" +
-                "<td style=\"text-align: left;\">Rubinius</td>" +
-                "<td>Ruby</td></tr></table>";
+        return "<table class=\"bodyTable\">" +
+            "<caption>Table caption&#8230;&#8203;or title</caption>" +
+            "<tr class=\"a\">" +
+            "<td style=\"text-align: left;\">JRuby</td>" +
+            "<td>Java</td></tr>" +
+            "<tr class=\"b\">" +
+            "<td style=\"text-align: left;\">Rubinius</td>" +
+            "<td>Ruby</td></tr></table>";
     }
 
     private static String expectedTableWithoutCaption() {
         return "<table class=\"bodyTable\">" +
-                "<tr class=\"a\">" +
-                "<td style=\"text-align: left;\">JRuby</td>" +
-                "<td>Java</td></tr>" +
-                "<tr class=\"b\">" +
-                "<td style=\"text-align: left;\">Rubinius</td>" +
-                "<td>Ruby</td></tr>" +
-                "<tr class=\"a\">" +
-                "<td style=\"text-align: left;\"><strong>Opal</strong></td>" +
-                "<td><em>JavaScript</em></td></tr></table>";
+            "<tr class=\"a\">" +
+            "<td style=\"text-align: left;\">JRuby</td>" +
+            "<td>Java</td></tr>" +
+            "<tr class=\"b\">" +
+            "<td style=\"text-align: left;\">Rubinius</td>" +
+            "<td>Ruby</td></tr>" +
+            "<tr class=\"a\">" +
+            "<td style=\"text-align: left;\"><strong>Opal</strong></td>" +
+            "<td><em>JavaScript</em></td></tr></table>";
     }
 
     static class DocumentBuilder {
 
         static class CaptionOptions {
 
-            final boolean include;
-            final boolean disableForTable;
-            final boolean disableGlobally;
+            final boolean includeTitle;
+            final boolean disableCaptionsForTable;
+            final boolean disableCaptionsGlobally;
 
             static final CaptionOptions noCaption = new CaptionOptions(false, false, false);
             static final CaptionOptions simpleCaption = new CaptionOptions(true, false, false);
@@ -161,36 +160,37 @@ class TableNodeProcessorTest {
             static final CaptionOptions disableLabelsGlobally = new CaptionOptions(true, false, true);
 
             private CaptionOptions(boolean include, boolean disableForTable, boolean disableGlobally) {
-                this.include = include;
-                this.disableForTable = disableForTable;
-                this.disableGlobally = disableGlobally;
+                this.includeTitle = include;
+                this.disableCaptionsForTable = disableForTable;
+                this.disableCaptionsGlobally = disableGlobally;
             }
 
         }
 
-        static String documentWithTable(boolean includeHeaderRow, CaptionOptions captionOptions, List<String> additionalRow) {
+        static String documentWithTable(boolean includeTableHeader, CaptionOptions captionOptions, List<String> additionalRow) {
             return "= Document tile\n" +
-                    (captionOptions.disableGlobally ? ":table-caption!:\n" : "") +
-                    "\n" +
-                    "== Section\n" +
-                    (captionOptions.disableForTable ? "[caption=]\n" : "") +
-                    (captionOptions.include ? ".Table caption...or title\n" : "") +
-                    "|===\n" +
-                    (includeHeaderRow ? "|Name |Language\n\n" : "") +
-                    "|JRuby |Java\n" +
-                    "|Rubinius |Ruby\n" +
-                    (!additionalRow.isEmpty() ? additionalRow.stream().collect(Collectors.joining("|", " |", "")) : "") +
-                    "|===";
+                (captionOptions.disableCaptionsGlobally ? ":table-caption!:\n" : "") +
+                "\n\n" +
+                "== Section\n" +
+                (captionOptions.disableCaptionsForTable ? "[caption=]\n" : "") +
+                (captionOptions.includeTitle ? ".Table caption...or title\n" : "") +
+                "|===\n" +
+                (includeTableHeader ? "|Name |Language\n\n" : "") +
+                "|JRuby |Java\n" +
+                "|Rubinius |Ruby\n" +
+                (!additionalRow.isEmpty() ? additionalRow.stream().collect(Collectors.joining("|", " |", "")) : "") +
+                "|===";
         }
     }
 
     private String process(String content) {
         StructuralNode node = asciidoctor.load(content, Options.builder().build())
-                .findBy(Collections.singletonMap("context", ":table"))
-                .get(0);
+            .findBy(Collections.singletonMap("context", ":table"))
+            .get(0);
 
         nodeProcessor.process(node);
 
-        return clean(sinkWriter.toString());
+        String string = sinkWriter.toString();
+        return removeLineBreaks(string);
     }
 }

--- a/asciidoctor-parser-doxia-module/src/test/java/org/asciidoctor/maven/site/parser/processors/UnorderedListNodeProcessorTest.java
+++ b/asciidoctor-parser-doxia-module/src/test/java/org/asciidoctor/maven/site/parser/processors/UnorderedListNodeProcessorTest.java
@@ -11,7 +11,7 @@ import org.asciidoctor.maven.site.parser.NodeProcessor;
 import org.asciidoctor.maven.site.parser.processors.test.NodeProcessorTest;
 import org.junit.jupiter.api.Test;
 
-import static org.asciidoctor.maven.site.parser.processors.test.StringTestUtils.clean;
+import static org.asciidoctor.maven.site.parser.processors.test.StringTestUtils.removeLineBreaks;
 import static org.assertj.core.api.Assertions.assertThat;
 
 @NodeProcessorTest(UnorderedListNodeProcessor.class)
@@ -83,6 +83,6 @@ class UnorderedListNodeProcessorTest {
 
         nodeProcessor.process(node);
 
-        return clean(sinkWriter.toString());
+        return removeLineBreaks(sinkWriter.toString());
     }
 }

--- a/asciidoctor-parser-doxia-module/src/test/java/org/asciidoctor/maven/site/parser/processors/test/Html.java
+++ b/asciidoctor-parser-doxia-module/src/test/java/org/asciidoctor/maven/site/parser/processors/test/Html.java
@@ -54,8 +54,4 @@ public class Html {
         }
         return String.format("<%1$s style=\"%3$s\">%2$s</%1$s>", element, text, style).trim();
     }
-
-    public static String removeLineBreaks(String html) {
-        return html.replaceAll("(\r)?\n", "");
-    }
 }

--- a/asciidoctor-parser-doxia-module/src/test/java/org/asciidoctor/maven/site/parser/processors/test/Html.java
+++ b/asciidoctor-parser-doxia-module/src/test/java/org/asciidoctor/maven/site/parser/processors/test/Html.java
@@ -16,6 +16,10 @@ public class Html {
         return htmlElement("code", text);
     }
 
+    public static String div(String text) {
+        return htmlElement("div", text);
+    }
+
     public static String ul(String... elements) {
         return htmlElement("ul", String.join("", elements));
     }
@@ -36,6 +40,10 @@ public class Html {
         return htmlElement("dd", text);
     }
 
+    public static String p(String text) {
+        return htmlElement("p", text);
+    }
+
     static String htmlElement(String element, String text) {
         return htmlElement(element, null, text);
     }
@@ -45,5 +53,9 @@ public class Html {
             return String.format("<%1$s>%2$s</%1$s>", element, text).trim();
         }
         return String.format("<%1$s style=\"%3$s\">%2$s</%1$s>", element, text, style).trim();
+    }
+
+    public static String removeLineBreaks(String html) {
+        return html.replaceAll("(\r)?\n", "");
     }
 }

--- a/asciidoctor-parser-doxia-module/src/test/java/org/asciidoctor/maven/site/parser/processors/test/StringTestUtils.java
+++ b/asciidoctor-parser-doxia-module/src/test/java/org/asciidoctor/maven/site/parser/processors/test/StringTestUtils.java
@@ -7,9 +7,8 @@ public class StringTestUtils {
      *
      * @param value string to clean
      */
-    public static String clean(String value) {
-        return value.replaceAll("\r\n", "")
-                .replaceAll("\n", "")
+    public static String removeLineBreaks(String value) {
+        return value.replaceAll("(\r)?\n", "")
                 .trim();
     }
 }

--- a/docs/modules/site-integration/pages/parser-module-setup-and-configuration.adoc
+++ b/docs/modules/site-integration/pages/parser-module-setup-and-configuration.adoc
@@ -189,6 +189,8 @@ NOTE: Unlike in Asciidoctor lists, descriptions are not surrounded by `<p>` and 
 ** Support for numbered lines with `linenums`
 ** Support for AsciiDoc titles
 
+* Examples
+
 * Literal blocks
 * Quotes
 


### PR DESCRIPTION
Still WIP:
* Added support for Example blocks
* Added support for captioned titles in tables, listing, figure, and examples.
- Missing: appendix

Working on examples made me realize the way we traverse the AST won't work.
We did some workaround for lists, making it so sub-blocks are traversed from a dedicated NodeProcessor.
But we can't apply the same for example, because it can contain many other elements. 
:thinking: 

~I will probably merge basic support for example nodes with a paragraph first and then work on the refactoring in another PR. This is experimental after all.~ :point_right: Done and rebased https://github.com/asciidoctor/asciidoctor-maven-plugin/pull/944

**What kind of change does this PR introduce?** (check at least one)
<!-- Update "[ ]" to "[x]" to check a box -->

- [ ] Bugfix
- [x] Feature
- [ ] Documentation
- [ ] Refactor
- [ ] Build improvement
- [ ] Other (please describe)


**What is the goal of this pull request?**


**Are there any alternative ways to implement this?**


**Are there any implications of this pull request? Anything a user must know?**


**Is it related to an existing issue?**
<!-- If Yes, please add a line of the form: `Fixes #Issue` --> 
- [x] Yes
- [ ] No

Fixes #749