### PR TITLE
Bump maven-site-plugin to v3.21.0 + Doxia to v2.0.0

### DIFF
--- a/asciidoctor-converter-doxia-module/src/it/maven-site-plugin/pom.xml
+++ b/asciidoctor-converter-doxia-module/src/it/maven-site-plugin/pom.xml
@@ -28,7 +28,7 @@
             <plugin>
                 <groupId>org.apache.maven.plugins</groupId>
                 <artifactId>maven-site-plugin</artifactId>
-                <version>3.20.0</version>
+                <version>3.21.0</version>
                 <configuration>
                     <asciidoc>
                         <baseDir>${project.basedir}/src/site/asciidoc</baseDir>

--- a/asciidoctor-parser-doxia-module/src/it/maven-site-plugin/pom.xml
+++ b/asciidoctor-parser-doxia-module/src/it/maven-site-plugin/pom.xml
@@ -23,7 +23,7 @@
             <plugin>
                 <groupId>org.apache.maven.plugins</groupId>
                 <artifactId>maven-site-plugin</artifactId>
-                <version>3.20.0</version>
+                <version>3.21.0</version>
                 <configuration>
                     <asciidoc>
                         <baseDir>${project.basedir}/src/site/asciidoc</baseDir>

--- a/pom.xml
+++ b/pom.xml
@@ -71,8 +71,8 @@
         <project.build.sourceEncoding>UTF-8</project.build.sourceEncoding>
         <project.java.version>11</project.java.version>
         <maven.version>3.9.9</maven.version>
-        <doxia.version>2.0.0-M12</doxia.version>
-        <doxia.sitetools.version>2.0.0-M19</doxia.sitetools.version>
+        <doxia.version>2.0.0</doxia.version>
+        <doxia.sitetools.version>2.0.0</doxia.sitetools.version>
         <plexus-component-metadata.version>2.2.0</plexus-component-metadata.version>
         <asciidoctorj.version>3.0.0</asciidoctorj.version>
         <jruby.version>9.4.6.0</jruby.version>


### PR DESCRIPTION
**What kind of change does this PR introduce?** (check at least one)
<!-- Update "[ ]" to "[x]" to check a box -->

- [ ] Bugfix
- [ ] Feature
- [ ] Documentation
- [ ] Refactor
- [x] Build improvement
- [ ] Other (please describe)


**What is the goal of this pull request?**

Bump maven-site-plugin to v3.21.0 + Doxia to v2.0.0.
Doxia is bumped to align with the version used in maven-site-plugin.

**Are there any alternative ways to implement this?**
No

**Are there any implications of this pull request? Anything a user must know?**
No

**Is it related to an existing issue?**
<!-- If Yes, please add a line of the form: `Fixes #Issue` --> 
- [ ] Yes
- [x] No