### PR TITLE
Bump JRuby to latest 9.4.8.0

### DIFF
--- a/.github/dependabot.yml
+++ b/.github/dependabot.yml
@@ -16,7 +16,6 @@ updates:
       prefix: "(main)"
     target-branch: "main"
     ignore:
-      - dependency-name: org.jruby:jruby
       - dependency-name: org.codehaus.plexus:plexus-utils
         update-types:
           - "version-update:semver-major"
@@ -38,7 +37,6 @@ updates:
       prefix: "(v2.2.x)"
     target-branch: "v2.2.x"
     ignore:
-      - dependency-name: org.jruby:jruby
       - dependency-name: org.apache.maven:*
       - dependency-name: org.apache.maven.plugin-tools:*
       - dependency-name: org.apache.maven.doxia:*

--- a/pom.xml
+++ b/pom.xml
@@ -75,7 +75,7 @@
         <doxia.sitetools.version>2.0.0</doxia.sitetools.version>
         <plexus-component-metadata.version>2.2.0</plexus-component-metadata.version>
         <asciidoctorj.version>3.0.0</asciidoctorj.version>
-        <jruby.version>9.4.6.0</jruby.version>
+        <jruby.version>9.4.8.0</jruby.version>
     </properties>
 
     <dependencies>


### PR DESCRIPTION
**What kind of change does this PR introduce?** (check at least one)
<!-- Update "[ ]" to "[x]" to check a box -->

- [ ] Bugfix
- [ ] Feature
- [ ] Documentation
- [ ] Refactor
- [x] Build improvement
- [ ] Other (please describe)


**What is the goal of this pull request?**

Just realized we were ignoring jRuby bumps.
I am removing it, we need to prioritize ease if maintenance before aligning to AsciidoctorJ.
If thanks to the Dependabot bumps we found some incompatibility, the better, we can research and contribute to AsciidoctorJ

**Are there any alternative ways to implement this?**

no

**Are there any implications of this pull request? Anything a user must know?**

no

**Is it related to an existing issue?**
<!-- If Yes, please add a line of the form: `Fixes #Issue` --> 
- [ ] Yes
- [x] No

*Finally, please add a corresponding entry to CHANGELOG.adoc*
