### PR TITLE
Remove unnecessary byte-buddy test dependency

### DIFF
--- a/asciidoctor-maven-plugin/pom.xml
+++ b/asciidoctor-maven-plugin/pom.xml
@@ -62,12 +62,6 @@
             <artifactId>netty-codec-http</artifactId>
             <version>4.1.118.Final</version>
         </dependency>
-        <dependency>
-            <groupId>net.bytebuddy</groupId>
-            <artifactId>byte-buddy</artifactId>
-            <version>1.16.1</version>
-            <scope>test</scope>
-        </dependency>
     </dependencies>
 
     <build>


### PR DESCRIPTION
**What kind of change does this PR introduce?** (check at least one)
<!-- Update "[ ]" to "[x]" to check a box -->

- [ ] Bugfix
- [ ] Feature
- [ ] Documentation
- [ ] Refactor
- [x] Build improvement
- [ ] Other (please describe)


**What is the goal of this pull request?**
Remove unnecessary dependencies to reduce maintenance tasks.
This was added for a Mockito fix in https://github.com/asciidoctor/asciidoctor-maven-plugin/pull/756. This is not necessary now

**Are there any alternative ways to implement this?**
n/a

**Are there any implications of this pull request? Anything a user must know?**
n/a

**Is it related to an existing issue?**
<!-- If Yes, please add a line of the form: `Fixes #Issue` --> 
- [ ] Yes
- [x] No

*Finally, please add a corresponding entry to CHANGELOG.adoc*
