### PR TITLE
Add failFast option to allow displaying all errors in build

### DIFF
--- a/CHANGELOG.adoc
+++ b/CHANGELOG.adoc
@@ -13,6 +13,9 @@ For a detailed view of what has changed, refer to the {uri-repo}/commits/main[co
 
 == Unreleased
 
+Improvements (Maven Plugin)::
+
+ * Add failFast option to allow displaying all errors in build (#1032)
 
 == v3.1.1 (2024-11-14)
 

--- a/CHANGELOG.adoc
+++ b/CHANGELOG.adoc
@@ -13,9 +13,9 @@ For a detailed view of what has changed, refer to the {uri-repo}/commits/main[co
 
 == Unreleased
 
-Improvements (Maven Plugin)::
+Improvements (for all modules)::
 
- * Add failFast option to allow displaying all errors in build (#1032)
+ * Add failFast option to logHandler to allow displaying all errors in build (#1032)
 
 == v3.1.1 (2024-11-14)
 

--- a/asciidoctor-maven-commons/src/main/java/org/asciidoctor/maven/log/CapturedLogRecord.java
+++ b/asciidoctor-maven-commons/src/main/java/org/asciidoctor/maven/log/CapturedLogRecord.java
@@ -1,0 +1,66 @@
+package org.asciidoctor.maven.log;
+
+import java.io.File;
+import java.util.Optional;
+
+import org.asciidoctor.ast.Cursor;
+import org.asciidoctor.log.LogRecord;
+
+/**
+ * {@link LogRecord} proxy that allows capturing the source file being
+ * processed.
+ * Important: the {@link #sourceFile} and the actual source where an error is present
+ * may not be the same. For example if the source is being included.
+ *
+ * @since 3.1.2
+ */
+final class CapturedLogRecord extends LogRecord {
+
+    private final File sourceFile;
+
+    CapturedLogRecord(LogRecord record, File sourceFile) {
+        super(record.getSeverity(), record.getCursor(), record.getMessage(), record.getSourceFileName(), record.getSourceMethodName());
+        this.sourceFile = sourceFile;
+    }
+
+    public Cursor getCursor() {
+        if (sourceFile == null)
+            return null;
+
+        return Optional.ofNullable(super.getCursor())
+            .orElse(new FileCursor(sourceFile));
+    }
+
+    public File getSourceFile() {
+        return sourceFile;
+    }
+
+    class FileCursor implements Cursor {
+
+        private final File file;
+
+        public FileCursor(File file) {
+            this.file = file;
+        }
+
+        @Override
+        public int getLineNumber() {
+            return 0;
+        }
+
+        @Override
+        public String getPath() {
+            return file.getName();
+        }
+
+        @Override
+        public String getDir() {
+            return file.getParent();
+        }
+
+        @Override
+        public String getFile() {
+            return file.getAbsolutePath();
+        }
+    }
+}

--- a/asciidoctor-maven-commons/src/main/java/org/asciidoctor/maven/log/CapturedLogRecord.java
+++ b/asciidoctor-maven-commons/src/main/java/org/asciidoctor/maven/log/CapturedLogRecord.java
@@ -11,7 +11,7 @@ import org.asciidoctor.log.LogRecord;
  * Important: the {@link #sourceFile} and the actual source where an error is present
  * may not be the same. For example if the source is being included.
  *
- * @since 3.1.2
+ * @since 3.2.0
  */
 final class CapturedLogRecord extends LogRecord {
 

--- a/asciidoctor-maven-commons/src/main/java/org/asciidoctor/maven/log/CapturedLogRecord.java
+++ b/asciidoctor-maven-commons/src/main/java/org/asciidoctor/maven/log/CapturedLogRecord.java
@@ -1,7 +1,6 @@
 package org.asciidoctor.maven.log;
 
 import java.io.File;
-import java.util.Optional;
 
 import org.asciidoctor.ast.Cursor;
 import org.asciidoctor.log.LogRecord;
@@ -24,11 +23,13 @@ final class CapturedLogRecord extends LogRecord {
     }
 
     public Cursor getCursor() {
-        if (sourceFile == null)
-            return null;
-
-        return Optional.ofNullable(super.getCursor())
-            .orElse(new FileCursor(sourceFile));
+        if (super.getCursor() != null) {
+            return super.getCursor();
+        }
+        if (sourceFile != null) {
+            return new FileCursor(sourceFile);
+        }
+        return null;
     }
 
     public File getSourceFile() {

--- a/asciidoctor-maven-commons/src/main/java/org/asciidoctor/maven/log/LogHandler.java
+++ b/asciidoctor-maven-commons/src/main/java/org/asciidoctor/maven/log/LogHandler.java
@@ -11,9 +11,14 @@ import static org.asciidoctor.maven.commons.StringUtils.isNotBlank;
  */
 public class LogHandler {
 
-    private boolean outputToConsole;
+    private Boolean outputToConsole;
     private FailIf failIf;
     private Boolean failFast;
+
+    public LogHandler() {
+        outputToConsole = Boolean.TRUE;
+        failFast = Boolean.TRUE;
+    }
 
     public Boolean getOutputToConsole() {
         return outputToConsole;

--- a/asciidoctor-maven-commons/src/main/java/org/asciidoctor/maven/log/LogHandler.java
+++ b/asciidoctor-maven-commons/src/main/java/org/asciidoctor/maven/log/LogHandler.java
@@ -7,11 +7,13 @@ import static org.asciidoctor.maven.commons.StringUtils.isNotBlank;
  * POJO for Maven XML mapping.
  *
  * @author abelsromero
+ * @since 1.5.7
  */
 public class LogHandler {
 
-    private Boolean outputToConsole;
+    private boolean outputToConsole;
     private FailIf failIf;
+    private Boolean failFast;
 
     public Boolean getOutputToConsole() {
         return outputToConsole;
@@ -37,4 +39,11 @@ public class LogHandler {
         return failIf != null && isNotBlank(failIf.getContainsText());
     }
 
+    public Boolean getFailFast() {
+        return failFast;
+    }
+
+    public void setFailFast(Boolean failFast) {
+        this.failFast = failFast;
+    }
 }

--- a/asciidoctor-maven-commons/src/main/java/org/asciidoctor/maven/log/MemoryLogHandler.java
+++ b/asciidoctor-maven-commons/src/main/java/org/asciidoctor/maven/log/MemoryLogHandler.java
@@ -47,9 +47,7 @@ public class MemoryLogHandler implements LogHandler {
      * @return list of filtered logRecords
      */
     public List<LogRecord> filter(Severity severity) {
-        return this.records.stream()
-            .filter(record -> severityIsHigher(record, severity))
-            .collect(Collectors.toList());
+        return filter(severity, null);
     }
 
     /**
@@ -59,16 +57,14 @@ public class MemoryLogHandler implements LogHandler {
      * @return list of filtered logRecords
      */
     public List<LogRecord> filter(String text) {
-        return this.records.stream()
-            .filter(record -> messageContains(record, text))
-            .collect(Collectors.toList());
+        return filter(null, text);
     }
 
     /**
      * Returns LogRecords that are equal or above the severity level and whose message contains text.
      *
-     * @param severity Asciidoctor's severity level
-     * @param text     text to search for in the LogRecords
+     * @param severity Asciidoctor's severity level (no filter applied when null)
+     * @param text     text to search for in the LogRecords (no filter applied when null)
      * @return list of filtered logRecords
      */
     public List<LogRecord> filter(Severity severity, String text) {
@@ -98,7 +94,7 @@ public class MemoryLogHandler implements LogHandler {
 
     private static boolean severityIsHigher(LogRecord record, Severity severity) {
         if (severity == null) {
-            return false;
+            return true;
         } else {
             return record.getSeverity().ordinal() >= severity.ordinal();
         }
@@ -106,7 +102,7 @@ public class MemoryLogHandler implements LogHandler {
 
     private static boolean messageContains(LogRecord record, String text) {
         if (StringUtils.isBlank(text)) {
-            return false;
+            return true;
         } else {
             return record.getMessage().contains(text);
         }

--- a/asciidoctor-maven-commons/src/main/java/org/asciidoctor/maven/log/MemoryLogHandler.java
+++ b/asciidoctor-maven-commons/src/main/java/org/asciidoctor/maven/log/MemoryLogHandler.java
@@ -29,7 +29,7 @@ public class MemoryLogHandler implements LogHandler {
      * Provides simple way to inject the current file being processes.
      * Will need re-work in concurrent scenarios.
      *
-     * @since 3.1.2
+     * @since 3.2.0
      */
     private File currentFile;
 

--- a/asciidoctor-maven-commons/src/main/java/org/asciidoctor/maven/log/MemoryLogHandler.java
+++ b/asciidoctor-maven-commons/src/main/java/org/asciidoctor/maven/log/MemoryLogHandler.java
@@ -8,6 +8,7 @@ import java.util.stream.Collectors;
 import org.asciidoctor.log.LogHandler;
 import org.asciidoctor.log.LogRecord;
 import org.asciidoctor.log.Severity;
+import org.asciidoctor.maven.commons.StringUtils;
 
 
 /**
@@ -96,11 +97,19 @@ public class MemoryLogHandler implements LogHandler {
     }
 
     private static boolean severityIsHigher(LogRecord record, Severity severity) {
-        return record.getSeverity().ordinal() >= severity.ordinal();
+        if (severity == null) {
+            return false;
+        } else {
+            return record.getSeverity().ordinal() >= severity.ordinal();
+        }
     }
 
     private static boolean messageContains(LogRecord record, String text) {
-        return record.getMessage().contains(text);
+        if (StringUtils.isBlank(text)) {
+            return false;
+        } else {
+            return record.getMessage().contains(text);
+        }
     }
 
 }

--- a/asciidoctor-maven-commons/src/main/java/org/asciidoctor/maven/log/MemoryLogHandler.java
+++ b/asciidoctor-maven-commons/src/main/java/org/asciidoctor/maven/log/MemoryLogHandler.java
@@ -1,5 +1,6 @@
 package org.asciidoctor.maven.log;
 
+import java.io.File;
 import java.util.ArrayList;
 import java.util.List;
 import java.util.function.Consumer;
@@ -24,6 +25,14 @@ public class MemoryLogHandler implements LogHandler {
     private final Boolean outputToConsole;
     private final Consumer<LogRecord> recordConsumer;
 
+    /**
+     * Provides simple way to inject the current file being processes.
+     * Will need re-work in concurrent scenarios.
+     *
+     * @since 3.1.2
+     */
+    private File currentFile;
+
     public MemoryLogHandler(Boolean outputToConsole, Consumer<LogRecord> recordConsumer) {
         this.outputToConsole = outputToConsole == null ? Boolean.FALSE : outputToConsole;
         this.recordConsumer = recordConsumer;
@@ -31,9 +40,11 @@ public class MemoryLogHandler implements LogHandler {
 
     @Override
     public void log(LogRecord logRecord) {
-        records.add(logRecord);
+        final CapturedLogRecord record = new CapturedLogRecord(logRecord, currentFile);
+
+        records.add(record);
         if (outputToConsole)
-            recordConsumer.accept(logRecord);
+            recordConsumer.accept(record);
     }
 
     public void clear() {
@@ -106,6 +117,10 @@ public class MemoryLogHandler implements LogHandler {
         } else {
             return record.getMessage().contains(text);
         }
+    }
+
+    public void setCurrentFile(File currentFile) {
+        this.currentFile = currentFile;
     }
 
 }

--- a/asciidoctor-maven-commons/src/main/java/org/asciidoctor/maven/site/SiteLogHandlerDeserializer.java
+++ b/asciidoctor-maven-commons/src/main/java/org/asciidoctor/maven/site/SiteLogHandlerDeserializer.java
@@ -20,16 +20,13 @@ public class SiteLogHandlerDeserializer {
         if (logHandlerNode == null || !logHandlerNode.getName().equals(NODE_NAME))
             return logHandler;
 
-        logHandler.setOutputToConsole(deserializeOutputToConsole(logHandlerNode));
+        logHandler.setOutputToConsole(getBoolean(logHandlerNode, "outputToConsole"));
+        logHandler.setFailFast(getBoolean(logHandlerNode, "failFast"));
 
         deserializeFailIf(logHandlerNode.getChild("failIf"))
-                .ifPresent(logHandler::setFailIf);
+            .ifPresent(logHandler::setFailIf);
 
         return logHandler;
-    }
-
-    private Boolean deserializeOutputToConsole(Xpp3Dom node) {
-        return getBoolean(node, "outputToConsole");
     }
 
     private Optional<FailIf> deserializeFailIf(Xpp3Dom node) {
@@ -58,18 +55,18 @@ public class SiteLogHandlerDeserializer {
         return Optional.ofNullable(failIf);
     }
 
-    private String sanitizeString(Xpp3Dom severity) {
-        String value = severity.getValue();
-        return value == null ? "" : value.trim();
-    }
-
     private LogHandler defaultLogHandler() {
         LogHandler logHandler = new LogHandler();
         logHandler.setOutputToConsole(Boolean.TRUE);
         return logHandler;
     }
 
-    private Boolean getBoolean(Xpp3Dom node, String name) {
+    private static String sanitizeString(Xpp3Dom node) {
+        final String value = node.getValue();
+        return value == null ? "" : value.trim();
+    }
+
+    private static Boolean getBoolean(Xpp3Dom node, String name) {
         final Xpp3Dom child = node.getChild(name);
         if (child == null) {
             return Boolean.TRUE;

--- a/asciidoctor-maven-commons/src/test/java/org/asciidoctor/maven/log/CapturedLogRecordTest.java
+++ b/asciidoctor-maven-commons/src/test/java/org/asciidoctor/maven/log/CapturedLogRecordTest.java
@@ -1,0 +1,60 @@
+package org.asciidoctor.maven.log;
+
+import java.io.File;
+
+import static org.assertj.core.api.Assertions.assertThat;
+
+import org.asciidoctor.ast.Cursor;
+import org.asciidoctor.log.LogRecord;
+import org.asciidoctor.log.Severity;
+import org.junit.jupiter.api.Nested;
+import org.junit.jupiter.api.Test;
+
+class CapturedLogRecordTest {
+
+    @Nested
+    class WhenLogRecordsContainsCursor {
+
+        @Test
+        void shouldReturnCursorFile() {
+            final var cursorFile = new File("uno", "dos");
+            final var recordFile = new File("tres", "quatre");
+            final var cursor = new TestCursor(cursorFile.getAbsolutePath(), 0, null, null);
+
+            final var logRecord = new CapturedLogRecord(getLogRecord(cursor), recordFile);
+            final var capturedLogRecord = new CapturedLogRecord(logRecord, cursorFile);
+
+            assertThat(capturedLogRecord.getCursor().getFile()).isEqualTo(cursorFile.getAbsolutePath());
+        }
+
+    }
+
+    @Nested
+    class WhenLogRecordsDoesNotContainsCursor {
+
+        @Test
+        void shouldReturnLogRecordFileWhenCursorFileIsSet() {
+            final var cursorFile = new File("uno", "dos");
+            final var recordFile = new File("tres", "quatre");
+
+            final var logRecord = new CapturedLogRecord(getLogRecord(null), recordFile);
+            final var capturedLogRecord = new CapturedLogRecord(logRecord, cursorFile);
+
+            assertThat(capturedLogRecord.getCursor().getFile()).isEqualTo(recordFile.getAbsolutePath());
+        }
+
+        @Test
+        void shouldReturnNullWhenCursorFileIsNoSet() {
+            final var logRecord = new CapturedLogRecord(getLogRecord(null), null);
+            final var capturedLogRecord = new CapturedLogRecord(logRecord, null);
+
+            assertThat(capturedLogRecord.getCursor()).isNull();
+        }
+
+    }
+
+    private LogRecord getLogRecord(Cursor cursor) {
+        return new LogRecord(Severity.INFO, cursor, "a message");
+    }
+
+}

--- a/asciidoctor-maven-commons/src/test/java/org/asciidoctor/maven/log/LogRecordFormatterTest.java
+++ b/asciidoctor-maven-commons/src/test/java/org/asciidoctor/maven/log/LogRecordFormatterTest.java
@@ -3,14 +3,14 @@ package org.asciidoctor.maven.log;
 import java.io.File;
 import java.io.IOException;
 
+import static java.lang.String.format;
+import static org.assertj.core.api.Assertions.assertThat;
+
 import org.asciidoctor.ast.Cursor;
 import org.asciidoctor.log.LogRecord;
 import org.asciidoctor.log.Severity;
 import org.junit.jupiter.api.Test;
 import org.mockito.Mockito;
-
-import static java.lang.String.format;
-import static org.assertj.core.api.Assertions.assertThat;
 
 class LogRecordFormatterTest {
 
@@ -117,38 +117,4 @@ class LogRecordFormatterTest {
         return formattedLogRecord.replaceAll("\\\\", "/");
     }
 
-    class TestCursor implements Cursor {
-
-        private final int lineNumber;
-        private final String file;
-        private final String path;
-        private final String dir;
-
-        TestCursor(String file, int lineNumber, String path, String dir) {
-            this.file = file;
-            this.lineNumber = lineNumber;
-            this.path = path;
-            this.dir = dir;
-        }
-
-        @Override
-        public int getLineNumber() {
-            return lineNumber;
-        }
-
-        @Override
-        public String getPath() {
-            return path;
-        }
-
-        @Override
-        public String getDir() {
-            return dir;
-        }
-
-        @Override
-        public String getFile() {
-            return file;
-        }
-    }
 }

--- a/asciidoctor-maven-commons/src/test/java/org/asciidoctor/maven/log/LogRecordsProcessorsTest.java
+++ b/asciidoctor-maven-commons/src/test/java/org/asciidoctor/maven/log/LogRecordsProcessorsTest.java
@@ -1,0 +1,271 @@
+package org.asciidoctor.maven.log;
+
+import java.util.ArrayList;
+import java.util.List;
+
+import static org.asciidoctor.log.Severity.*;
+import static org.assertj.core.api.Assertions.assertThat;
+import static org.assertj.core.api.Assertions.catchThrowable;
+
+import org.asciidoctor.log.LogRecord;
+import org.junit.jupiter.api.Nested;
+import org.junit.jupiter.api.Test;
+
+class LogRecordsProcessorsTest {
+
+    @Test
+    void should_not_fail_with_empty_data() {
+        final var config = new org.asciidoctor.maven.log.LogHandler();
+        final var recordsProcessor = new LogRecordsProcessors(config, null, null);
+
+        final var logHandler = new MemoryLogHandler(null, null);
+        Throwable throwable = catchThrowable(() -> recordsProcessor.processLogRecords(logHandler));
+
+        assertThat(throwable).isNull();
+    }
+
+    @Nested
+    class Severity {
+
+        @Test
+        void should_report_messages_when_severity_is_error() {
+            final var config = logHandlerConfig(ERROR, null);
+            final List<String> messages = new ArrayList();
+
+            final var recordsProcessor = new LogRecordsProcessors(config, null, messages::add);
+
+            final var logHandler = testMemoryLogHandler();
+            Throwable throwable = catchThrowable(() -> recordsProcessor.processLogRecords(logHandler));
+
+            assertThat(messages)
+                .containsExactlyInAnyOrder(
+                    "asciidoctor: ERROR: error message 1",
+                    "asciidoctor: ERROR: error message 2",
+                    "asciidoctor: ERROR: error message 3");
+            assertThat(throwable)
+                .hasMessage("Found 3 issue(s) of severity ERROR or higher during conversion");
+        }
+
+        @Test
+        void should_report_messages_when_severity_is_info() {
+            final var config = logHandlerConfig(INFO, null);
+            final List<String> messages = new ArrayList();
+
+            final var recordsProcessor = new LogRecordsProcessors(config, null, messages::add);
+
+            final var logHandler = testMemoryLogHandler();
+            Throwable throwable = catchThrowable(() -> recordsProcessor.processLogRecords(logHandler));
+
+            assertThat(messages)
+                .containsExactlyInAnyOrder(
+                    "asciidoctor: ERROR: error message 1",
+                    "asciidoctor: ERROR: error message 2",
+                    "asciidoctor: ERROR: error message 3",
+                    "asciidoctor: INFO: info message 1",
+                    "asciidoctor: INFO: info message 2",
+                    "asciidoctor: INFO: info message 3",
+                    "asciidoctor: WARN: warning message 1",
+                    "asciidoctor: WARN: warning message 2",
+                    "asciidoctor: WARN: warning message 3");
+            assertThat(throwable)
+                .hasMessage("Found 9 issue(s) of severity INFO or higher during conversion");
+        }
+
+        @Test
+        void should_report_no_messages_when_severity_is_fatal() {
+            final var config = logHandlerConfig(FATAL, null);
+            final List<String> messages = new ArrayList();
+
+            final var recordsProcessor = new LogRecordsProcessors(config, null, messages::add);
+
+            final var logHandler = testMemoryLogHandler();
+            Throwable throwable = catchThrowable(() -> recordsProcessor.processLogRecords(logHandler));
+
+            assertThat(messages).isEmpty();
+            assertThat(throwable).isNull();
+        }
+    }
+
+    @Nested
+    class Text {
+
+        @Test
+        void should_report_messages_when_text_contains_error() {
+            final var config = logHandlerConfig(null, "error");
+            final List<String> messages = new ArrayList();
+
+            final var recordsProcessor = new LogRecordsProcessors(config, null, messages::add);
+
+            final var logHandler = testMemoryLogHandler();
+            Throwable throwable = catchThrowable(() -> recordsProcessor.processLogRecords(logHandler));
+
+            assertThat(messages)
+                .containsExactlyInAnyOrder(
+                    "asciidoctor: ERROR: error message 1",
+                    "asciidoctor: ERROR: error message 2",
+                    "asciidoctor: ERROR: error message 3");
+            assertThat(throwable)
+                .hasMessage("Found 3 issue(s) containing 'error'");
+        }
+
+        @Test
+        void should_report_messages_when_text_contains_info() {
+            final var config = logHandlerConfig(null, "info");
+            final List<String> messages = new ArrayList();
+
+            final var recordsProcessor = new LogRecordsProcessors(config, null, messages::add);
+
+            final var logHandler = testMemoryLogHandler();
+            Throwable throwable = catchThrowable(() -> recordsProcessor.processLogRecords(logHandler));
+
+            assertThat(messages)
+                .containsExactlyInAnyOrder(
+                    "asciidoctor: INFO: info message 1",
+                    "asciidoctor: INFO: info message 2",
+                    "asciidoctor: INFO: info message 3");
+            assertThat(throwable)
+                .hasMessage("Found 3 issue(s) containing 'info'");
+        }
+
+        @Test
+        void should_report_messages_when_text_contains_warn() {
+            final var config = logHandlerConfig(null, "warn");
+            final List<String> messages = new ArrayList();
+
+            final var recordsProcessor = new LogRecordsProcessors(config, null, messages::add);
+
+            final var logHandler = testMemoryLogHandler();
+            Throwable throwable = catchThrowable(() -> recordsProcessor.processLogRecords(logHandler));
+
+            assertThat(messages)
+                .containsExactlyInAnyOrder(
+                    "asciidoctor: WARN: warning message 1",
+                    "asciidoctor: WARN: warning message 2",
+                    "asciidoctor: WARN: warning message 3");
+            assertThat(throwable)
+                .hasMessage("Found 3 issue(s) containing 'warn'");
+        }
+
+        @Test
+        void should_report_messages_when_text_does_not_match() {
+            final var config = logHandlerConfig(null, "not present");
+            final List<String> messages = new ArrayList();
+
+            final var recordsProcessor = new LogRecordsProcessors(config, null, messages::add);
+
+            final var logHandler = testMemoryLogHandler();
+            Throwable throwable = catchThrowable(() -> recordsProcessor.processLogRecords(logHandler));
+
+            assertThat(messages).isEmpty();
+            assertThat(throwable).isNull();
+        }
+    }
+
+    @Nested
+    class SeverityAndText {
+
+        @Test
+        void should_report_messages_when_severity_and_text_contains_error() {
+            final var config = logHandlerConfig(ERROR, "error");
+            final List<String> messages = new ArrayList();
+
+            final var recordsProcessor = new LogRecordsProcessors(config, null, messages::add);
+
+            final var logHandler = testMemoryLogHandler();
+            Throwable throwable = catchThrowable(() -> recordsProcessor.processLogRecords(logHandler));
+
+            assertThat(messages)
+                .containsExactlyInAnyOrder(
+                    "asciidoctor: ERROR: error message 1",
+                    "asciidoctor: ERROR: error message 2",
+                    "asciidoctor: ERROR: error message 3");
+            assertThat(throwable)
+                .hasMessage("Found 3 issue(s) matching severity ERROR or higher and text 'error'");
+        }
+
+        @Test
+        void should_report_messages_when_severity_and_text_contains_info() {
+            final var config = logHandlerConfig(INFO, "info");
+            final List<String> messages = new ArrayList();
+
+            final var recordsProcessor = new LogRecordsProcessors(config, null, messages::add);
+
+            final var logHandler = testMemoryLogHandler();
+            Throwable throwable = catchThrowable(() -> recordsProcessor.processLogRecords(logHandler));
+
+            assertThat(messages)
+                .containsExactlyInAnyOrder(
+                    "asciidoctor: INFO: info message 1",
+                    "asciidoctor: INFO: info message 2",
+                    "asciidoctor: INFO: info message 3");
+            assertThat(throwable)
+                .hasMessage("Found 3 issue(s) matching severity INFO or higher and text 'info'");
+        }
+
+        @Test
+        void should_report_messages_when_severity_and_text_contains_warn() {
+            final var config = logHandlerConfig(WARN, "warn");
+            final List<String> messages = new ArrayList();
+
+            final var recordsProcessor = new LogRecordsProcessors(config, null, messages::add);
+
+            final var logHandler = testMemoryLogHandler();
+            Throwable throwable = catchThrowable(() -> recordsProcessor.processLogRecords(logHandler));
+
+            assertThat(messages)
+                .containsExactlyInAnyOrder(
+                    "asciidoctor: WARN: warning message 1",
+                    "asciidoctor: WARN: warning message 2",
+                    "asciidoctor: WARN: warning message 3");
+            assertThat(throwable)
+                .hasMessage("Found 3 issue(s) matching severity WARN or higher and text 'warn'");
+        }
+
+
+        @Test
+        void should_report_messages_when_text_return_none() {
+            final var config = logHandlerConfig(FATAL, "not present");
+            final List<String> messages = new ArrayList();
+
+            final var recordsProcessor = new LogRecordsProcessors(config, null, messages::add);
+
+            final var logHandler = testMemoryLogHandler();
+            Throwable throwable = catchThrowable(() -> recordsProcessor.processLogRecords(logHandler));
+
+            assertThat(messages).isEmpty();
+            assertThat(throwable).isNull();
+        }
+    }
+
+    private static LogHandler logHandlerConfig(org.asciidoctor.log.Severity severity, String text) {
+        final var config = new LogHandler();
+        FailIf failIf = new FailIf();
+        failIf.setSeverity(severity);
+        failIf.setContainsText(text);
+        config.setFailIf(failIf);
+        return config;
+    }
+
+    private static MemoryLogHandler testMemoryLogHandler() {
+        final var memoryLogHandler = new MemoryLogHandler(null, null);
+        for (int i = 1; i < 4; i++) {
+            memoryLogHandler.log(errorMessage(i));
+            memoryLogHandler.log(getInfoMessage(i));
+            memoryLogHandler.log(warningMessage(i));
+        }
+        return memoryLogHandler;
+    }
+
+    private static LogRecord errorMessage(int index) {
+        return new LogRecord(ERROR, "error message " + index);
+    }
+
+    private static LogRecord getInfoMessage(int index) {
+        return new LogRecord(INFO, "info message " + index);
+    }
+
+    private static LogRecord warningMessage(int index) {
+        return new LogRecord(WARN, "warning message " + index);
+    }
+
+}

--- a/asciidoctor-maven-commons/src/test/java/org/asciidoctor/maven/log/LogRecordsProcessorsTest.java
+++ b/asciidoctor-maven-commons/src/test/java/org/asciidoctor/maven/log/LogRecordsProcessorsTest.java
@@ -4,10 +4,10 @@ import java.util.ArrayList;
 import java.util.List;
 
 import static org.asciidoctor.log.Severity.*;
+import static org.asciidoctor.maven.log.TestLogRecords.*;
 import static org.assertj.core.api.Assertions.assertThat;
 import static org.assertj.core.api.Assertions.catchThrowable;
 
-import org.asciidoctor.log.LogRecord;
 import org.junit.jupiter.api.Nested;
 import org.junit.jupiter.api.Test;
 
@@ -254,18 +254,6 @@ class LogRecordsProcessorsTest {
             memoryLogHandler.log(warningMessage(i));
         }
         return memoryLogHandler;
-    }
-
-    private static LogRecord errorMessage(int index) {
-        return new LogRecord(ERROR, "error message " + index);
-    }
-
-    private static LogRecord getInfoMessage(int index) {
-        return new LogRecord(INFO, "info message " + index);
-    }
-
-    private static LogRecord warningMessage(int index) {
-        return new LogRecord(WARN, "warning message " + index);
     }
 
 }

--- a/asciidoctor-maven-commons/src/test/java/org/asciidoctor/maven/log/MemoryLogHandlerTest.java
+++ b/asciidoctor-maven-commons/src/test/java/org/asciidoctor/maven/log/MemoryLogHandlerTest.java
@@ -25,12 +25,12 @@ class MemoryLogHandlerTest {
     }
 
     @Test
-    void should_not_fail_when_filtering_null_values() {
+    void should_return_all_by_default() {
         final var memoryLogHandler = testMemoryLogHandler();
 
-        assertThat(memoryLogHandler.filter((org.asciidoctor.log.Severity) null)).hasSize(0);
-        assertThat(memoryLogHandler.filter((String) null)).hasSize(0);
-        assertThat(memoryLogHandler.filter(null, null)).hasSize(0);
+        assertThat(memoryLogHandler.filter((org.asciidoctor.log.Severity) null)).hasSize(3);
+        assertThat(memoryLogHandler.filter((String) null)).hasSize(3);
+        assertThat(memoryLogHandler.filter(null, null)).hasSize(3);
     }
 
     @Test

--- a/asciidoctor-maven-commons/src/test/java/org/asciidoctor/maven/log/MemoryLogHandlerTest.java
+++ b/asciidoctor-maven-commons/src/test/java/org/asciidoctor/maven/log/MemoryLogHandlerTest.java
@@ -3,6 +3,7 @@ package org.asciidoctor.maven.log;
 import java.util.List;
 
 import static org.asciidoctor.log.Severity.*;
+import static org.asciidoctor.maven.log.TestLogRecords.*;
 import static org.assertj.core.api.Assertions.assertThat;
 
 import org.asciidoctor.log.LogRecord;
@@ -162,15 +163,4 @@ class MemoryLogHandlerTest {
         return memoryLogHandler;
     }
 
-    private static LogRecord errorMessage() {
-        return new LogRecord(ERROR, "error message");
-    }
-
-    private static LogRecord getInfoMessage() {
-        return new LogRecord(INFO, "info message");
-    }
-
-    private static LogRecord warningMessage() {
-        return new LogRecord(WARN, "warning message");
-    }
 }

--- a/asciidoctor-maven-commons/src/test/java/org/asciidoctor/maven/log/MemoryLogHandlerTest.java
+++ b/asciidoctor-maven-commons/src/test/java/org/asciidoctor/maven/log/MemoryLogHandlerTest.java
@@ -152,7 +152,6 @@ class MemoryLogHandlerTest {
                 .contains(warningMessage())
                 .hasSize(3);
         }
-
     }
 
     private static MemoryLogHandler testMemoryLogHandler() {

--- a/asciidoctor-maven-commons/src/test/java/org/asciidoctor/maven/log/MemoryLogHandlerTest.java
+++ b/asciidoctor-maven-commons/src/test/java/org/asciidoctor/maven/log/MemoryLogHandlerTest.java
@@ -1,0 +1,177 @@
+package org.asciidoctor.maven.log;
+
+import java.util.List;
+
+import static org.asciidoctor.log.Severity.*;
+import static org.assertj.core.api.Assertions.assertThat;
+
+import org.asciidoctor.log.LogRecord;
+import org.junit.jupiter.api.Nested;
+import org.junit.jupiter.api.Test;
+
+class MemoryLogHandlerTest {
+
+    @Test
+    void should_not_fail_when_filtering_without_records() {
+        final var memoryLogHandler = new MemoryLogHandler(null, null);
+
+        assertThat(memoryLogHandler.filter(ERROR)).hasSize(0);
+        assertThat(memoryLogHandler.filter("any text")).hasSize(0);
+        assertThat(memoryLogHandler.filter(INFO, "any text")).hasSize(0);
+
+        assertThat(memoryLogHandler.filter((org.asciidoctor.log.Severity) null)).hasSize(0);
+        assertThat(memoryLogHandler.filter((String) null)).hasSize(0);
+        assertThat(memoryLogHandler.filter(null, null)).hasSize(0);
+    }
+
+    @Test
+    void should_not_fail_when_filtering_null_values() {
+        final var memoryLogHandler = testMemoryLogHandler();
+
+        assertThat(memoryLogHandler.filter((org.asciidoctor.log.Severity) null)).hasSize(0);
+        assertThat(memoryLogHandler.filter((String) null)).hasSize(0);
+        assertThat(memoryLogHandler.filter(null, null)).hasSize(0);
+    }
+
+    @Test
+    void should_return_non_empty() {
+        final var memoryLogHandler = new MemoryLogHandler(null, null);
+        assertThat(memoryLogHandler.isEmpty()).isTrue();
+    }
+
+    @Test
+    void should_return_empty() {
+        final var memoryLogHandler = testMemoryLogHandler();
+        assertThat(memoryLogHandler.isEmpty()).isFalse();
+    }
+
+    @Nested
+    class Severity {
+
+        @Test
+        void should_filter_by_error_severity() {
+            final var memoryLogHandler = testMemoryLogHandler();
+
+            List<LogRecord> filter = memoryLogHandler.filter(ERROR);
+
+            assertThat(filter)
+                .usingRecursiveFieldByFieldElementComparator()
+                .contains(errorMessage())
+                .hasSize(1);
+        }
+
+        @Test
+        void should_filter_by_info_severity() {
+            final var memoryLogHandler = testMemoryLogHandler();
+
+            List<LogRecord> filter = memoryLogHandler.filter(INFO);
+
+            assertThat(filter)
+                .usingRecursiveFieldByFieldElementComparator()
+                .contains(errorMessage())
+                .contains(getInfoMessage())
+                .contains(warningMessage())
+                .hasSize(3);
+        }
+
+        @Test
+        void should_filter_by_warn_severity() {
+            final var memoryLogHandler = testMemoryLogHandler();
+
+            List<LogRecord> filter = memoryLogHandler.filter(WARN);
+
+            assertThat(filter)
+                .usingRecursiveFieldByFieldElementComparator()
+                .contains(errorMessage())
+                .contains(warningMessage())
+                .hasSize(2);
+        }
+    }
+
+    @Nested
+    class Text {
+
+        @Test
+        void should_filter_by_text_and_return_none() {
+            final var memoryLogHandler = testMemoryLogHandler();
+
+            List<LogRecord> filter = memoryLogHandler.filter("nothing");
+
+            assertThat(filter).hasSize(0);
+        }
+
+        @Test
+        void should_filter_by_text_and_return_some_record() {
+            final var memoryLogHandler = testMemoryLogHandler();
+
+            List<LogRecord> filter = memoryLogHandler.filter("error");
+
+            assertThat(filter)
+                .usingRecursiveFieldByFieldElementComparator()
+                .contains(errorMessage())
+                .hasSize(1);
+        }
+
+        @Test
+        void should_filter_by_text_and_return_all_records() {
+            final var memoryLogHandler = testMemoryLogHandler();
+
+            List<LogRecord> filter = memoryLogHandler.filter("message");
+
+            assertThat(filter)
+                .usingRecursiveFieldByFieldElementComparator()
+                .contains(errorMessage())
+                .contains(getInfoMessage())
+                .contains(warningMessage())
+                .hasSize(3);
+        }
+    }
+
+    @Nested
+    class SeverityAndText {
+
+        @Test
+        void should_filter_by_severity_and_test_and_return_none() {
+            final var memoryLogHandler = testMemoryLogHandler();
+
+            List<LogRecord> filter = memoryLogHandler.filter(INFO, "nothing");
+
+            assertThat(filter).hasSize(0);
+        }
+
+        @Test
+        void should_filter_by_severity_and_test_and_return_all() {
+            final var memoryLogHandler = testMemoryLogHandler();
+
+            List<LogRecord> filter = memoryLogHandler.filter(INFO, "message");
+
+            assertThat(filter)
+                .usingRecursiveFieldByFieldElementComparator()
+                .contains(errorMessage())
+                .contains(getInfoMessage())
+                .contains(warningMessage())
+                .hasSize(3);
+        }
+
+    }
+
+    private static MemoryLogHandler testMemoryLogHandler() {
+        final var memoryLogHandler = new MemoryLogHandler(null, null);
+        memoryLogHandler.log(errorMessage());
+        memoryLogHandler.log(getInfoMessage());
+        memoryLogHandler.log(warningMessage());
+        return memoryLogHandler;
+    }
+
+    private static LogRecord errorMessage() {
+        return new LogRecord(ERROR, "error message");
+    }
+
+    private static LogRecord getInfoMessage() {
+        return new LogRecord(INFO, "info message");
+    }
+
+    private static LogRecord warningMessage() {
+        return new LogRecord(WARN, "warning message");
+    }
+}

--- a/asciidoctor-maven-commons/src/test/java/org/asciidoctor/maven/log/TestCursor.java
+++ b/asciidoctor-maven-commons/src/test/java/org/asciidoctor/maven/log/TestCursor.java
@@ -1,0 +1,38 @@
+package org.asciidoctor.maven.log;
+
+import org.asciidoctor.ast.Cursor;
+
+class TestCursor implements Cursor {
+
+    private final int lineNumber;
+    private final String file;
+    private final String path;
+    private final String dir;
+
+    TestCursor(String file, int lineNumber, String path, String dir) {
+        this.file = file;
+        this.lineNumber = lineNumber;
+        this.path = path;
+        this.dir = dir;
+    }
+
+    @Override
+    public int getLineNumber() {
+        return lineNumber;
+    }
+
+    @Override
+    public String getPath() {
+        return path;
+    }
+
+    @Override
+    public String getDir() {
+        return dir;
+    }
+
+    @Override
+    public String getFile() {
+        return file;
+    }
+}

--- a/asciidoctor-maven-commons/src/test/java/org/asciidoctor/maven/log/TestLogRecords.java
+++ b/asciidoctor-maven-commons/src/test/java/org/asciidoctor/maven/log/TestLogRecords.java
@@ -1,0 +1,43 @@
+package org.asciidoctor.maven.log;
+
+import java.util.Optional;
+
+import static org.asciidoctor.log.Severity.*;
+
+import org.asciidoctor.log.LogRecord;
+
+class TestLogRecords {
+
+    static LogRecord errorMessage() {
+        return errorMessage(null);
+    }
+
+    static LogRecord errorMessage(Integer index) {
+        LogRecord logRecord = new LogRecord(ERROR, buildMessage("error", index));
+        return new CapturedLogRecord(logRecord, null);
+    }
+
+    static LogRecord getInfoMessage() {
+        return getInfoMessage(null);
+    }
+
+    static LogRecord getInfoMessage(Integer index) {
+        LogRecord logRecord = new LogRecord(INFO, buildMessage("info", index));
+        return new CapturedLogRecord(logRecord, null);
+    }
+
+    static LogRecord warningMessage() {
+        return warningMessage(null);
+    }
+
+    static LogRecord warningMessage(Integer index) {
+        LogRecord logRecord = new LogRecord(WARN, buildMessage("warning", index));
+        return new CapturedLogRecord(logRecord, null);
+    }
+
+    private static String buildMessage(String type, Integer index) {
+        return Optional.ofNullable(index)
+            .map(i -> type + " message " + index)
+            .orElse(type + " message");
+    }
+}

--- a/asciidoctor-maven-plugin/src/main/java/org/asciidoctor/maven/AsciidoctorMojo.java
+++ b/asciidoctor-maven-plugin/src/main/java/org/asciidoctor/maven/AsciidoctorMojo.java
@@ -242,7 +242,6 @@ public class AsciidoctorMojo extends AbstractMojo {
 
         final Set<File> uniquePaths = new HashSet<>();
         for (int i = 0; i < sourceFiles.size(); i++) {
-//        for (final File source : sourceFiles) {
             final File source = sourceFiles.get(i);
             final Destination destination = setDestinationPaths(source, optionsBuilder, sourceDir, this);
             final File destinationPath = destination.path;
@@ -255,8 +254,8 @@ public class AsciidoctorMojo extends AbstractMojo {
                 getLog().warn("Duplicated destination found: overwriting file: " + destinationFile);
             }
 
-            boolean lastFile = i == (sourceFiles.size() - 1);
-            convertFile(asciidoctor, optionsBuilder.build(), source, sourceDir, memoryLogHandler, lastFile);
+            boolean processLogRecords = logHandler.getFailFast() || (i == (sourceFiles.size() - 1));
+            convertFile(asciidoctor, optionsBuilder.build(), source, sourceDir, memoryLogHandler, processLogRecords);
         }
     }
 
@@ -354,10 +353,11 @@ public class AsciidoctorMojo extends AbstractMojo {
             finder.find(sourceDirectoryPath, sourceDocumentExtensions);
     }
 
-    private void convertFile(Asciidoctor asciidoctor, Options options, File f, File sourceDir, MemoryLogHandler memoryLogHandler, boolean lastFile) throws MojoExecutionException {
+    private void convertFile(Asciidoctor asciidoctor, Options options, File f, File sourceDir, MemoryLogHandler memoryLogHandler, boolean processLogRecords) throws MojoExecutionException {
+        memoryLogHandler.setCurrentFile(f);
         asciidoctor.convertFile(f, options);
         logConvertedFile(f);
-        if (logHandler.getFailFast() || lastFile) {
+        if (processLogRecords) {
             processLogRecords(sourceDir, memoryLogHandler);
         }
     }

--- a/asciidoctor-maven-plugin/src/main/java/org/asciidoctor/maven/AsciidoctorMojo.java
+++ b/asciidoctor-maven-plugin/src/main/java/org/asciidoctor/maven/AsciidoctorMojo.java
@@ -234,8 +234,7 @@ public class AsciidoctorMojo extends AbstractMojo {
         resourcesProcessor.process(sourceDir, outputDirectory, this);
 
         // register LogHandler to capture asciidoctor messages
-        final Boolean outputToConsole = Optional.ofNullable(logHandler.getOutputToConsole()).orElse(Boolean.TRUE);
-        final MemoryLogHandler memoryLogHandler = new MemoryLogHandler(outputToConsole,
+        final MemoryLogHandler memoryLogHandler = new MemoryLogHandler(logHandler.getOutputToConsole(),
             logRecord -> getLog().info(LogRecordFormatter.format(logRecord, sourceDir)));
         asciidoctor.registerLogHandler(memoryLogHandler);
         // disable default console output of AsciidoctorJ
@@ -261,7 +260,7 @@ public class AsciidoctorMojo extends AbstractMojo {
             }
         }
 
-        processLogRecords(sourceDir, memoryLogHandler);
+//        processLogRecords(sourceDir, memoryLogHandler);
     }
 
     private void processLogRecords(File sourceDir, MemoryLogHandler memoryLogHandler) throws MojoExecutionException {

--- a/asciidoctor-maven-plugin/src/main/java/org/asciidoctor/maven/process/SourceDocumentFinder.java
+++ b/asciidoctor-maven-plugin/src/main/java/org/asciidoctor/maven/process/SourceDocumentFinder.java
@@ -79,6 +79,7 @@ public class SourceDocumentFinder {
                         return true;
                     })
                     .map(Path::toFile)
+                    .sorted()
                     .collect(Collectors.toList());
         } catch (IOException e) {
             return Collections.emptyList();

--- a/asciidoctor-maven-plugin/src/test/java/org/asciidoctor/maven/AsciidoctorMojoLogHandlerTest.java
+++ b/asciidoctor-maven-plugin/src/test/java/org/asciidoctor/maven/AsciidoctorMojoLogHandlerTest.java
@@ -427,6 +427,7 @@ class AsciidoctorMojoLogHandlerTest {
 
             List<String> errorMessages = Arrays.stream(consoleHolder.getError().split("\n"))
                 .filter(line -> line.contains("asciidoctor:"))
+                .sorted()
                 .collect(Collectors.toList());
 
             assertThat(errorMessages)
@@ -438,11 +439,11 @@ class AsciidoctorMojoLogHandlerTest {
             assertThat(errorMessages.get(2))
                 .contains(fixOsSeparator("[error] asciidoctor: ERROR: document-with-missing-include.adoc: line 9: include file not found:"));
             assertThat(errorMessages.get(3))
-                .contains(fixOsSeparator("[error] asciidoctor: WARN: document-with-missing-include.adoc: line 25: no callout found for <1>"));
-            assertThat(errorMessages.get(4))
                 .contains(fixOsSeparator("[error] asciidoctor: INFO: document-with-invalid-reference.adoc: possible invalid reference: ../path/some-file.adoc"));
-            assertThat(errorMessages.get(5))
+            assertThat(errorMessages.get(4))
                 .contains(fixOsSeparator("[error] asciidoctor: INFO: document-with-invalid-reference.adoc: possible invalid reference: section-id"));
+            assertThat(errorMessages.get(5))
+                .contains(fixOsSeparator("[error] asciidoctor: WARN: document-with-missing-include.adoc: line 25: no callout found for <1>"));
             // cleanup
             consoleHolder.release();
         }
@@ -478,6 +479,7 @@ class AsciidoctorMojoLogHandlerTest {
 
             List<String> asciidoctorMessages = Arrays.stream(consoleHolder.getError().split("\n"))
                 .filter(line -> line.contains("asciidoctor:"))
+                .sorted()
                 .collect(Collectors.toList());
 
             assertThat(asciidoctorMessages)

--- a/asciidoctor-maven-plugin/src/test/java/org/asciidoctor/maven/AsciidoctorMojoLogHandlerTest.java
+++ b/asciidoctor-maven-plugin/src/test/java/org/asciidoctor/maven/AsciidoctorMojoLogHandlerTest.java
@@ -431,7 +431,7 @@ class AsciidoctorMojoLogHandlerTest {
             assertThat(errorMessages)
                 .hasSize(6);
             assertThat(errorMessages.get(0))
-                .contains(fixOsSeparator("[error] asciidoctor: INFO: document-with-invalid-reference.adoc: possible invalid reference: ../path/some-file.adoc"));
+                .contains(fixOsSeparator("[error] asciidoctor: INFO: document-with-invalid-reference.adoc: possible invalid reference:"));
             assertThat(errorMessages.get(1))
                 .contains(fixOsSeparator("[error] asciidoctor: INFO: document-with-invalid-reference.adoc: possible invalid reference: section-id"));
             assertThat(errorMessages.get(2))
@@ -482,7 +482,7 @@ class AsciidoctorMojoLogHandlerTest {
             assertThat(asciidoctorMessages)
                 .hasSize(2);
             assertThat(asciidoctorMessages.get(0))
-                .contains(fixOsSeparator("[error] asciidoctor: INFO: document-with-invalid-reference.adoc: possible invalid reference: ../path/some-file.adoc"));
+                .contains(fixOsSeparator("[error] asciidoctor: INFO: document-with-invalid-reference.adoc: possible invalid reference:"));
             assertThat(asciidoctorMessages.get(1))
                 .contains(fixOsSeparator("[error] asciidoctor: INFO: document-with-invalid-reference.adoc: possible invalid reference: section-id"));
             // cleanup

--- a/asciidoctor-maven-plugin/src/test/java/org/asciidoctor/maven/AsciidoctorMojoLogHandlerTest.java
+++ b/asciidoctor-maven-plugin/src/test/java/org/asciidoctor/maven/AsciidoctorMojoLogHandlerTest.java
@@ -12,7 +12,6 @@ import static org.asciidoctor.maven.test.TestUtils.mockAsciidoctorMojo;
 import static org.assertj.core.api.Assertions.assertThat;
 import static org.assertj.core.api.Assertions.catchThrowable;
 
-import lombok.extern.slf4j.Slf4j;
 import org.apache.maven.plugin.MojoExecutionException;
 import org.apache.maven.plugin.MojoFailureException;
 import org.asciidoctor.log.Severity;
@@ -24,7 +23,6 @@ import org.junit.jupiter.api.Nested;
 import org.junit.jupiter.api.Test;
 
 
-@Slf4j
 class AsciidoctorMojoLogHandlerTest {
 
     private static final String DEFAULT_SOURCE_DIRECTORY = "target/test-classes/src/asciidoctor";

--- a/asciidoctor-maven-plugin/src/test/java/org/asciidoctor/maven/AsciidoctorMojoLogHandlerTest.java
+++ b/asciidoctor-maven-plugin/src/test/java/org/asciidoctor/maven/AsciidoctorMojoLogHandlerTest.java
@@ -19,7 +19,6 @@ import org.asciidoctor.log.Severity;
 import org.asciidoctor.maven.io.ConsoleHolder;
 import org.asciidoctor.maven.log.FailIf;
 import org.asciidoctor.maven.log.LogHandler;
-import org.assertj.core.api.Assertions;
 import org.junit.jupiter.api.Disabled;
 import org.junit.jupiter.api.Nested;
 import org.junit.jupiter.api.Test;
@@ -427,21 +426,20 @@ class AsciidoctorMojoLogHandlerTest {
 
             List<String> errorMessages = Arrays.stream(consoleHolder.getError().split("\n"))
                 .filter(line -> line.contains("asciidoctor:"))
-                .sorted()
                 .collect(Collectors.toList());
 
             assertThat(errorMessages)
                 .hasSize(6);
             assertThat(errorMessages.get(0))
-                .contains(fixOsSeparator("[error] asciidoctor: ERROR: document-with-missing-include.adoc: line 3: include file not found:"));
-            assertThat(errorMessages.get(1))
-                .contains(fixOsSeparator("[error] asciidoctor: ERROR: document-with-missing-include.adoc: line 5: include file not found:"));
-            assertThat(errorMessages.get(2))
-                .contains(fixOsSeparator("[error] asciidoctor: ERROR: document-with-missing-include.adoc: line 9: include file not found:"));
-            assertThat(errorMessages.get(3))
                 .contains(fixOsSeparator("[error] asciidoctor: INFO: document-with-invalid-reference.adoc: possible invalid reference: ../path/some-file.adoc"));
-            assertThat(errorMessages.get(4))
+            assertThat(errorMessages.get(1))
                 .contains(fixOsSeparator("[error] asciidoctor: INFO: document-with-invalid-reference.adoc: possible invalid reference: section-id"));
+            assertThat(errorMessages.get(2))
+                .contains(fixOsSeparator("[error] asciidoctor: ERROR: document-with-missing-include.adoc: line 3: include file not found:"));
+            assertThat(errorMessages.get(3))
+                .contains(fixOsSeparator("[error] asciidoctor: ERROR: document-with-missing-include.adoc: line 5: include file not found:"));
+            assertThat(errorMessages.get(4))
+                .contains(fixOsSeparator("[error] asciidoctor: ERROR: document-with-missing-include.adoc: line 9: include file not found:"));
             assertThat(errorMessages.get(5))
                 .contains(fixOsSeparator("[error] asciidoctor: WARN: document-with-missing-include.adoc: line 25: no callout found for <1>"));
             // cleanup
@@ -470,7 +468,7 @@ class AsciidoctorMojoLogHandlerTest {
             // then
             assertThat(throwable)
                 .isInstanceOf(MojoExecutionException.class)
-                .hasMessageContaining("Found 4 issue(s) of severity DEBUG or higher during conversion");
+                .hasMessageContaining("Found 2 issue(s) of severity DEBUG or higher during conversion");
 
             long convertedFiles = Arrays.stream(consoleHolder.getOutput().split("\n"))
                 .filter(line -> line.contains("Converted"))
@@ -479,19 +477,14 @@ class AsciidoctorMojoLogHandlerTest {
 
             List<String> asciidoctorMessages = Arrays.stream(consoleHolder.getError().split("\n"))
                 .filter(line -> line.contains("asciidoctor:"))
-                .sorted()
                 .collect(Collectors.toList());
 
             assertThat(asciidoctorMessages)
-                .hasSize(4);
+                .hasSize(2);
             assertThat(asciidoctorMessages.get(0))
-                .contains(fixOsSeparator("[error] asciidoctor: ERROR: document-with-missing-include.adoc: line 3: include file not found:"));
+                .contains(fixOsSeparator("[error] asciidoctor: INFO: document-with-invalid-reference.adoc: possible invalid reference: ../path/some-file.adoc"));
             assertThat(asciidoctorMessages.get(1))
-                .contains(fixOsSeparator("[error] asciidoctor: ERROR: document-with-missing-include.adoc: line 5: include file not found:"));
-            assertThat(asciidoctorMessages.get(2))
-                .contains(fixOsSeparator("[error] asciidoctor: ERROR: document-with-missing-include.adoc: line 9: include file not found:"));
-            assertThat(asciidoctorMessages.get(3))
-                .contains(fixOsSeparator("[error] asciidoctor: WARN: document-with-missing-include.adoc: line 25: no callout found for <1>"));
+                .contains(fixOsSeparator("[error] asciidoctor: INFO: document-with-invalid-reference.adoc: possible invalid reference: section-id"));
             // cleanup
             consoleHolder.release();
         }

--- a/asciidoctor-maven-plugin/src/test/resources/src/asciidoctor/errors/valid.adoc
+++ b/asciidoctor-maven-plugin/src/test/resources/src/asciidoctor/errors/valid.adoc
@@ -1,0 +1,7 @@
+= Document Title
+
+This a valid document.
+
+== Section A
+
+No errors to be seen.

--- a/docs/modules/plugin/partials/process-asciidoc-mojo-parameters.adoc
+++ b/docs/modules/plugin/partials/process-asciidoc-mojo-parameters.adoc
@@ -207,7 +207,7 @@ Options are:
 Redirects all Asciidoctor messages to Maven's console logger as INFO during conversion.
 * `failFast`: `Boolean`, defaults to `true`.
 Fail the build on the first source with errors found (`true`), or after attempting to convert all sources (`false`).
-When `false`, errors for all sources will be shown matching conditions set in `failIf`.
+When `false`, errors (matching the conditions in `failIf`) from all sources will be shown.
 * `failIf`: build fail conditions, disabled by default.
 Allows setting one or many conditions that when met, abort the Maven build with `BUILD FAILURE` status.
 +

--- a/docs/modules/plugin/partials/process-asciidoc-mojo-parameters.adoc
+++ b/docs/modules/plugin/partials/process-asciidoc-mojo-parameters.adoc
@@ -205,6 +205,9 @@ Options are:
 
 * `outputToConsole`: `Boolean`, defaults to `true`.
 Redirects all Asciidoctor messages to Maven's console logger as INFO during conversion.
+* `failFast`: `Boolean`, defaults to `true`.
+Fail the build on the first source with errors found (`true`), or after attempting to convert all sources (`false`).
+When `false`, errors for all sources will be shown matching conditions set in `failIf`.
 * `failIf`: build fail conditions, disabled by default.
 Allows setting one or many conditions that when met, abort the Maven build with `BUILD FAILURE` status.
 +


### PR DESCRIPTION
Thank you for opening a pull request and contributing to asciidoctor-maven-plugin!

**What kind of change does this PR introduce?** (check at least one)
<!-- Update "[ ]" to "[x]" to check a box -->

- [ ] Bugfix
- [x] Feature
- [ ] Documentation
- [ ] Refactor
- [ ] Build improvement
- [ ] Other (please describe)


**What is the goal of this pull request?**

Allows to see all errors in all files before reporting a build failure. Previously, build failed on the first error found.

See https://github.com/asciidoctor/asciidoctor-maven-plugin/issues/1023

**Are there any alternative ways to implement this?**

The approach opts to extend the current features for minimal changes.
See the whole conversation in the linked issue for context.

**Are there any implications of this pull request? Anything a user must know?**

No.
The default behavior remains the same.

**Is it related to an existing issue?**
<!-- If Yes, please add a line of the form: `Fixes #Issue` --> 
- [x] Yes
- [ ] No

*Finally, please add a corresponding entry to CHANGELOG.adoc*
