### PR TITLE
Set minimal Maven version to v3.8.8 from v3.8.5

### DIFF
--- a/CHANGELOG.adoc
+++ b/CHANGELOG.adoc
@@ -17,6 +17,9 @@ Improvements (for all modules)::
 
  * Add failFast option to logHandler to allow displaying all errors in build (#1032)
 
+Build / Infrastructure::
+ * Set minimal maven version to 3.8.8 (#)
+
 == v3.1.1 (2024-11-14)
 
 Improvements (for all modules)::

--- a/asciidoctor-maven-plugin/pom.xml
+++ b/asciidoctor-maven-plugin/pom.xml
@@ -17,7 +17,7 @@
     <url>https://github.com/asciidoctor/asciidoctor-maven-plugin</url>
 
     <prerequisites>
-        <maven>3.8.5</maven>
+        <maven>3.8.8</maven>
     </prerequisites>
 
     <properties>

--- a/docs/modules/plugin/pages/compatibility-matrix.adoc
+++ b/docs/modules/plugin/pages/compatibility-matrix.adoc
@@ -9,7 +9,7 @@ The current policy for Maven compatibility is to support https://maven.apache.or
 
 That is:
 
-* Maven v3.8.5 and higher
+* Maven v3.8.8 and higher
 * Maven v3.9.x
 
 == AsciidoctorJ compatible versions

--- a/pom.xml
+++ b/pom.xml
@@ -132,7 +132,7 @@
                         <configuration>
                             <rules>
                                 <requireMavenVersion>
-                                    <version>3.8.5</version>
+                                    <version>3.8.8</version>
                                 </requireMavenVersion>
                             </rules>
                         </configuration>


### PR DESCRIPTION
**What kind of change does this PR introduce?** (check at least one)
<!-- Update "[ ]" to "[x]" to check a box -->

- [ ] Bugfix
- [ ] Feature
- [x] Documentation
- [ ] Refactor
- [ ] Build improvement
- [x] Other (please describe)


**What is the goal of this pull request?**

Update the minimal Maven version according to policy in docs.
Being the latest minimal version 3.8.8 released 2023-03-08.
Note: GH pipelines were already testing 3.8.8.

**Are there any alternative ways to implement this?**
no

**Are there any implications of this pull request? Anything a user must know?**
n/a

**Is it related to an existing issue?**
<!-- If Yes, please add a line of the form: `Fixes #Issue` --> 
- [ ] Yes
- [x] No

*Finally, please add a corresponding entry to CHANGELOG.adoc*
