### PR TITLE
Set maven-compiler-plugin release to Java 11

### DIFF
--- a/CHANGELOG.adoc
+++ b/CHANGELOG.adoc
@@ -13,6 +13,10 @@ For a detailed view of what has changed, refer to the {uri-repo}/commits/main[co
 
 == Unreleased
 
+Build / Infrastructure::
+
+  * Set maven-compiler-plugin 'release' value to Java 11 (#1042)
+
 == v3.2.0 (2025-03-28)
 
 Improvements (for all modules)::

--- a/pom.xml
+++ b/pom.xml
@@ -269,7 +269,7 @@
                         <artifactId>maven-compiler-plugin</artifactId>
                         <version>3.14.0</version>
                         <configuration>
-                            <release>17</release>
+                            <release>${project.java.version}</release>
                         </configuration>
                     </plugin>
                 </plugins>


### PR DESCRIPTION
Thank you for opening a pull request and contributing to asciidoctor-maven-plugin!

**What kind of change does this PR introduce?** (check at least one)
<!-- Update "[ ]" to "[x]" to check a box -->

- [ ] Bugfix
- [ ] Feature
- [ ] Documentation
- [ ] Refactor
- [x] Build improvement
- [ ] Other (please describe)


**What is the goal of this pull request?**
Fixes maven-compiler-plugin configuration to ensure compatibility with Java 11.
Luckily, CI configuration ensures compatibility with Java 11 is guaranteed.

**Are there any alternative ways to implement this?**
n/a

**Are there any implications of this pull request? Anything a user must know?**
n/a

**Is it related to an existing issue?**
<!-- If Yes, please add a line of the form: `Fixes #Issue` --> 
- [ ] Yes
- [x] No

*Finally, please add a corresponding entry to CHANGELOG.adoc*
