### PR TITLE
(main) Fix resolution of baseDir in site-integration

### DIFF
--- a/CHANGELOG.adoc
+++ b/CHANGELOG.adoc
@@ -15,7 +15,7 @@ For a detailed view of what has changed, refer to the {uri-repo}/commits/main[co
 
 Bug Fixes (Site Modules)::
 
-* Fix calculation of baseDir for Doxia modules (#968)
+* Fix resolution of baseDir for Doxia modules (#968)
 
 == v3.1.0 (2024-10-30)
 

--- a/CHANGELOG.adoc
+++ b/CHANGELOG.adoc
@@ -13,6 +13,9 @@ For a detailed view of what has changed, refer to the {uri-repo}/commits/main[co
 
 == Unreleased
 
+Bug Fixes (Site Modules)::
+
+* Fix calculation of baseDir for Doxia modules (#968)
 
 == v3.1.0 (2024-10-30)
 

--- a/asciidoctor-converter-doxia-module/src/test/java/org/asciidoctor/maven/site/AsciidoctorConverterDoxiaParserTest.java
+++ b/asciidoctor-converter-doxia-module/src/test/java/org/asciidoctor/maven/site/AsciidoctorConverterDoxiaParserTest.java
@@ -3,6 +3,7 @@ package org.asciidoctor.maven.site;
 import java.io.File;
 import java.io.FileNotFoundException;
 import java.io.FileReader;
+import java.io.IOException;
 import java.io.Reader;
 import java.io.StringReader;
 
@@ -15,6 +16,7 @@ import org.codehaus.plexus.util.xml.Xpp3DomBuilder;
 import org.junit.jupiter.api.Test;
 import org.mockito.Mockito;
 
+import static org.asciidoctor.maven.site.AsciidoctorConverterDoxiaParser.ROLE_HINT;
 import static org.assertj.core.api.Assertions.assertThat;
 import static org.assertj.core.api.Assertions.catchThrowable;
 import static org.codehaus.plexus.util.ReflectionUtils.setVariableValueInObject;
@@ -24,10 +26,11 @@ import static org.mockito.Mockito.when;
 class AsciidoctorConverterDoxiaParserTest {
 
     private static final String TEST_DOCS_PATH = "src/test/resources/";
+    private static final String SAMPLE_ASCIIDOC = "sample.asciidoc";
 
     @Test
     void should_convert_html_without_any_configuration() throws FileNotFoundException, ParseException {
-        final File srcAsciidoc = new File(TEST_DOCS_PATH, "sample.asciidoc");
+        final File srcAsciidoc = new File(TEST_DOCS_PATH, SAMPLE_ASCIIDOC);
         final Sink sink = createSinkMock();
 
         AsciidoctorConverterDoxiaParser parser = mockAsciidoctorDoxiaParser();
@@ -35,32 +38,32 @@ class AsciidoctorConverterDoxiaParserTest {
         parser.parse(new FileReader(srcAsciidoc), sink);
 
         assertThat(((TextProviderSink) sink).text)
-                .contains("<h1>Document Title</h1>")
-                .contains("<div class=\"ulist\">")
-                .contains("<div class=\"listingblock\">")
-                .contains("require 'asciidoctor'")
-                .contains("<div class=\"title\">Note</div>");
+            .contains("<h1>Document Title</h1>")
+            .contains("<div class=\"ulist\">")
+            .contains("<div class=\"listingblock\">")
+            .contains("require 'asciidoctor'")
+            .contains("<div class=\"title\">Note</div>");
     }
 
     @Test
     void should_convert_html_with_an_attribute() throws FileNotFoundException, ParseException {
-        final File srcAsciidoc = new File(TEST_DOCS_PATH, "sample.asciidoc");
+        final File srcAsciidoc = new File(TEST_DOCS_PATH, SAMPLE_ASCIIDOC);
         Reader reader = new FileReader(srcAsciidoc);
 
         Sink sink = createSinkMock();
         AsciidoctorConverterDoxiaParser parser = mockAsciidoctorDoxiaParser(
-                "<configuration>\n" +
-                        "  <asciidoc>\n" +
-                        "    <attributes>\n" +
-                        "      <icons>font</icons>\n" +
-                        "    </attributes>\n" +
-                        "  </asciidoc>\n" +
-                        "</configuration>");
+            "<configuration>\n" +
+                "  <asciidoc>\n" +
+                "    <attributes>\n" +
+                "      <icons>font</icons>\n" +
+                "    </attributes>\n" +
+                "  </asciidoc>\n" +
+                "</configuration>");
 
         parser.parse(reader, sink);
 
         assertThat(((TextProviderSink) sink).text)
-                .contains("<i class=\"fa icon-note\" title=\"Note\"></i>");
+            .contains("<i class=\"fa icon-note\" title=\"Note\"></i>");
     }
 
     @Test
@@ -69,18 +72,18 @@ class AsciidoctorConverterDoxiaParserTest {
         final Sink sink = createSinkMock();
 
         AsciidoctorConverterDoxiaParser parser = mockAsciidoctorDoxiaParser(
-                "<configuration>\n" +
-                        "  <asciidoc>\n" +
-                        "    <baseDir>" + new File(srcAsciidoc.getParent()).getAbsolutePath() + "</baseDir>\n" +
-                        "  </asciidoc>\n" +
-                        "</configuration>");
+            "<configuration>\n" +
+                "  <asciidoc>\n" +
+                "    <baseDir>" + new File(srcAsciidoc.getParent()).getAbsolutePath() + "</baseDir>\n" +
+                "  </asciidoc>\n" +
+                "</configuration>");
 
         parser.parse(new FileReader(srcAsciidoc), sink);
 
         // 'include works'
         assertThat(((TextProviderSink) sink).text)
-                .contains("<h1>Include test</h1>")
-                .contains("println \"HelloWorld from Groovy on ${new Date()}\"");
+            .contains("<h1>Include test</h1>")
+            .contains("println \"HelloWorld from Groovy on ${new Date()}\"");
     }
 
     @Test
@@ -89,39 +92,39 @@ class AsciidoctorConverterDoxiaParserTest {
         final Sink sink = createSinkMock();
 
         AsciidoctorConverterDoxiaParser parser = mockAsciidoctorDoxiaParser(
-                "<configuration>\n" +
-                        "  <asciidoc>\n" +
-                        "    <baseDir>" + TEST_DOCS_PATH + "</baseDir>\n" +
-                        "  </asciidoc>\n" +
-                        "</configuration>");
+            "<configuration>\n" +
+                "  <asciidoc>\n" +
+                "    <baseDir>" + TEST_DOCS_PATH + "</baseDir>\n" +
+                "  </asciidoc>\n" +
+                "</configuration>");
 
         parser.parse(new FileReader(srcAsciidoc), sink);
 
         // 'include works'
         assertThat(((TextProviderSink) sink).text)
-                .contains("<h1>Include test</h1>")
-                .contains("println \"HelloWorld from Groovy on ${new Date()}\"");
+            .contains("<h1>Include test</h1>")
+            .contains("println \"HelloWorld from Groovy on ${new Date()}\"");
     }
 
     @Test
     void should_convert_html_with_templateDir_option() throws FileNotFoundException, ParseException {
-        final File srcAsciidoc = new File(TEST_DOCS_PATH, "sample.asciidoc");
+        final File srcAsciidoc = new File(TEST_DOCS_PATH, SAMPLE_ASCIIDOC);
         final Sink sink = createSinkMock();
 
         AsciidoctorConverterDoxiaParser parser = mockAsciidoctorDoxiaParser(
-                "<configuration>\n" +
-                        "  <asciidoc>\n" +
-                        "    <templateDirs>\n" +
-                        "      <dir>" + TEST_DOCS_PATH + "/templates</dir>\n" +
-                        "    </templateDirs>\n" +
-                        "  </asciidoc>\n" +
-                        "</configuration>");
+            "<configuration>\n" +
+                "  <asciidoc>\n" +
+                "    <templateDirs>\n" +
+                "      <dir>" + TEST_DOCS_PATH + "/templates</dir>\n" +
+                "    </templateDirs>\n" +
+                "  </asciidoc>\n" +
+                "</configuration>");
 
         parser.parse(new FileReader(srcAsciidoc), sink);
 
         assertThat(((TextProviderSink) sink).text)
-                .contains("<h1>Document Title</h1>")
-                .contains("<p class=\"custom-template \">");
+            .contains("<h1>Document Title</h1>")
+            .contains("<p class=\"custom-template \">");
     }
 
     @Test
@@ -130,68 +133,92 @@ class AsciidoctorConverterDoxiaParserTest {
         final Sink sink = createSinkMock();
 
         AsciidoctorConverterDoxiaParser parser = mockAsciidoctorDoxiaParser(
-                "<configuration>\n" +
-                        "  <asciidoc>\n" +
-                        "    <baseDir>" + new File(srcAsciidoc.getParent()).getAbsolutePath() + "</baseDir>\n" +
-                        "    <attributes>\n" +
-                        "      <sectnums></sectnums>\n" +
-                        "      <icons>font</icons>\n" +
-                        "      <my-label>Hello World!!</my-label>\n" +
-                        "    </attributes>\n" +
-                        "  </asciidoc>\n" +
-                        "</configuration>");
+            "<configuration>\n" +
+                "  <asciidoc>\n" +
+                "    <baseDir>" + new File(srcAsciidoc.getParent()).getAbsolutePath() + "</baseDir>\n" +
+                "    <attributes>\n" +
+                "      <sectnums></sectnums>\n" +
+                "      <icons>font</icons>\n" +
+                "      <my-label>Hello World!!</my-label>\n" +
+                "    </attributes>\n" +
+                "  </asciidoc>\n" +
+                "</configuration>");
 
         parser.parse(new FileReader(srcAsciidoc), sink);
 
         assertThat(((TextProviderSink) sink).text)
-                .contains("<h1>Include test</h1>")
-                .contains("<h2 id=\"code\">1. Code</h2>")
-                .contains("<h2 id=\"optional_section\">2. Optional section</h2>")
-                .contains("println \"HelloWorld from Groovy on ${new Date()}\"")
-                .contains("Hello World!!")
-                .contains("<i class=\"fa icon-tip\" title=\"Tip\"></i>");
+            .contains("<h1>Include test</h1>")
+            .contains("<h2 id=\"code\">1. Code</h2>")
+            .contains("<h2 id=\"optional_section\">2. Optional section</h2>")
+            .contains("println \"HelloWorld from Groovy on ${new Date()}\"")
+            .contains("Hello World!!")
+            .contains("<i class=\"fa icon-tip\" title=\"Tip\"></i>");
+    }
+
+    @Test
+    void should_convert_html_in_locale_path() throws IOException, ParseException {
+        final String localeSourceDir = TEST_DOCS_PATH + "with-locale/";
+        final File srcAsciidoc = new File(localeSourceDir + "en/" + ROLE_HINT, "sample.adoc");
+        Reader reader = new FileReader(srcAsciidoc);
+
+        Sink sink = createSinkMock();
+        AsciidoctorConverterDoxiaParser parser = mockAsciidoctorDoxiaParser(
+            "<configuration>\n" +
+                "  <siteDirectory>" + localeSourceDir + "</siteDirectory>\n" +
+                "  <locales>en</locales>\n" +
+                "  <asciidoc>\n" +
+                "    <attributes>\n" +
+                "      <icons>font</icons>\n" +
+                "    </attributes>\n" +
+                "  </asciidoc>\n" +
+                "</configuration>");
+
+        parser.parse(reader, sink);
+
+        assertThat(((TextProviderSink) sink).text)
+            .contains("This has been included");
     }
 
     @Test
     void should_process_empty_selfclosing_XML_attributes() throws FileNotFoundException, ParseException {
-        final File srcAsciidoc = new File(TEST_DOCS_PATH, "sample.asciidoc");
+        final File srcAsciidoc = new File(TEST_DOCS_PATH, SAMPLE_ASCIIDOC);
         final Sink sink = createSinkMock();
 
         AsciidoctorConverterDoxiaParser parser = mockAsciidoctorDoxiaParser(
-                "<configuration>\n" +
-                        "  <asciidoc>\n" +
-                        "    <attributes>\n" +
-                        "      <sectnums/>\n" +
-                        "    </attributes>\n" +
-                        "  </asciidoc>\n" +
-                        "</configuration>");
+            "<configuration>\n" +
+                "  <asciidoc>\n" +
+                "    <attributes>\n" +
+                "      <sectnums/>\n" +
+                "    </attributes>\n" +
+                "  </asciidoc>\n" +
+                "</configuration>");
 
         parser.parse(new FileReader(srcAsciidoc), sink);
 
         assertThat(((TextProviderSink) sink).text)
-                .contains("<h2 id=\"id_section_a\">1. Section A</h2>")
-                .contains("<h3 id=\"id_section_a_subsection\">1.1. Section A Subsection</h3>");
+            .contains("<h2 id=\"id_section_a\">1. Section A</h2>")
+            .contains("<h3 id=\"id_section_a_subsection\">1.1. Section A Subsection</h3>");
     }
 
     @Test
     void should_process_empty_value_XML_attributes() throws FileNotFoundException, ParseException {
-        final File srcAsciidoc = new File(TEST_DOCS_PATH, "sample.asciidoc");
+        final File srcAsciidoc = new File(TEST_DOCS_PATH, SAMPLE_ASCIIDOC);
         final Sink sink = createSinkMock();
 
         AsciidoctorConverterDoxiaParser parser = mockAsciidoctorDoxiaParser(
-                "<configuration>\n" +
-                        "  <asciidoc>\n" +
-                        "    <attributes>\n" +
-                        "      <sectnums></sectnums>\n" +
-                        "    </attributes>\n" +
-                        "  </asciidoc>\n" +
-                        "</configuration>");
+            "<configuration>\n" +
+                "  <asciidoc>\n" +
+                "    <attributes>\n" +
+                "      <sectnums></sectnums>\n" +
+                "    </attributes>\n" +
+                "  </asciidoc>\n" +
+                "</configuration>");
 
         parser.parse(new FileReader(srcAsciidoc), sink);
 
         assertThat(((TextProviderSink) sink).text)
-                .contains("<h2 id=\"id_section_a\">1. Section A</h2>")
-                .contains("<h3 id=\"id_section_a_subsection\">1.1. Section A Subsection</h3>");
+            .contains("<h2 id=\"id_section_a\">1. Section A</h2>")
+            .contains("<h3 id=\"id_section_a_subsection\">1.1. Section A Subsection</h3>");
     }
 
     @Test
@@ -200,32 +227,32 @@ class AsciidoctorConverterDoxiaParserTest {
         final Sink sink = createSinkMock();
 
         AsciidoctorConverterDoxiaParser parser = mockAsciidoctorDoxiaParser(
-                "<configuration>\n" +
-                        "  <asciidoc>\n" +
-                        "    <logHandler>\n" +
-                        "      <!-- <outputToConsole>false</outputToConsole> -->\n" +
-                        "      <failIf>\n" +
-                        "        <severity>WARN</severity>\n" +
-                        "      </failIf>\n" +
-                        "    </logHandler>\n" +
-                        "  </asciidoc>\n" +
-                        "</configuration>");
+            "<configuration>\n" +
+                "  <asciidoc>\n" +
+                "    <logHandler>\n" +
+                "      <!-- <outputToConsole>false</outputToConsole> -->\n" +
+                "      <failIf>\n" +
+                "        <severity>WARN</severity>\n" +
+                "      </failIf>\n" +
+                "    </logHandler>\n" +
+                "  </asciidoc>\n" +
+                "</configuration>");
 
         Throwable throwable = catchThrowable(() -> parser.parse(new FileReader(srcAsciidoc), sink));
 
         // 'issues with WARN and ERROR are returned'
         assertThat(throwable)
-                .isInstanceOf(org.apache.maven.doxia.parser.ParseException.class)
-                .hasMessageContaining("Found 4 issue(s) of severity WARN or higher during conversion");
+            .isInstanceOf(org.apache.maven.doxia.parser.ParseException.class)
+            .hasMessageContaining("Found 4 issue(s) of severity WARN or higher during conversion");
     }
 
     @SneakyThrows
     private javax.inject.Provider<MavenProject> createMavenProjectMock(String configuration) {
         MavenProject mockProject = Mockito.mock(MavenProject.class);
         when(mockProject.getBasedir())
-                .thenReturn(new File("."));
+            .thenReturn(new File("."));
         when(mockProject.getGoalConfiguration(anyString(), anyString(), anyString(), anyString()))
-                .thenReturn(configuration != null ? Xpp3DomBuilder.build(new StringReader(configuration)) : null);
+            .thenReturn(configuration != null ? Xpp3DomBuilder.build(new StringReader(configuration)) : null);
 
         return () -> mockProject;
     }

--- a/asciidoctor-converter-doxia-module/src/test/resources/with-locale/en/asciidoc/included.adoc
+++ b/asciidoctor-converter-doxia-module/src/test/resources/with-locale/en/asciidoc/included.adoc
@@ -1,0 +1,3 @@
+== Included section
+
+This has been included.

--- a/asciidoctor-converter-doxia-module/src/test/resources/with-locale/en/asciidoc/sample.adoc
+++ b/asciidoctor-converter-doxia-module/src/test/resources/with-locale/en/asciidoc/sample.adoc
@@ -1,0 +1,5 @@
+= Document Title
+
+== Include
+
+include::included.adoc[]

--- a/asciidoctor-maven-commons/src/main/java/org/asciidoctor/maven/site/SiteBaseDirResolver.java
+++ b/asciidoctor-maven-commons/src/main/java/org/asciidoctor/maven/site/SiteBaseDirResolver.java
@@ -4,6 +4,8 @@ import java.io.File;
 import java.nio.file.Path;
 
 import org.codehaus.plexus.util.xml.Xpp3Dom;
+import org.slf4j.Logger;
+import org.slf4j.LoggerFactory;
 
 /**
  * Calculates the path where the root of the sources are located based on the
@@ -14,6 +16,8 @@ import org.codehaus.plexus.util.xml.Xpp3Dom;
  * @since 3.1.1
  */
 public class SiteBaseDirResolver {
+
+    private static final Logger logger = LoggerFactory.getLogger(SiteBaseDirResolver.class);
 
     public static File resolveBaseDir(File mavenBaseDir, Xpp3Dom siteConfig) {
         final String siteDirectory = resolveSiteDirectory(siteConfig);
@@ -47,8 +51,11 @@ public class SiteBaseDirResolver {
         if (siteConfig != null) {
             final Xpp3Dom locales = siteConfig.getChild("locales");
             if (locales != null) {
-                // For now,2 we support 1 locale
+                // We can support 1 locale: https://issues.apache.org/jira/browse/DOXIA-755
                 String[] split = locales.getValue().split(",");
+                if (split.length > 0) {
+                    logger.warn("Multiple locales found: {}, this is not supported. Configure multiple plugin executions instead.", locales.getValue());
+                }
                 return split[0];
             }
         }

--- a/asciidoctor-maven-commons/src/main/java/org/asciidoctor/maven/site/SiteBaseDirResolver.java
+++ b/asciidoctor-maven-commons/src/main/java/org/asciidoctor/maven/site/SiteBaseDirResolver.java
@@ -1,0 +1,64 @@
+package org.asciidoctor.maven.site;
+
+import java.io.File;
+import java.nio.file.Path;
+
+import org.codehaus.plexus.util.xml.Xpp3Dom;
+
+/**
+ * Calculates the path where the root of the sources are located based on the
+ * maven-site-plugin configuration.
+ * Not to confuse with Asciidoctor's baseDir.
+ *
+ * @author abelsromero
+ * @since 3.1.1
+ */
+public class SiteBaseDirResolver {
+
+    public static File resolveBaseDir(File mavenBaseDir, Xpp3Dom siteConfig) {
+        final String siteDirectory = resolveSiteDirectory(siteConfig);
+        final String locale = resolveLocale(siteConfig);
+
+        final Path path = Path.of(mavenBaseDir.getPath());
+
+        if (siteDirectory != null && locale != null)
+            return normalize(path, siteDirectory, locale);
+
+        if (siteDirectory != null)
+            return normalize(path, siteDirectory);
+
+        if (locale != null)
+            return normalize(path, "src/site", locale);
+
+        return normalize(path, "src/site");
+    }
+
+    private static String resolveSiteDirectory(Xpp3Dom siteConfig) {
+        if (siteConfig != null) {
+            Xpp3Dom siteDirectoryNode = siteConfig.getChild("siteDirectory");
+            if (siteDirectoryNode != null) {
+                return siteDirectoryNode.getValue();
+            }
+        }
+        return null;
+    }
+
+    private static String resolveLocale(Xpp3Dom siteConfig) {
+        if (siteConfig != null) {
+            final Xpp3Dom locales = siteConfig.getChild("locales");
+            if (locales != null) {
+                // For now,2 we support 1 locale
+                String[] split = locales.getValue().split(",");
+                return split[0];
+            }
+        }
+        return null;
+    }
+
+    private static File normalize(Path path, String... other) {
+        for (String value : other)
+            path = path.resolve(value);
+
+        return path.normalize().toFile();
+    }
+}

--- a/asciidoctor-maven-commons/src/test/java/org/asciidoctor/maven/site/SiteBaseDirResolverTest.java
+++ b/asciidoctor-maven-commons/src/test/java/org/asciidoctor/maven/site/SiteBaseDirResolverTest.java
@@ -2,20 +2,18 @@ package org.asciidoctor.maven.site;
 
 import java.io.File;
 import java.io.StringReader;
+import java.util.Arrays;
 import java.util.Map;
 import java.util.stream.Collectors;
 
 import lombok.SneakyThrows;
-import org.apache.maven.project.MavenProject;
 import org.codehaus.plexus.util.xml.Xpp3Dom;
 import org.codehaus.plexus.util.xml.Xpp3DomBuilder;
 import org.junit.jupiter.api.Test;
 import org.junit.jupiter.params.ParameterizedTest;
 import org.junit.jupiter.params.provider.ValueSource;
-import org.mockito.Mockito;
 
 import static org.assertj.core.api.Assertions.assertThat;
-import static org.mockito.Mockito.when;
 
 class SiteBaseDirResolverTest {
 
@@ -28,7 +26,7 @@ class SiteBaseDirResolverTest {
         SiteBaseDirResolver resolver = new SiteBaseDirResolver();
         File result = resolver.resolveBaseDir(BASE_DIR, siteConfiguration);
 
-        assertThat(result.toString()).isEqualTo("src/site");
+        assertThat(result.toString()).isEqualTo(path("src", "site"));
     }
 
     @ParameterizedTest
@@ -40,7 +38,7 @@ class SiteBaseDirResolverTest {
         SiteBaseDirResolver resolver = new SiteBaseDirResolver();
         File result = resolver.resolveBaseDir(new File(mavenBaseDir), siteConfiguration);
 
-        assertThat(result.toString()).isEqualTo(mavenBaseDir.equals(".") ? "my-src/my-site" : "something/my-src/my-site");
+        assertThat(result.toString()).isEqualTo(mavenBaseDir.equals(".") ? path("my-src", "my-site") : path("something", "my-src", "my-site"));
     }
 
     @Test
@@ -51,7 +49,7 @@ class SiteBaseDirResolverTest {
         SiteBaseDirResolver resolver = new SiteBaseDirResolver();
         File result = resolver.resolveBaseDir(BASE_DIR, siteConfiguration);
 
-        assertThat(result.toString()).isEqualTo("src/site/es");
+        assertThat(result.toString()).isEqualTo(path("src", "site", "es"));
     }
 
     @Test
@@ -66,14 +64,7 @@ class SiteBaseDirResolverTest {
         SiteBaseDirResolver resolver = new SiteBaseDirResolver();
         File result = resolver.resolveBaseDir(new File("some"), siteConfiguration);
 
-        assertThat(result.toString()).isEqualTo("some/my-src/my-site/es");
-    }
-
-    @SneakyThrows
-    private javax.inject.Provider<MavenProject> createMavenProjectMock() {
-        MavenProject mockProject = Mockito.mock(MavenProject.class);
-        when(mockProject.getBasedir()).thenReturn(new File("."));
-        return () -> mockProject;
+        assertThat(result.toString()).isEqualTo(path("some", "my-src", "my-site", "es"));
     }
 
     @SneakyThrows
@@ -83,6 +74,10 @@ class SiteBaseDirResolverTest {
             .map(k -> String.format("<%1$s>%2$s</%1$s>", k, config.get(k)))
             .collect(Collectors.joining());
         return Xpp3DomBuilder.build(new StringReader(String.format("<configuration>%s</configuration>", configurationsXml)));
+    }
+
+    private static String path(String... parts) {
+        return Arrays.stream(parts).collect(Collectors.joining(File.separator));
     }
 
 }

--- a/asciidoctor-maven-commons/src/test/java/org/asciidoctor/maven/site/SiteBaseDirResolverTest.java
+++ b/asciidoctor-maven-commons/src/test/java/org/asciidoctor/maven/site/SiteBaseDirResolverTest.java
@@ -1,0 +1,88 @@
+package org.asciidoctor.maven.site;
+
+import java.io.File;
+import java.io.StringReader;
+import java.util.Map;
+import java.util.stream.Collectors;
+
+import lombok.SneakyThrows;
+import org.apache.maven.project.MavenProject;
+import org.codehaus.plexus.util.xml.Xpp3Dom;
+import org.codehaus.plexus.util.xml.Xpp3DomBuilder;
+import org.junit.jupiter.api.Test;
+import org.junit.jupiter.params.ParameterizedTest;
+import org.junit.jupiter.params.provider.ValueSource;
+import org.mockito.Mockito;
+
+import static org.assertj.core.api.Assertions.assertThat;
+import static org.mockito.Mockito.when;
+
+class SiteBaseDirResolverTest {
+
+    private static final File BASE_DIR = new File(".");
+
+    @Test
+    void should_resolve_default_value() {
+        final Xpp3Dom siteConfiguration = buildXpp3Dom(Map.of());
+
+        SiteBaseDirResolver resolver = new SiteBaseDirResolver();
+        File result = resolver.resolveBaseDir(BASE_DIR, siteConfiguration);
+
+        assertThat(result.toString()).isEqualTo("src/site");
+    }
+
+    @ParameterizedTest
+    @ValueSource(strings = {".", "something", "something/"})
+    void should_resolve_from_siteDirectory(String mavenBaseDir) {
+        final String siteDirectory = "./my-src/my-site";
+        final Xpp3Dom siteConfiguration = buildXpp3Dom(Map.of("siteDirectory", siteDirectory));
+
+        SiteBaseDirResolver resolver = new SiteBaseDirResolver();
+        File result = resolver.resolveBaseDir(new File(mavenBaseDir), siteConfiguration);
+
+        assertThat(result.toString()).isEqualTo(mavenBaseDir.equals(".") ? "my-src/my-site" : "something/my-src/my-site");
+    }
+
+    @Test
+    void should_resolve_from_locale() {
+        final String locale = "es";
+        final Xpp3Dom siteConfiguration = buildXpp3Dom(Map.of("locales", locale));
+
+        SiteBaseDirResolver resolver = new SiteBaseDirResolver();
+        File result = resolver.resolveBaseDir(BASE_DIR, siteConfiguration);
+
+        assertThat(result.toString()).isEqualTo("src/site/es");
+    }
+
+    @Test
+    void should_resolve_from_siteDirectory_and_locale() {
+        final String siteDirectory = "./my-src/my-site";
+        final String locale = "es";
+        final Xpp3Dom siteConfiguration = buildXpp3Dom(Map.of(
+            "siteDirectory", siteDirectory,
+            "locales", locale
+        ));
+
+        SiteBaseDirResolver resolver = new SiteBaseDirResolver();
+        File result = resolver.resolveBaseDir(new File("some"), siteConfiguration);
+
+        assertThat(result.toString()).isEqualTo("some/my-src/my-site/es");
+    }
+
+    @SneakyThrows
+    private javax.inject.Provider<MavenProject> createMavenProjectMock() {
+        MavenProject mockProject = Mockito.mock(MavenProject.class);
+        when(mockProject.getBasedir()).thenReturn(new File("."));
+        return () -> mockProject;
+    }
+
+    @SneakyThrows
+    private static Xpp3Dom buildXpp3Dom(Map<String, String> config) {
+        String configurationsXml = config.keySet()
+            .stream()
+            .map(k -> String.format("<%1$s>%2$s</%1$s>", k, config.get(k)))
+            .collect(Collectors.joining());
+        return Xpp3DomBuilder.build(new StringReader(String.format("<configuration>%s</configuration>", configurationsXml)));
+    }
+
+}

--- a/asciidoctor-parser-doxia-module/src/main/java/org/asciidoctor/maven/site/parser/AsciidoctorAstDoxiaParser.java
+++ b/asciidoctor-parser-doxia-module/src/main/java/org/asciidoctor/maven/site/parser/AsciidoctorAstDoxiaParser.java
@@ -5,7 +5,6 @@ import javax.inject.Provider;
 import java.io.File;
 import java.io.IOException;
 import java.io.Reader;
-import java.util.List;
 import java.util.logging.Logger;
 
 import org.apache.maven.doxia.parser.AbstractTextParser;
@@ -30,13 +29,13 @@ import org.asciidoctor.maven.site.HeaderMetadata;
 import org.asciidoctor.maven.site.SiteConversionConfiguration;
 import org.asciidoctor.maven.site.SiteConversionConfigurationParser;
 import org.asciidoctor.maven.site.SiteLogHandlerDeserializer;
-import org.asciidoctor.maven.site.parser.processors.DescriptionListNodeProcessor;
 import org.codehaus.plexus.component.annotations.Component;
 import org.codehaus.plexus.util.IOUtil;
 import org.codehaus.plexus.util.xml.Xpp3Dom;
 import org.slf4j.LoggerFactory;
 
 import static org.asciidoctor.maven.commons.StringUtils.isNotBlank;
+import static org.asciidoctor.maven.site.SiteBaseDirResolver.resolveBaseDir;
 
 /**
  * This class is used by <a href="https://maven.apache.org/doxia/overview.html">the Doxia framework</a>
@@ -76,7 +75,7 @@ public class AsciidoctorAstDoxiaParser extends AbstractTextParser {
 
         final MavenProject project = mavenProjectProvider.get();
         final Xpp3Dom siteConfig = getSiteConfig(project);
-        final File siteDirectory = resolveSiteDirectory(project, siteConfig);
+        final File siteDirectory = resolveBaseDir(project.getBasedir(), siteConfig);
 
         // Doxia handles a single instance of this class and invokes it multiple times.
         // We need to ensure certain elements are initialized only once to avoid errors.
@@ -138,17 +137,6 @@ public class AsciidoctorAstDoxiaParser extends AbstractTextParser {
 
     protected Xpp3Dom getSiteConfig(MavenProject project) {
         return project.getGoalConfiguration("org.apache.maven.plugins", "maven-site-plugin", "site", "site");
-    }
-
-    protected File resolveSiteDirectory(MavenProject project, Xpp3Dom siteConfig) {
-        File siteDirectory = new File(project.getBasedir(), "src/site");
-        if (siteConfig != null) {
-            Xpp3Dom siteDirectoryNode = siteConfig.getChild("siteDirectory");
-            if (siteDirectoryNode != null) {
-                siteDirectory = new File(siteDirectoryNode.getValue());
-            }
-        }
-        return siteDirectory;
     }
 
     protected OptionsBuilder defaultOptions(File siteDirectory) {

--- a/asciidoctor-parser-doxia-module/src/test/java/org/asciidoctor/maven/site/parser/AsciidoctorAstDoxiaParserTest.java
+++ b/asciidoctor-parser-doxia-module/src/test/java/org/asciidoctor/maven/site/parser/AsciidoctorAstDoxiaParserTest.java
@@ -3,6 +3,7 @@ package org.asciidoctor.maven.site.parser;
 import java.io.File;
 import java.io.FileNotFoundException;
 import java.io.FileReader;
+import java.io.IOException;
 import java.io.StringReader;
 import java.io.StringWriter;
 
@@ -16,6 +17,7 @@ import org.junit.jupiter.api.BeforeEach;
 import org.junit.jupiter.api.Test;
 import org.mockito.Mockito;
 
+import static org.asciidoctor.maven.site.parser.AsciidoctorAstDoxiaParser.ROLE_HINT;
 import static org.asciidoctor.maven.site.parser.AsciidoctorAstDoxiaParserTest.TestMocks.mockAsciidoctorDoxiaParser;
 import static org.asciidoctor.maven.site.parser.processors.test.ReflectionUtils.extractField;
 import static org.asciidoctor.maven.site.parser.processors.test.StringTestUtils.removeLineBreaks;
@@ -48,45 +50,67 @@ class AsciidoctorAstDoxiaParserTest {
         String result = parse(parser, srcAsciidoc);
 
         assertThat(result)
-                .isEqualTo("<h1>Document Title</h1><p>Preamble paragraph.</p>" +
-                        "<div>"+
-                        "<h2><a id=\"id_section_a\"></a>Section A</h2>" +
-                        "<p><strong>Section A</strong> paragraph.</p>" +
-                        "<div>"+
-                        "<h3><a id=\"id_section_a_subsection\"></a>Section A Subsection</h3>" +
-                        "<p><strong>Section A</strong> 'subsection' paragraph.</p>" +
-                        "</div>"+
-                        "</div>"+
-                        "<div>"+
-                        "<h2><a id=\"id_section_b\"></a>Section B</h2>" +
-                        "<p><strong>Section B</strong> paragraph.</p>" +
-                        "<ul>" +
-                        "<li>Item 1</li>" +
-                        "<li>Item 2</li>" +
-                        "<li>Item 3</li></ul>" +
-                        "<div class=\"source\"><pre class=\"prettyprint\"><code>require 'asciidoctor'</code></pre></div>" +
-                        "</div>");
+            .isEqualTo("<h1>Document Title</h1><p>Preamble paragraph.</p>" +
+                "<div>" +
+                "<h2><a id=\"id_section_a\"></a>Section A</h2>" +
+                "<p><strong>Section A</strong> paragraph.</p>" +
+                "<div>" +
+                "<h3><a id=\"id_section_a_subsection\"></a>Section A Subsection</h3>" +
+                "<p><strong>Section A</strong> 'subsection' paragraph.</p>" +
+                "</div>" +
+                "</div>" +
+                "<div>" +
+                "<h2><a id=\"id_section_b\"></a>Section B</h2>" +
+                "<p><strong>Section B</strong> paragraph.</p>" +
+                "<ul>" +
+                "<li>Item 1</li>" +
+                "<li>Item 2</li>" +
+                "<li>Item 3</li></ul>" +
+                "<div class=\"source\"><pre class=\"prettyprint\"><code>require 'asciidoctor'</code></pre></div>" +
+                "</div>");
     }
 
     @Test
     void should_convert_html_with_an_attribute() throws ParseException {
         final String source = "= Document Title\n\n" +
-                "== Section A\n\n" +
-                "My attribute value is {custom-attribute}.\n";
+            "== Section A\n\n" +
+            "My attribute value is {custom-attribute}.\n";
 
         AsciidoctorAstDoxiaParser parser = mockAsciidoctorDoxiaParser(
-                "<configuration>\n" +
-                        "  <asciidoc>\n" +
-                        "    <attributes>\n" +
-                        "      <custom-attribute>a_value</custom-attribute>\n" +
-                        "    </attributes>\n" +
-                        "  </asciidoc>\n" +
-                        "</configuration>");
+            "<configuration>\n" +
+                "  <asciidoc>\n" +
+                "    <attributes>\n" +
+                "      <custom-attribute>a_value</custom-attribute>\n" +
+                "    </attributes>\n" +
+                "  </asciidoc>\n" +
+                "</configuration>");
 
         String result = parse(parser, source);
 
         assertThat(result)
-                .contains("<p>My attribute value is a_value.</p>");
+            .contains("<p>My attribute value is a_value.</p>");
+    }
+
+    @Test
+    void should_convert_html_in_locale_path() throws IOException, ParseException {
+        final String localeSourceDir = TEST_DOCS_PATH + "with-locale/";
+        final File srcAsciidoc = new File(localeSourceDir + "en/" + ROLE_HINT, "sample.adoc");
+
+        AsciidoctorAstDoxiaParser parser = mockAsciidoctorDoxiaParser(
+            "<configuration>\n" +
+                "  <siteDirectory>" + localeSourceDir + "</siteDirectory>\n" +
+                "  <locales>en</locales>\n" +
+                "  <asciidoc>\n" +
+                "    <attributes>\n" +
+                "      <icons>font</icons>\n" +
+                "    </attributes>\n" +
+                "  </asciidoc>\n" +
+                "</configuration>");
+
+        String result = parse(parser, srcAsciidoc);
+
+        assertThat(result)
+            .contains("This has been included");
     }
 
     @Test
@@ -94,21 +118,21 @@ class AsciidoctorAstDoxiaParserTest {
         final String source = sectionsSample();
 
         AsciidoctorAstDoxiaParser parser = mockAsciidoctorDoxiaParser(
-                "<configuration>\n" +
-                        "  <asciidoc>\n" +
-                        "    <attributes>\n" +
-                        "      <sectnums/>\n" +
-                        "    </attributes>\n" +
-                        "  </asciidoc>\n" +
-                        "</configuration>");
+            "<configuration>\n" +
+                "  <asciidoc>\n" +
+                "    <attributes>\n" +
+                "      <sectnums/>\n" +
+                "    </attributes>\n" +
+                "  </asciidoc>\n" +
+                "</configuration>");
 
         String result = parse(parser, source);
 
         assertThat(result)
-                .contains("</a>1. Section A</h2>")
-                .contains("</a>1.1. Section A Subsection</h3>")
-                .contains("</a>2. Section B</h2>")
-                .contains("</a>2.1. Section B Subsection</h3>");
+            .contains("</a>1. Section A</h2>")
+            .contains("</a>1.1. Section A Subsection</h3>")
+            .contains("</a>2. Section B</h2>")
+            .contains("</a>2.1. Section B Subsection</h3>");
     }
 
     @Test
@@ -116,22 +140,22 @@ class AsciidoctorAstDoxiaParserTest {
         final String source = sectionsSample();
 
         AsciidoctorAstDoxiaParser parser = mockAsciidoctorDoxiaParser(
-                "<configuration>\n" +
-                        "  <asciidoc>\n" +
-                        "    <attributes>\n" +
-                        "      <sectnums/>\n" +
-                        "      <sectnumlevels>1</sectnumlevels>\n" +
-                        "    </attributes>\n" +
-                        "  </asciidoc>\n" +
-                        "</configuration>");
+            "<configuration>\n" +
+                "  <asciidoc>\n" +
+                "    <attributes>\n" +
+                "      <sectnums/>\n" +
+                "      <sectnumlevels>1</sectnumlevels>\n" +
+                "    </attributes>\n" +
+                "  </asciidoc>\n" +
+                "</configuration>");
 
         String result = parse(parser, source);
 
         assertThat(result)
-                .contains("</a>1. Section A</h2>")
-                .contains("</a>Section A Subsection</h3>")
-                .contains("</a>2. Section B</h2>")
-                .contains("</a>Section B Subsection</h3>");
+            .contains("</a>1. Section A</h2>")
+            .contains("</a>Section A Subsection</h3>")
+            .contains("</a>2. Section B</h2>")
+            .contains("</a>Section B Subsection</h3>");
     }
 
     @Test
@@ -139,58 +163,58 @@ class AsciidoctorAstDoxiaParserTest {
         final String source = sectionsSample();
 
         AsciidoctorAstDoxiaParser parser = mockAsciidoctorDoxiaParser(
-                "<configuration>\n" +
-                        "  <asciidoc>\n" +
-                        "    <attributes>\n" +
-                        "      <sectnums></sectnums>\n" +
-                        "    </attributes>\n" +
-                        "  </asciidoc>\n" +
-                        "</configuration>");
+            "<configuration>\n" +
+                "  <asciidoc>\n" +
+                "    <attributes>\n" +
+                "      <sectnums></sectnums>\n" +
+                "    </attributes>\n" +
+                "  </asciidoc>\n" +
+                "</configuration>");
 
         String result = parse(parser, source);
 
         assertThat(result)
-                .contains("</a>1. Section A</h2>")
-                .contains("</a>1.1. Section A Subsection</h3>")
-                .contains("</a>2. Section B</h2>")
-                .contains("</a>2.1. Section B Subsection</h3>");
+            .contains("</a>1. Section A</h2>")
+            .contains("</a>1.1. Section A Subsection</h3>")
+            .contains("</a>2. Section B</h2>")
+            .contains("</a>2.1. Section B Subsection</h3>");
     }
 
     private static String sectionsSample() {
         return "= Document Title\n\n" +
-                "== Section A\n\n" +
-                "Section A paragraph.\n\n" +
-                "=== Section A Subsection\n\n" +
-                "Section A 'subsection' paragraph.\n\n" +
-                "== Section B\n\n" +
-                "*Section B* paragraph.\n\n" +
-                "=== Section B Subsection\n\n" +
-                "Section B 'subsection' paragraph.\n\n";
+            "== Section A\n\n" +
+            "Section A paragraph.\n\n" +
+            "=== Section A Subsection\n\n" +
+            "Section A 'subsection' paragraph.\n\n" +
+            "== Section B\n\n" +
+            "*Section B* paragraph.\n\n" +
+            "=== Section B Subsection\n\n" +
+            "Section B 'subsection' paragraph.\n\n";
     }
 
     @Test
     void should_fail_when_logHandler_failIf_is_WARNING() {
         final String source = "= My Document\n\n" +
-                "include::unexistingdoc.adoc[]\n\n" +
-                "include::unexistingdoc.adoc[]";
+            "include::unexistingdoc.adoc[]\n\n" +
+            "include::unexistingdoc.adoc[]";
 
         AsciidoctorAstDoxiaParser parser = mockAsciidoctorDoxiaParser(
-                "<configuration>\n" +
-                        "  <asciidoc>\n" +
-                        "    <logHandler>\n" +
-                        "      <failIf>\n" +
-                        "        <severity>WARN</severity>\n" +
-                        "      </failIf>\n" +
-                        "    </logHandler>\n" +
-                        "  </asciidoc>\n" +
-                        "</configuration>");
+            "<configuration>\n" +
+                "  <asciidoc>\n" +
+                "    <logHandler>\n" +
+                "      <failIf>\n" +
+                "        <severity>WARN</severity>\n" +
+                "      </failIf>\n" +
+                "    </logHandler>\n" +
+                "  </asciidoc>\n" +
+                "</configuration>");
 
         Throwable throwable = catchThrowable(() -> parser.parse(new StringReader(source), sink));
 
         // 'issues with WARN and ERROR are returned'
         assertThat(throwable)
-                .isInstanceOf(ParseException.class)
-                .hasMessageContaining("Found 2 issue(s) of severity WARN or higher during conversion");
+            .isInstanceOf(ParseException.class)
+            .hasMessageContaining("Found 2 issue(s) of severity WARN or higher during conversion");
     }
 
     private String parse(AbstractTextParser parser, File source) throws FileNotFoundException, ParseException {
@@ -208,9 +232,9 @@ class AsciidoctorAstDoxiaParserTest {
         static javax.inject.Provider<MavenProject> createMavenProjectMock(String configuration) {
             MavenProject mockProject = Mockito.mock(MavenProject.class);
             when(mockProject.getBasedir())
-                    .thenReturn(new File("."));
+                .thenReturn(new File("."));
             when(mockProject.getGoalConfiguration(anyString(), anyString(), anyString(), anyString()))
-                    .thenReturn(configuration != null ? Xpp3DomBuilder.build(new StringReader(configuration)) : null);
+                .thenReturn(configuration != null ? Xpp3DomBuilder.build(new StringReader(configuration)) : null);
 
             return () -> mockProject;
         }

--- a/asciidoctor-parser-doxia-module/src/test/resources/with-locale/en/asciidoc/included.adoc
+++ b/asciidoctor-parser-doxia-module/src/test/resources/with-locale/en/asciidoc/included.adoc
@@ -1,0 +1,3 @@
+== Included section
+
+This has been included.

--- a/asciidoctor-parser-doxia-module/src/test/resources/with-locale/en/asciidoc/sample.adoc
+++ b/asciidoctor-parser-doxia-module/src/test/resources/with-locale/en/asciidoc/sample.adoc
@@ -1,0 +1,5 @@
+= Document Title
+
+== Include
+
+include::included.adoc[]


### PR DESCRIPTION
**What kind of change does this PR introduce?** (check at least one)
<!-- Update "[ ]" to "[x]" to check a box -->

- [x] Bugfix
- [ ] Feature
- [ ] Documentation
- [ ] Refactor
- [ ] Build improvement
- [ ] Other (please describe)


**What is the goal of this pull request?**

The calculation now takes into consideration locale and siteDirectory correctly. All of this when user does not explicitly sets `baseDir`  in the 

**Are there any alternative ways to implement this?**

For better compatibility with older maven-site plugin we could have tried some reflection to "guess" the version, but this adds "IMO" unnecessary complexity. Users should be incentivized to upgrade. 

**Are there any implications of this pull request? Anything a user must know?**

1. This is done for conventions in maven-site v3.20.+
Users with older versions should upgrade or avoid using locales. As a workaround, multiple executions with siteDirectory can be configured.
2. Currently we support setting 1 locale, when more than one are present, the first one will be used since the Doxia parent component does not report which one is in use :shrug: 

**Is it related to an existing issue?**
<!-- If Yes, please add a line of the form: `Fixes #Issue` --> 
- [x] Yes
- [ ] No

*Finally, please add a corresponding entry to CHANGELOG.adoc*

Fixes #968
